### PR TITLE
Fix new clippy warnings (Rust 1.51)

### DIFF
--- a/packages/hurl/src/cli/fs.rs
+++ b/packages/hurl/src/cli/fs.rs
@@ -16,7 +16,7 @@
  *
  */
 
-use crate::cli::CLIError;
+use crate::cli::CliError;
 use std::fs;
 use std::fs::File;
 use std::io::prelude::*;
@@ -30,11 +30,11 @@ fn strip_bom(bytes: &mut Vec<u8>) {
 
 /// Similar to the standard read_to_string()
 /// But remove any existing BOM
-pub fn read_to_string(filename: &str) -> Result<String, CLIError> {
+pub fn read_to_string(filename: &str) -> Result<String, CliError> {
     let mut f = match File::open(&filename) {
         Ok(f) => f,
         Err(e) => {
-            return Err(CLIError {
+            return Err(CliError {
                 message: e.to_string(),
             })
         }
@@ -42,19 +42,19 @@ pub fn read_to_string(filename: &str) -> Result<String, CLIError> {
     let metadata = fs::metadata(&filename).expect("unable to read metadata");
     let mut buffer = vec![0; metadata.len() as usize];
     if let Err(e) = f.read(&mut buffer) {
-        return Err(CLIError {
+        return Err(CliError {
             message: e.to_string(),
         });
     }
     string_from_utf8(buffer)
 }
 
-pub fn string_from_utf8(buffer: Vec<u8>) -> Result<String, CLIError> {
+pub fn string_from_utf8(buffer: Vec<u8>) -> Result<String, CliError> {
     let mut buffer = buffer;
     strip_bom(&mut buffer);
     match String::from_utf8(buffer) {
         Ok(s) => Ok(s),
-        Err(e) => Err(CLIError {
+        Err(e) => Err(CliError {
             message: e.to_string(),
         }),
     }
@@ -94,7 +94,7 @@ pub mod tests {
         );
         assert_eq!(
             string_from_utf8(vec![0xef]).err().unwrap(),
-            CLIError {
+            CliError {
                 message: "incomplete utf-8 byte sequence from index 0".to_string()
             }
         );

--- a/packages/hurl/src/cli/mod.rs
+++ b/packages/hurl/src/cli/mod.rs
@@ -29,6 +29,6 @@ mod logger;
 mod variables;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct CLIError {
+pub struct CliError {
     pub message: String,
 }

--- a/packages/hurl/src/cli/variables.rs
+++ b/packages/hurl/src/cli/variables.rs
@@ -16,12 +16,12 @@
  *
  */
 
-use crate::cli::CLIError;
+use crate::cli::CliError;
 use crate::runner::Value;
 
-pub fn parse(s: &str) -> Result<(String, Value), CLIError> {
+pub fn parse(s: &str) -> Result<(String, Value), CliError> {
     match s.find('=') {
-        None => Err(CLIError {
+        None => Err(CliError {
             message: format!("Missing value for variable {}!", s),
         }),
         Some(index) => {
@@ -32,7 +32,7 @@ pub fn parse(s: &str) -> Result<(String, Value), CLIError> {
     }
 }
 
-fn parse_value(s: &str) -> Result<Value, CLIError> {
+fn parse_value(s: &str) -> Result<Value, CliError> {
     if s == "true" {
         Ok(Value::Bool(true))
     } else if s == "false" {
@@ -50,7 +50,7 @@ fn parse_value(s: &str) -> Result<Value, CLIError> {
         if let Some(s) = s.strip_suffix('"') {
             Ok(Value::String(s.to_string()))
         } else {
-            Err(CLIError {
+            Err(CliError {
                 message: "Value should end with a double quote".to_string(),
             })
         }
@@ -98,7 +98,7 @@ pub mod tests {
     fn test_parse_error() {
         assert_eq!(
             parse("name").err().unwrap(),
-            CLIError {
+            CliError {
                 message: "Missing value for variable name!".to_string()
             }
         );
@@ -129,7 +129,7 @@ pub mod tests {
     fn test_parse_value_error() {
         assert_eq!(
             parse_value("\"123").err().unwrap(),
-            CLIError {
+            CliError {
                 message: "Value should end with a double quote".to_string()
             }
         )

--- a/packages/hurl/src/http/client.rs
+++ b/packages/hurl/src/http/client.rs
@@ -36,7 +36,7 @@ pub enum HttpError {
     FailToConnect,
     TooManyRedirect,
     CouldNotParseResponse,
-    SSLCertificate(Option<String>),
+    SslCertificate(Option<String>),
     InvalidUrl,
     Timeout,
     StatuslineIsMissing,
@@ -208,7 +208,7 @@ impl Client {
                     6 => Err(HttpError::CouldNotResolveHost),
                     7 => Err(HttpError::FailToConnect),
                     28 => Err(HttpError::Timeout),
-                    60 => Err(HttpError::SSLCertificate(
+                    60 => Err(HttpError::SslCertificate(
                         e.extra_description().map(String::from),
                     )),
                     _ => Err(HttpError::Other {

--- a/packages/hurl/src/runner/content_decoding.rs
+++ b/packages/hurl/src/runner/content_decoding.rs
@@ -48,9 +48,9 @@ impl Encoding {
     pub fn decode(&self, data: &[u8]) -> Result<Vec<u8>, RunnerError> {
         match self {
             Encoding::Identity => Ok(data.to_vec()),
-            Encoding::Gzip => uncompress_gzip(&data[..]),
-            Encoding::Deflate => uncompress_zlib(&data[..]),
-            Encoding::Brotli => uncompress_brotli(&data[..]),
+            Encoding::Gzip => uncompress_gzip(data),
+            Encoding::Deflate => uncompress_zlib(data),
+            Encoding::Brotli => uncompress_brotli(data),
         }
     }
 }

--- a/packages/hurl/src/runner/core.rs
+++ b/packages/hurl/src/runner/core.rs
@@ -121,7 +121,7 @@ pub enum RunnerError {
     InvalidJson {
         value: String,
     },
-    InvalidURL(String),
+    InvalidUrl(String),
 
     HttpConnection {
         url: String,
@@ -133,7 +133,7 @@ pub enum RunnerError {
     Timeout,
     TooManyRedirect,
     CouldNotParseResponse,
-    SSLCertificate(String),
+    SslCertificate(String),
 
     UnsupportedContentEncoding(String),
     CouldNotUncompressResponse(String),

--- a/packages/hurl/src/runner/entry.rs
+++ b/packages/hurl/src/runner/entry.rs
@@ -109,10 +109,10 @@ pub fn run(
                 HttpError::Timeout => RunnerError::Timeout,
                 HttpError::TooManyRedirect => RunnerError::TooManyRedirect,
                 HttpError::CouldNotParseResponse => RunnerError::CouldNotParseResponse,
-                HttpError::SSLCertificate(description) => RunnerError::SSLCertificate(
+                HttpError::SslCertificate(description) => RunnerError::SslCertificate(
                     description.unwrap_or_else(|| "SSL certificate problem".to_string()),
                 ),
-                HttpError::InvalidUrl => RunnerError::InvalidURL(http_request.url.clone()),
+                HttpError::InvalidUrl => RunnerError::InvalidUrl(http_request.url.clone()),
                 HttpError::StatuslineIsMissing => RunnerError::HttpConnection {
                     message: "status line is missing".to_string(),
                     url: http_request.url.clone(),

--- a/packages/hurl/src/runner/error.rs
+++ b/packages/hurl/src/runner/error.rs
@@ -15,7 +15,7 @@ impl Error for runner::Error {
 
     fn description(&self) -> String {
         match &self.inner {
-            RunnerError::InvalidURL(..) => "Invalid url".to_string(),
+            RunnerError::InvalidUrl(..) => "Invalid url".to_string(),
             RunnerError::TemplateVariableNotDefined { .. } => "Undefined Variable".to_string(),
             RunnerError::VariableNotDefined { .. } => "Undefined Variable".to_string(),
             RunnerError::HttpConnection { .. } => "Http Connection".to_string(),
@@ -25,7 +25,7 @@ impl Error for runner::Error {
             RunnerError::Timeout => "Http Connection".to_string(),
             RunnerError::TooManyRedirect => "Http Connection".to_string(),
             RunnerError::CouldNotParseResponse => "Http Connection".to_string(),
-            RunnerError::SSLCertificate { .. } => "SSL Certificate".to_string(),
+            RunnerError::SslCertificate { .. } => "SSL Certificate".to_string(),
             RunnerError::PredicateValue { .. } => "Assert - Predicate Value Failed".to_string(),
             RunnerError::InvalidRegex {} => "Invalid regex".to_string(),
             RunnerError::FileReadAccess { .. } => "File ReadAccess".to_string(),
@@ -54,7 +54,7 @@ impl Error for runner::Error {
 
     fn fixme(&self) -> String {
         match &self.inner {
-            RunnerError::InvalidURL(url) => format!("Invalid url <{}>", url),
+            RunnerError::InvalidUrl(url) => format!("Invalid url <{}>", url),
             RunnerError::TemplateVariableNotDefined { name } => {
                 format!("You must set the variable {}", name)
             }
@@ -67,7 +67,7 @@ impl Error for runner::Error {
             RunnerError::Timeout => "Timeout has been reached".to_string(),
             RunnerError::TooManyRedirect => "Too many redirect".to_string(),
             RunnerError::CouldNotParseResponse => "Could not parse response".to_string(),
-            RunnerError::SSLCertificate(description) => description.clone(),
+            RunnerError::SslCertificate(description) => description.clone(),
             RunnerError::AssertVersion { actual, .. } => format!("actual value is <{}>", actual),
             RunnerError::AssertStatus { actual, .. } => format!("actual value is <{}>", actual),
             RunnerError::PredicateValue(value) => {

--- a/packages/hurl/src/runner/query.rs
+++ b/packages/hurl/src/runner/query.rs
@@ -99,7 +99,7 @@ pub fn eval_query(
                     };
                     match result {
                         Ok(value) => Ok(Some(value)),
-                        Err(xpath::XpathError::InvalidXML {}) => Err(Error {
+                        Err(xpath::XpathError::InvalidXml {}) => Err(Error {
                             source_info: query.source_info,
                             inner: RunnerError::QueryInvalidXml,
                             assert: false,

--- a/packages/hurl/src/runner/xpath.rs
+++ b/packages/hurl/src/runner/xpath.rs
@@ -25,7 +25,7 @@ use super::value::Value;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum XpathError {
-    InvalidXML,
+    InvalidXml,
     InvalidHtml,
     Eval,
     Unsupported,
@@ -36,12 +36,12 @@ pub fn eval_xml(xml: String, expr: String) -> Result<Value, XpathError> {
     match parser.parse_string(xml) {
         Ok(doc) => {
             if doc.get_root_element() == None {
-                Err(XpathError::InvalidXML {})
+                Err(XpathError::InvalidXml {})
             } else {
                 eval(doc, expr)
             }
         }
-        Err(_) => Err(XpathError::InvalidXML {}),
+        Err(_) => Err(XpathError::InvalidXml {}),
     }
 }
 
@@ -151,7 +151,7 @@ mod tests {
             eval_xml(String::from("??"), String::from("//person"))
                 .err()
                 .unwrap(),
-            XpathError::InvalidXML
+            XpathError::InvalidXml
         );
     }
 

--- a/packages/hurl/tests/libcurl.rs
+++ b/packages/hurl/tests/libcurl.rs
@@ -542,7 +542,7 @@ fn test_error_ssl() {
     } else {
         "SSL certificate problem: self signed certificate".to_string()
     };
-    assert_eq!(error, HttpError::SSLCertificate(Some(message)));
+    assert_eq!(error, HttpError::SslCertificate(Some(message)));
 }
 
 #[test]

--- a/packages/hurl_core/src/parser/template.rs
+++ b/packages/hurl_core/src/parser/template.rs
@@ -34,7 +34,7 @@ pub fn templatize(encoded_string: EncodedString) -> ParseResult<'static, Vec<Tem
         Template {},
         FirstOpenBracket {},
         FirstCloseBracket {},
-    };
+    }
 
     let mut elements = vec![];
 

--- a/packages/hurlfmt/src/cli/fs.rs
+++ b/packages/hurlfmt/src/cli/fs.rs
@@ -16,7 +16,7 @@
  *
  */
 
-use crate::cli::CLIError;
+use crate::cli::CliError;
 use std::fs;
 use std::fs::File;
 use std::io::prelude::*;
@@ -30,11 +30,11 @@ fn strip_bom(bytes: &mut Vec<u8>) {
 
 /// Similar to the standard read_to_string()
 /// But remove any existing BOM
-pub fn read_to_string(filename: &str) -> Result<String, CLIError> {
+pub fn read_to_string(filename: &str) -> Result<String, CliError> {
     let mut f = match File::open(&filename) {
         Ok(f) => f,
         Err(e) => {
-            return Err(CLIError {
+            return Err(CliError {
                 message: e.to_string(),
             })
         }
@@ -42,19 +42,19 @@ pub fn read_to_string(filename: &str) -> Result<String, CLIError> {
     let metadata = fs::metadata(&filename).expect("unable to read metadata");
     let mut buffer = vec![0; metadata.len() as usize];
     if let Err(e) = f.read(&mut buffer) {
-        return Err(CLIError {
+        return Err(CliError {
             message: e.to_string(),
         });
     }
     string_from_utf8(buffer)
 }
 
-pub fn string_from_utf8(buffer: Vec<u8>) -> Result<String, CLIError> {
+pub fn string_from_utf8(buffer: Vec<u8>) -> Result<String, CliError> {
     let mut buffer = buffer;
     strip_bom(&mut buffer);
     match String::from_utf8(buffer) {
         Ok(s) => Ok(s),
-        Err(e) => Err(CLIError {
+        Err(e) => Err(CliError {
             message: e.to_string(),
         }),
     }
@@ -94,7 +94,7 @@ pub mod tests {
         );
         assert_eq!(
             string_from_utf8(vec![0xef]).err().unwrap(),
-            CLIError {
+            CliError {
                 message: "incomplete utf-8 byte sequence from index 0".to_string()
             }
         );

--- a/packages/hurlfmt/src/cli/mod.rs
+++ b/packages/hurlfmt/src/cli/mod.rs
@@ -26,6 +26,6 @@ mod fs;
 mod logger;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct CLIError {
+pub struct CliError {
     pub message: String,
 }

--- a/packages/hurlfmt/src/format/json.rs
+++ b/packages/hurlfmt/src/format/json.rs
@@ -38,8 +38,7 @@ impl ToJson for HurlFile {
 
 impl ToJson for Entry {
     fn to_json(&self) -> JValue {
-        let mut attributes = vec![];
-        attributes.push(("request".to_string(), self.request.to_json()));
+        let mut attributes = vec![("request".to_string(), self.request.to_json())];
         if let Some(response) = self.response.clone() {
             attributes.push(("response".to_string(), response.to_json()));
         }
@@ -49,12 +48,13 @@ impl ToJson for Entry {
 
 impl ToJson for Request {
     fn to_json(&self) -> JValue {
-        let mut attributes = vec![];
-        attributes.push((
-            "method".to_string(),
-            JValue::String(self.method.to_string()),
-        ));
-        attributes.push(("url".to_string(), JValue::String(self.url.to_string())));
+        let mut attributes = vec![
+            (
+                "method".to_string(),
+                JValue::String(self.method.to_string()),
+            ),
+            ("url".to_string(), JValue::String(self.url.to_string())),
+        ];
         add_headers(&mut attributes, self.headers.clone());
 
         if !self.clone().querystring_params().is_empty() {
@@ -181,9 +181,10 @@ fn get_json_version(version_value: VersionValue) -> Option<String> {
 
 impl ToJson for KeyValue {
     fn to_json(&self) -> JValue {
-        let mut attributes = vec![];
-        attributes.push(("name".to_string(), JValue::String(self.key.value.clone())));
-        attributes.push(("value".to_string(), JValue::String(self.value.to_string())));
+        let attributes = vec![
+            ("name".to_string(), JValue::String(self.key.value.clone())),
+            ("value".to_string(), JValue::String(self.value.to_string())),
+        ];
         JValue::Object(attributes)
     }
 }
@@ -199,12 +200,13 @@ impl ToJson for MultipartParam {
 
 impl ToJson for FileParam {
     fn to_json(&self) -> JValue {
-        let mut attributes = vec![];
-        attributes.push(("name".to_string(), JValue::String(self.key.value.clone())));
-        attributes.push((
-            "filename".to_string(),
-            JValue::String(self.value.filename.value.clone()),
-        ));
+        let mut attributes = vec![
+            ("name".to_string(), JValue::String(self.key.value.clone())),
+            (
+                "filename".to_string(),
+                JValue::String(self.value.filename.value.clone()),
+            ),
+        ];
         if let Some(content_type) = self.value.content_type.clone() {
             attributes.push(("content_type".to_string(), JValue::String(content_type)));
         }
@@ -214,21 +216,23 @@ impl ToJson for FileParam {
 
 impl ToJson for Cookie {
     fn to_json(&self) -> JValue {
-        let mut attributes = vec![];
-        attributes.push(("name".to_string(), JValue::String(self.name.value.clone())));
-        attributes.push((
-            "value".to_string(),
-            JValue::String(self.value.value.clone()),
-        ));
+        let attributes = vec![
+            ("name".to_string(), JValue::String(self.name.value.clone())),
+            (
+                "value".to_string(),
+                JValue::String(self.value.value.clone()),
+            ),
+        ];
         JValue::Object(attributes)
     }
 }
 
 impl ToJson for Capture {
     fn to_json(&self) -> JValue {
-        let mut attributes = vec![];
-        attributes.push(("name".to_string(), JValue::String(self.name.value.clone())));
-        attributes.push(("query".to_string(), self.query.to_json()));
+        let mut attributes = vec![
+            ("name".to_string(), JValue::String(self.name.value.clone())),
+            ("query".to_string(), self.query.to_json()),
+        ];
         if let Some(subquery) = self.subquery.clone() {
             attributes.push(("subquery".to_string(), subquery.to_json()));
         }
@@ -238,17 +242,16 @@ impl ToJson for Capture {
 
 impl ToJson for Assert {
     fn to_json(&self) -> JValue {
-        let mut attributes = vec![];
-        attributes.push(("query".to_string(), self.query.to_json()));
-        attributes.push(("predicate".to_string(), self.predicate.to_json()));
+        let attributes = vec![
+            ("query".to_string(), self.query.to_json()),
+            ("predicate".to_string(), self.predicate.to_json()),
+        ];
         JValue::Object(attributes)
     }
 }
 
 impl ToJson for Query {
     fn to_json(&self) -> JValue {
-        let mut attributes = vec![];
-        attributes.push(("type".to_string(), self.value.to_json()));
         self.value.to_json()
     }
 }

--- a/packages/hurlfmt/src/format/token.rs
+++ b/packages/hurlfmt/src/format/token.rs
@@ -154,8 +154,7 @@ impl Tokenizable for Status {
 
 impl Tokenizable for Version {
     fn tokenize(&self) -> Vec<Token> {
-        let mut tokens: Vec<Token> = vec![];
-        tokens.push(Token::Version(format!(
+        vec![Token::Version(format!(
             "HTTP/{}",
             match self.value {
                 VersionValue::Version1 => String::from("1.0"),
@@ -163,8 +162,7 @@ impl Tokenizable for Version {
                 VersionValue::Version2 => String::from("2"),
                 VersionValue::VersionAny => String::from("*"),
             }
-        )));
-        tokens
+        ))]
     }
 }
 
@@ -340,8 +338,7 @@ impl Tokenizable for FileParam {
 
 impl Tokenizable for FileValue {
     fn tokenize(&self) -> Vec<Token> {
-        let mut tokens: Vec<Token> = vec![];
-        tokens.push(Token::Keyword("file,".to_string()));
+        let mut tokens: Vec<Token> = vec![Token::Keyword("file,".to_string())];
         tokens.append(&mut self.space0.tokenize());
         tokens.append(&mut self.filename.tokenize());
         tokens.append(&mut self.space1.tokenize());
@@ -377,9 +374,7 @@ impl Tokenizable for Cookie {
 
 impl Tokenizable for CookieValue {
     fn tokenize(&self) -> Vec<Token> {
-        let mut tokens: Vec<Token> = vec![];
-        tokens.push(Token::Value(self.clone().value));
-        tokens
+        vec![Token::Value(self.clone().value)]
     }
 }
 
@@ -486,8 +481,7 @@ impl Tokenizable for CookiePath {
 
 impl Tokenizable for CookieAttribute {
     fn tokenize(&self) -> Vec<Token> {
-        let mut tokens: Vec<Token> = vec![];
-        tokens.push(Token::CodeDelimiter("[".to_string()));
+        let mut tokens: Vec<Token> = vec![Token::CodeDelimiter("[".to_string())];
         add_tokens(&mut tokens, self.space0.tokenize());
         tokens.push(Token::String(self.name.value()));
         add_tokens(&mut tokens, self.space1.tokenize());
@@ -720,9 +714,7 @@ impl Tokenizable for TemplateElement {
     fn tokenize(&self) -> Vec<Token> {
         match self {
             TemplateElement::String { encoded, .. } => {
-                let mut tokens: Vec<Token> = vec![];
-                tokens.push(Token::String(encoded.to_string()));
-                tokens
+                vec![Token::String(encoded.to_string())]
             }
             TemplateElement::Expression(value) => {
                 let mut tokens: Vec<Token> = vec![];
@@ -735,8 +727,7 @@ impl Tokenizable for TemplateElement {
 
 impl Tokenizable for Expr {
     fn tokenize(&self) -> Vec<Token> {
-        let mut tokens: Vec<Token> = vec![];
-        tokens.push(Token::CodeDelimiter(String::from("{{")));
+        let mut tokens: Vec<Token> = vec![Token::CodeDelimiter(String::from("{{"))];
         add_tokens(&mut tokens, self.space0.tokenize());
         tokens.push(Token::CodeVariable(self.variable.name.clone()));
         add_tokens(&mut tokens, self.space1.tokenize());
@@ -769,9 +760,7 @@ impl Tokenizable for Whitespace {
 
 impl Tokenizable for Comment {
     fn tokenize(&self) -> Vec<Token> {
-        let mut tokens: Vec<Token> = vec![];
-        tokens.push(Token::Comment(format!("#{}", self.clone().value)));
-        tokens
+        vec![Token::Comment(format!("#{}", self.clone().value))]
     }
 }
 
@@ -831,8 +820,7 @@ impl Tokenizable for JsonValue {
 
 impl Tokenizable for JsonListElement {
     fn tokenize(&self) -> Vec<Token> {
-        let mut tokens: Vec<Token> = vec![];
-        tokens.push(Token::Whitespace(self.space0.clone()));
+        let mut tokens: Vec<Token> = vec![Token::Whitespace(self.space0.clone())];
         tokens.append(&mut self.value.tokenize());
         tokens.push(Token::Whitespace(self.space1.clone()));
         tokens
@@ -841,8 +829,7 @@ impl Tokenizable for JsonListElement {
 
 impl Tokenizable for JsonObjectElement {
     fn tokenize(&self) -> Vec<Token> {
-        let mut tokens: Vec<Token> = vec![];
-        tokens.push(Token::Whitespace(self.space0.clone()));
+        let mut tokens: Vec<Token> = vec![Token::Whitespace(self.space0.clone())];
         tokens.push(Token::Quote("\"".to_string()));
         tokens.push(Token::String(self.name.clone()));
         tokens.push(Token::Quote("\"".to_string()));


### PR DESCRIPTION
- upper_case_acronyms
- redundant_slicing
- vec_init_then_push