### PR TITLE
Run cargo test in single thread 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,7 +120,7 @@ jobs:
         wget https://snapshots.mitmproxy.org/5.2/mitmproxy-5.2-linux.tar.gz -O - | tar -xz && ./mitmdump -p 8888 --modify-header "/From-Proxy/Hello" &
     - name: Run Tests units
       run: |
-        cargo test --features strict
+        cargo test --features strict -- --test-threads 1
     - name: Run Integration Tests
       run: |
          export PATH="$PWD/target/debug:$PATH"
@@ -175,7 +175,7 @@ jobs:
           mitmdump -p 8888 --modify-header "/From-Proxy/Hello" >mitmdump.log 2>&1 &
           ps auxww | grep -v grep | grep -E "server.py|mitmdump"
           echo "----- tests units -----"
-          cargo test --features strict
+          cargo test --features strict -- --test-threads 1
           echo "----- integration tests -----"
           ./integration.py
     - name: Archive production artifacts
@@ -219,7 +219,7 @@ jobs:
           mitmdump -p 8888 --modify-header "/From-Proxy/Hello" >mitmdump.log 2>&1 &
           ps auxww | grep -v grep | grep -E "server.py|mitmdump"
           echo "----- tests units -----"
-          cargo test --features strict
+          cargo test --features strict -- --test-threads 1
           echo "----- integration tests -----"
           ./integration.py
     - name: Archive production artifacts
@@ -264,7 +264,7 @@ jobs:
           mitmdump -p 8888 --modify-header "/From-Proxy/Hello" >mitmdump.log 2>&1 &
           ps auxww | grep -v grep | grep -E "server.py|mitmdump"
           echo "----- tests units -----"
-          cargo test --features strict
+          cargo test --features strict -- --test-threads 1
           echo "----- integration tests -----"
           ./integration.py
     - name: Archive production artifacts
@@ -307,7 +307,7 @@ jobs:
         wget https://snapshots.mitmproxy.org/5.2/mitmproxy-5.2-osx.tar.gz -O - | tar -xz && ./mitmdump -p 8888 --modify-header "/From-Proxy/Hello" &
     - name: Run Tests units
       run: |
-        cargo test
+        cargo test -- --test-threads 1
     - name: Run Integration Tests
       run: |
          export PATH="$PWD/target/debug:$PATH"
@@ -369,7 +369,7 @@ jobs:
         Get-Job -Name mitmdump
         Start-Sleep 5
         cd ..
-        cargo test --verbose
+        cargo test --verbose -- --test-threads 1
     - name: Run Integration tests
       run: |
         cargo build --release --verbose


### PR DESCRIPTION
Cargo test multithread runner might pose a problem to our libxml based implementation.
On Windows, but also on macOs, we can have random segmentation fault:

```
Caused by:
568
  process didn't exit successfully: `D:\a\hurl\hurl\target\debug\deps\hurl-33f8d88a0d2b2f3c.exe` (exit code: 0xc0000005, STATUS_ACCESS_VIOLATION)
```

So, we temporarily switch to a single threaded execution for `cargo test` and will revert as soon as we've fixed this issue.