### PR TITLE
Refacto - Remove inherent impl

### DIFF
--- a/src/linter/rules.rs
+++ b/src/linter/rules.rs
@@ -89,7 +89,7 @@ impl Lintable<Request> for Request {
             Some(body) => Some(body.lint()),
         };
         let mut sections: Vec<Section> = self.sections.iter().map(|e| e.lint()).collect();
-        sections.sort_by_key(|k| k.value.clone().index());
+        sections.sort_by_key(|k| section_value_index(k.value.clone()));
 
         let source_info = SourceInfo::init(0, 0, 0, 0);
         Request {
@@ -128,7 +128,7 @@ impl Lintable<Response> for Response {
         let line_terminator0 = self.clone().line_terminator0;
         let headers = self.headers.iter().map(|e| e.lint()).collect();
         let mut sections: Vec<Section> = self.sections.iter().map(|e| e.lint()).collect();
-        sections.sort_by_key(|k| k.value.clone().index());
+        sections.sort_by_key(|k| section_value_index(k.value.clone()));
 
         let b = self.body.clone();
         Response {
@@ -194,16 +194,14 @@ impl Lintable<SectionValue> for SectionValue {
     }
 }
 
-impl SectionValue {
-    fn index(self) -> u32 {
-        match self {
-            SectionValue::QueryParams(_) => 0,
-            SectionValue::FormParams(_) => 1,
-            SectionValue::MultipartFormData(_) => 2,
-            SectionValue::Cookies(_) => 3,
-            SectionValue::Captures(_) => 0,
-            SectionValue::Asserts(_) => 1,
-        }
+fn section_value_index(section_value: SectionValue) -> u32 {
+    match section_value {
+        SectionValue::QueryParams(_) => 0,
+        SectionValue::FormParams(_) => 1,
+        SectionValue::MultipartFormData(_) => 2,
+        SectionValue::Cookies(_) => 3,
+        SectionValue::Captures(_) => 0,
+        SectionValue::Asserts(_) => 1,
     }
 }
 

--- a/src/runner/expr.rs
+++ b/src/runner/expr.rs
@@ -22,18 +22,16 @@ use crate::ast::Expr;
 use super::core::{Error, RunnerError};
 use super::value::Value;
 
-impl Expr {
-    pub fn eval(self, variables: &HashMap<String, Value>) -> Result<Value, Error> {
-        if let Some(value) = variables.get(self.variable.name.as_str()) {
-            Ok(value.clone())
-        } else {
-            Err(Error {
-                source_info: self.variable.source_info,
-                inner: RunnerError::TemplateVariableNotDefined {
-                    name: self.variable.name,
-                },
-                assert: false,
-            })
-        }
+pub fn eval_expr(expr: Expr, variables: &HashMap<String, Value>) -> Result<Value, Error> {
+    if let Some(value) = variables.get(expr.variable.name.as_str()) {
+        Ok(value.clone())
+    } else {
+        Err(Error {
+            source_info: expr.variable.source_info,
+            inner: RunnerError::TemplateVariableNotDefined {
+                name: expr.variable.name,
+            },
+            assert: false,
+        })
     }
 }

--- a/src/runner/multipart.rs
+++ b/src/runner/multipart.rs
@@ -29,6 +29,7 @@ use crate::ast::*;
 use crate::http;
 
 use super::core::{Error, RunnerError};
+use super::template::eval_template;
 use super::value::Value;
 
 impl MultipartParam {
@@ -40,7 +41,7 @@ impl MultipartParam {
         match self {
             MultipartParam::Param(KeyValue { key, value, .. }) => {
                 let name = key.value;
-                let value = value.eval(variables)?;
+                let value = eval_template(value, variables)?;
                 Ok(http::MultipartParam::Param(http::Param { name, value }))
             }
             MultipartParam::FileParam(param) => {

--- a/src/runner/response.rs
+++ b/src/runner/response.rs
@@ -20,202 +20,205 @@ use std::collections::HashMap;
 use crate::ast::*;
 use crate::http;
 
+use super::assert::eval_assert;
+use super::body::eval_body;
+use super::capture::eval_capture;
 use super::core::*;
+use super::json::eval_json_value;
+use super::template::eval_template;
 use super::value::Value;
 
-impl Response {
-    pub fn eval_asserts(
-        self,
-        variables: &HashMap<String, Value>,
-        http_response: http::Response,
-        context_dir: String,
-    ) -> Vec<AssertResult> {
-        let mut asserts = vec![];
+pub fn eval_asserts(
+    response: Response,
+    variables: &HashMap<String, Value>,
+    http_response: http::Response,
+    context_dir: String,
+) -> Vec<AssertResult> {
+    let mut asserts = vec![];
 
-        let version = self.clone().version;
-        asserts.push(AssertResult::Version {
-            actual: http_response.version.to_string(),
-            expected: version.value.as_str().to_string(),
-            source_info: version.source_info,
-        });
+    let version = response.clone().version;
+    asserts.push(AssertResult::Version {
+        actual: http_response.version.to_string(),
+        expected: version.value.as_str().to_string(),
+        source_info: version.source_info,
+    });
 
-        let status = self.clone().status;
-        asserts.push(AssertResult::Status {
-            actual: u64::from(http_response.status),
-            expected: status.value as u64,
-            source_info: status.source_info,
-        });
+    let status = response.clone().status;
+    asserts.push(AssertResult::Status {
+        actual: u64::from(http_response.status),
+        expected: status.value as u64,
+        source_info: status.source_info,
+    });
 
-        for header in self.clone().headers {
-            match header.value.clone().eval(variables) {
-                Err(e) => {
+    for header in response.clone().headers {
+        match eval_template(header.value.clone(), variables) {
+            Err(e) => {
+                asserts.push(AssertResult::Header {
+                    actual: Err(e),
+                    expected: String::from(""),
+                    source_info: header.key.clone().source_info,
+                });
+            }
+            Ok(expected) => {
+                let header_name = header.key.value.clone();
+                let actuals = http_response.get_header(header_name);
+                if actuals.is_empty() {
                     asserts.push(AssertResult::Header {
-                        actual: Err(e),
-                        expected: String::from(""),
+                        actual: Err(Error {
+                            source_info: header.key.clone().source_info,
+                            inner: RunnerError::QueryHeaderNotFound {},
+                            assert: false,
+                        }),
+                        expected,
                         source_info: header.key.clone().source_info,
                     });
-                }
-                Ok(expected) => {
-                    let header_name = header.key.value.clone();
-                    let actuals = http_response.get_header(header_name);
-                    if actuals.is_empty() {
-                        asserts.push(AssertResult::Header {
-                            actual: Err(Error {
-                                source_info: header.key.clone().source_info,
-                                inner: RunnerError::QueryHeaderNotFound {},
-                                assert: false,
-                            }),
-                            expected,
-                            source_info: header.key.clone().source_info,
-                        });
-                    } else if actuals.len() == 1 {
-                        let actual = actuals.first().unwrap().to_string();
-                        asserts.push(AssertResult::Header {
-                            actual: Ok(actual),
-                            expected,
-                            source_info: header.value.clone().source_info,
-                        });
-                    } else {
-                        // failure by default
-                        // expected value not found in the list
-                        // actual is therefore the full list
-                        let mut actual = format!(
-                            "[{}]",
-                            actuals
-                                .iter()
-                                .map(|v| format!("\"{}\"", v))
-                                .collect::<Vec<String>>()
-                                .join(", ")
-                        );
-                        for value in actuals {
-                            if value == expected {
-                                actual = value;
-                                break;
-                            }
+                } else if actuals.len() == 1 {
+                    let actual = actuals.first().unwrap().to_string();
+                    asserts.push(AssertResult::Header {
+                        actual: Ok(actual),
+                        expected,
+                        source_info: header.value.clone().source_info,
+                    });
+                } else {
+                    // failure by default
+                    // expected value not found in the list
+                    // actual is therefore the full list
+                    let mut actual = format!(
+                        "[{}]",
+                        actuals
+                            .iter()
+                            .map(|v| format!("\"{}\"", v))
+                            .collect::<Vec<String>>()
+                            .join(", ")
+                    );
+                    for value in actuals {
+                        if value == expected {
+                            actual = value;
+                            break;
                         }
-                        asserts.push(AssertResult::Header {
-                            actual: Ok(actual),
-                            expected,
-                            source_info: header.value.clone().source_info,
-                        });
                     }
+                    asserts.push(AssertResult::Header {
+                        actual: Ok(actual),
+                        expected,
+                        source_info: header.value.clone().source_info,
+                    });
                 }
             }
         }
-
-        // implicit assert on body
-        if let Some(body) = self.clone().body {
-            match body.value {
-                Bytes::Json { value } => {
-                    let expected = match value.eval(variables) {
-                        Ok(s) => Ok(Value::String(s)),
-                        Err(e) => Err(e),
-                    };
-                    let actual = match http_response.text() {
-                        Ok(s) => Ok(Value::String(s)),
-                        Err(e) => Err(Error {
-                            source_info: SourceInfo {
-                                start: body.space0.source_info.end.clone(),
-                                end: body.space0.source_info.end.clone(),
-                            },
-                            inner: e,
-                            assert: true,
-                        }),
-                    };
-                    asserts.push(AssertResult::Body {
-                        actual,
-                        expected,
-                        source_info: body.space0.source_info.clone(),
-                    })
-                }
-                Bytes::Xml { value } => {
-                    let expected = Ok(Value::String(value));
-                    let actual = match http_response.text() {
-                        Ok(s) => Ok(Value::String(s)),
-                        Err(e) => Err(Error {
-                            source_info: SourceInfo {
-                                start: body.space0.source_info.end.clone(),
-                                end: body.space0.source_info.end.clone(),
-                            },
-                            inner: e,
-                            assert: true,
-                        }),
-                    };
-                    asserts.push(AssertResult::Body {
-                        actual,
-                        expected,
-                        source_info: body.space0.source_info.clone(),
-                    })
-                }
-                Bytes::RawString { value, .. } => {
-                    let expected = match value.clone().eval(variables) {
-                        Ok(s) => Ok(Value::String(s)),
-                        Err(e) => Err(e),
-                    };
-                    let actual = match http_response.text() {
-                        Ok(s) => Ok(Value::String(s)),
-                        Err(e) => Err(Error {
-                            source_info: SourceInfo {
-                                start: body.space0.source_info.end.clone(),
-                                end: body.space0.source_info.end.clone(),
-                            },
-                            inner: e,
-                            assert: true,
-                        }),
-                    };
-                    asserts.push(AssertResult::Body {
-                        actual,
-                        expected,
-                        source_info: value.source_info,
-                    })
-                }
-                Bytes::Base64 {
-                    value,
-                    space0,
-                    space1,
-                    ..
-                } => asserts.push(AssertResult::Body {
-                    actual: Ok(Value::Bytes(http_response.body.clone())),
-                    expected: Ok(Value::Bytes(value)),
-                    source_info: SourceInfo {
-                        start: space0.source_info.end,
-                        end: space1.source_info.start,
-                    },
-                }),
-                Bytes::File { .. } => {
-                    let expected = match body.clone().eval(variables, context_dir) {
-                        Ok(bytes) => Ok(Value::Bytes(bytes)),
-                        Err(e) => Err(e),
-                    };
-                    let actual = Ok(Value::Bytes(http_response.body.clone()));
-                    asserts.push(AssertResult::Body {
-                        actual,
-                        expected,
-                        source_info: body.space0.source_info.clone(),
-                    })
-                }
-            };
-        }
-
-        for assert in self.asserts() {
-            let assert_result = assert.eval(http_response.clone(), variables);
-            asserts.push(assert_result);
-        }
-        asserts
     }
 
-    pub fn eval_captures(
-        self,
-        http_response: http::Response,
-        variables: &HashMap<String, Value>,
-    ) -> Result<Vec<CaptureResult>, Error> {
-        let mut captures = vec![];
-        for capture in self.captures() {
-            let capture_result = capture.eval(variables, http_response.clone())?;
-            captures.push(capture_result);
-        }
-        Ok(captures)
+    // implicit assert on body
+    if let Some(body) = response.clone().body {
+        match body.value {
+            Bytes::Json { value } => {
+                let expected = match eval_json_value(value, variables) {
+                    Ok(s) => Ok(Value::String(s)),
+                    Err(e) => Err(e),
+                };
+                let actual = match http_response.text() {
+                    Ok(s) => Ok(Value::String(s)),
+                    Err(e) => Err(Error {
+                        source_info: SourceInfo {
+                            start: body.space0.source_info.end.clone(),
+                            end: body.space0.source_info.end.clone(),
+                        },
+                        inner: e,
+                        assert: true,
+                    }),
+                };
+                asserts.push(AssertResult::Body {
+                    actual,
+                    expected,
+                    source_info: body.space0.source_info.clone(),
+                })
+            }
+            Bytes::Xml { value } => {
+                let expected = Ok(Value::String(value));
+                let actual = match http_response.text() {
+                    Ok(s) => Ok(Value::String(s)),
+                    Err(e) => Err(Error {
+                        source_info: SourceInfo {
+                            start: body.space0.source_info.end.clone(),
+                            end: body.space0.source_info.end.clone(),
+                        },
+                        inner: e,
+                        assert: true,
+                    }),
+                };
+                asserts.push(AssertResult::Body {
+                    actual,
+                    expected,
+                    source_info: body.space0.source_info.clone(),
+                })
+            }
+            Bytes::RawString { value, .. } => {
+                let expected = match eval_template(value.clone(), variables) {
+                    Ok(s) => Ok(Value::String(s)),
+                    Err(e) => Err(e),
+                };
+                let actual = match http_response.text() {
+                    Ok(s) => Ok(Value::String(s)),
+                    Err(e) => Err(Error {
+                        source_info: SourceInfo {
+                            start: body.space0.source_info.end.clone(),
+                            end: body.space0.source_info.end.clone(),
+                        },
+                        inner: e,
+                        assert: true,
+                    }),
+                };
+                asserts.push(AssertResult::Body {
+                    actual,
+                    expected,
+                    source_info: value.source_info,
+                })
+            }
+            Bytes::Base64 {
+                value,
+                space0,
+                space1,
+                ..
+            } => asserts.push(AssertResult::Body {
+                actual: Ok(Value::Bytes(http_response.body.clone())),
+                expected: Ok(Value::Bytes(value)),
+                source_info: SourceInfo {
+                    start: space0.source_info.end,
+                    end: space1.source_info.start,
+                },
+            }),
+            Bytes::File { .. } => {
+                let expected = match eval_body(body.clone(), variables, context_dir) {
+                    Ok(bytes) => Ok(Value::Bytes(bytes)),
+                    Err(e) => Err(e),
+                };
+                let actual = Ok(Value::Bytes(http_response.body.clone()));
+                asserts.push(AssertResult::Body {
+                    actual,
+                    expected,
+                    source_info: body.space0.source_info.clone(),
+                })
+            }
+        };
     }
+
+    for assert in response.asserts() {
+        let assert_result = eval_assert(assert, variables, http_response.clone());
+        asserts.push(assert_result);
+    }
+    asserts
+}
+
+pub fn eval_captures(
+    response: Response,
+    http_response: http::Response,
+    variables: &HashMap<String, Value>,
+) -> Result<Vec<CaptureResult>, Error> {
+    let mut captures = vec![];
+    for capture in response.captures() {
+        let capture_result = eval_capture(capture, variables, http_response.clone())?;
+        captures.push(capture_result);
+    }
+    Ok(captures)
 }
 
 #[cfg(test)]
@@ -276,10 +279,11 @@ mod tests {
         let variables = HashMap::new();
         let context_dir = "undefined".to_string();
         assert_eq!(
-            user_response().eval_asserts(
+            eval_asserts(
+                user_response(),
                 &variables,
                 http::xml_two_users_http_response(),
-                context_dir
+                context_dir,
             ),
             vec![
                 AssertResult::Version {
@@ -313,9 +317,12 @@ mod tests {
     pub fn test_eval_captures() {
         let variables = HashMap::new();
         assert_eq!(
-            user_response()
-                .eval_captures(http::xml_two_users_http_response(), &variables)
-                .unwrap(),
+            eval_captures(
+                user_response(),
+                http::xml_two_users_http_response(),
+                &variables,
+            )
+            .unwrap(),
             vec![CaptureResult {
                 name: "UserCount".to_string(),
                 value: Value::Float(2, 0),


### PR DESCRIPTION
Typically all the eval functions on the AST struct
so that eval and ast can live in 2 different crates

Defining a trait makes sense only if the signature is always the same,
which is not the case for eval function.