### PR TITLE
Add lib version to version info

### DIFF
--- a/packages/hurl/src/cli/options.rs
+++ b/packages/hurl/src/cli/options.rs
@@ -21,7 +21,7 @@ use crate::cli::CliError;
 use crate::http::ClientOptions;
 use crate::runner::Value;
 use atty::Stream;
-use clap::{AppSettings, ArgMatches};
+use clap::{App, AppSettings, ArgMatches};
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
@@ -68,9 +68,8 @@ pub struct CliOptions {
     pub verbose: bool,
 }
 
-pub fn app() -> clap::App<'static, 'static> {
-    clap::App::new("hurl")
-        .version(clap::crate_version!())
+pub fn app() -> App<'static, 'static> {
+    App::new("hurl")
         .about("Run hurl FILE(s) or standard input")
         .setting(AppSettings::DeriveDisplayOrder)
         .setting(AppSettings::UnifiedHelpMessage)

--- a/packages/hurl/src/main.rs
+++ b/packages/hurl/src/main.rs
@@ -16,6 +16,7 @@
  *
  */
 
+use std::fmt::Write as FmtWrite;
 use std::io::prelude::*;
 use std::io::{self};
 use std::path::{Path, PathBuf};
@@ -24,6 +25,7 @@ use std::time::Instant;
 use atty::Stream;
 use colored::*;
 
+use curl::Version;
 use hurl::cli;
 use hurl::cli::{CliError, CliOptions};
 use hurl::http;
@@ -247,9 +249,11 @@ pub fn unwrap_or_exit<T>(
 }
 
 fn main() {
-    let app = cli::app();
+    let version_info = get_version_info();
+    let app = cli::app().version(version_info.as_str());
     let matches = app.clone().get_matches();
     init_colored();
+
     let mut filenames = match matches.values_of("INPUT") {
         None => vec![],
         Some(v) => v.collect(),
@@ -563,4 +567,38 @@ fn print_summary(duration: u128, hurl_results: Vec<HurlResult>) {
         100.0 * failed as f32 / total as f32
     );
     eprintln!("Duration:  {}ms", duration);
+}
+
+fn get_version_info() -> String {
+    let mut ver_string = String::new();
+    let curl_v = Version::get();
+    writeln!(ver_string, clap::crate_version!()).expect("Failed to write hurl version string");
+    for (lib, ver) in [
+        ("libcurl", Some(curl_v.version())),
+        ("", curl_v.ssl_version()),
+        ("zlib", curl_v.libz_version()),
+        ("", curl_v.nghttp2_version()),
+        ("ares", curl_v.ares_version()),
+        ("brotli", curl_v.brotli_version()),
+        ("gsasl", curl_v.gsasl_version()),
+        ("hyper", curl_v.hyper_version()),
+        (
+            "iconv",
+            curl_v.iconv_version_num().map(|v| v.to_string()).as_deref(),
+        ),
+        ("libidn", curl_v.libidn_version()),
+        ("libssh", curl_v.libssh_version()),
+        ("quic", curl_v.quic_version()),
+    ] {
+        if let Some(version) = ver {
+            if !lib.is_empty() {
+                write!(ver_string, "{}/{} ", lib, version)
+                    .expect("Failed to write custom lib version");
+            } else {
+                write!(ver_string, "{} ", version).expect("Failed to write lib version string");
+            }
+        }
+    }
+    writeln!(ver_string).expect("Failed to write version string");
+    ver_string
 }


### PR DESCRIPTION
This replaces https://github.com/Orange-OpenSource/hurl/pull/319.

Adds libcurl and other lib related information to the `--version`/`-v` flag output.

Closes #309 