### PR TITLE
Do not run flask in debug mode anymore

### DIFF
--- a/integration/server.py
+++ b/integration/server.py
@@ -1,4 +1,4 @@
 from tests import app
 if __name__ == '__main__':
-    app.run(debug=True, host='0.0.0.0', port=8000)
+    app.run(host='0.0.0.0', port=8000)
 


### PR DESCRIPTION
It might solve the import issue with the form_param.py test
ImportError: cannot import name 'attach_enctype_error_multidict' from partially initialized module 'flask.debughelpers' (most likely due to a circular import) (/usr/local/lib/python3.9/site-packages/flask/debughelpers.py)