### PR TITLE
Fixes the DisplayName being too long.

### DIFF
--- a/ci/windows/hurl.nsi
+++ b/ci/windows/hurl.nsi
@@ -66,7 +66,7 @@ SectionGroup "executables"
     ; Write windows uninstall panel informations  
     ${GetSize} "$INSTDIR" "/S=0K" $0 $1 $2
     IntFmt $0 "0x%08X" $0
-    WriteRegStr HKLM "${UNINSTALLPANELKEY}" "DisplayName" "Hurl - Command line tool that runs HTTP requests defined in a simple plain text format."
+    WriteRegStr HKLM "${UNINSTALLPANELKEY}" "DisplayName" "Hurl"
     WriteRegStr HKLM "${UNINSTALLPANELKEY}" "DisplayVersion" "${VERSION}"
     WriteRegStr HKLM "${UNINSTALLPANELKEY}" "DisplayIcon" "$INSTDIR\hurl.exe"
     WriteRegStr HKLM "${UNINSTALLPANELKEY}" "UninstallString" "$\"$INSTDIR\uninstall.exe$\""


### PR DESCRIPTION
Solves complaints in the https://github.com/microsoft/winget-pkgs repository, and complaints from other people about the DisplayName being too long in Control Panel as the Application Name is being truncated due to how long it is.

Almost all applications have a DisplayName that isn't too long, i.e. `Microsoft OneDrive`; `Microsoft Teams`, etc.

This change was also done to make it a bit more consistent with other programs.

Related: https://github.com/texstudio-org/texstudio/pull/2000