### PR TITLE
Activate libcurl verbose option only if hurl verbose option is on.

### DIFF
--- a/packages/hurl/src/http/client.rs
+++ b/packages/hurl/src/http/client.rs
@@ -123,7 +123,7 @@ impl Client {
     pub fn execute(&mut self, request: &RequestSpec) -> Result<(Request, Response), HttpError> {
         // set handle attributes
         // that have not been set or reset
-        self.handle.verbose(true).unwrap();
+        self.handle.verbose(self.options.verbose).unwrap();
         self.handle.ssl_verify_host(!self.options.insecure).unwrap();
         self.handle.ssl_verify_peer(!self.options.insecure).unwrap();
         if let Some(cacert_file) = self.options.cacert_file.clone() {


### PR DESCRIPTION
Closes #377 

On macOS Big Sur, running hurl 1.4.0:

```
$ echo 'GET https://google.com' | hurl
* Closing connection 0
<HTML><HEAD><meta http-equiv="content-type" content="text/html;charset=utf-8">
<TITLE>301 Moved</TITLE></HEAD><BODY>
<H1>301 Moved</H1>
The document has moved
<A HREF="https://www.google.com/">here</A>.
</BODY></HTML>
```

`* Closing connection 0` is outputed on stderr by lib curl because verbose options is force to true.
We link now the libcurl verbose option to hurl verbose option.

After:

```
$ echo 'GET https://google.com' | hurl
<HTML><HEAD><meta http-equiv="content-type" content="text/html;charset=utf-8">
<TITLE>301 Moved</TITLE></HEAD><BODY>
<H1>301 Moved</H1>
The document has moved
<A HREF="https://www.google.com/">here</A>.
</BODY></HTML>
```

```
$ echo 'GET https://google.com' | hurl --verbose
* fail fast: true
* insecure: false
* follow redirect: false
* max redirect: 50
* ------------------------------------------------------------------------------
* executing entry 1
* 
* Cookie store:
* 
* Request
* GET https://google.com
* 
* request can be run with the following curl command:
* curl 'https://google.com'
*
> GET / HTTP/2
> Host: google.com
> accept: */*
> user-agent: hurl/1.4.0
> 
< HTTP/2 301 
< location: https://www.google.com/
< content-type: text/html; charset=UTF-8
< date: Fri, 26 Nov 2021 22:59:28 GMT
< expires: Fri, 26 Nov 2021 22:59:28 GMT
< cache-control: private, max-age=2592000
< server: gws
< content-length: 220
< x-xss-protection: 0
< x-frame-options: SAMEORIGIN
< set-cookie: CONSENT=PENDING+033; expires=Sun, 26-Nov-2023 22:59:28 GMT; path=/; domain=.google.com; Secure
< p3p: CP="This is not a P3P policy! See g.co/p3phelp for more info."
< alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000,h3-Q050=":443"; ma=2592000,h3-Q046=":443"; ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"
< 
*
* Closing connection 0
<HTML><HEAD><meta http-equiv="content-type" content="text/html;charset=utf-8">
<TITLE>301 Moved</TITLE></HEAD><BODY>
<H1>301 Moved</H1>
The document has moved
<A HREF="https://www.google.com/">here</A>.
</BODY></HTML>
```

