### PR TITLE
Add tiny css improvments to html export.

### DIFF
--- a/packages/hurl/src/report/mod.rs
+++ b/packages/hurl/src/report/mod.rs
@@ -113,7 +113,7 @@ fn percentage(count: usize, total: usize) -> String {
 
 fn create_html_index(now: String, hurl_results: Vec<HurlResult>) -> html::Html {
     let head = html::Head {
-        title: "Hurl Report".to_string(),
+        title: "Test Report".to_string(),
         stylesheet: Some("report.css".to_string()),
     };
 
@@ -126,7 +126,7 @@ fn create_html_index(now: String, hurl_results: Vec<HurlResult>) -> html::Html {
             html::Element::NodeElement {
                 name: "h2".to_string(),
                 attributes: vec![],
-                children: vec![html::Element::TextElement("Hurl Report".to_string())],
+                children: vec![html::Element::TextElement("Test Report".to_string())],
             },
             html::Element::NodeElement {
                 name: "div".to_string(),
@@ -141,7 +141,7 @@ fn create_html_index(now: String, hurl_results: Vec<HurlResult>) -> html::Html {
                         name: "div".to_string(),
                         attributes: vec![html::Attribute::Class("count".to_string())],
                         children: vec![html::Element::TextElement(format!(
-                            "total: {} (100%)",
+                            "Executed: {} (100%)",
                             count_total
                         ))],
                     },
@@ -149,18 +149,18 @@ fn create_html_index(now: String, hurl_results: Vec<HurlResult>) -> html::Html {
                         name: "div".to_string(),
                         attributes: vec![html::Attribute::Class("count".to_string())],
                         children: vec![html::Element::TextElement(format!(
-                            "failure: {} ({})",
-                            count_failure,
-                            percentage(count_failure, count_total)
+                            "Succeeded: {} ({})",
+                            count_success,
+                            percentage(count_success, count_total)
                         ))],
                     },
                     html::Element::NodeElement {
                         name: "div".to_string(),
                         attributes: vec![html::Attribute::Class("count".to_string())],
                         children: vec![html::Element::TextElement(format!(
-                            "success: {} ({})",
-                            count_success,
-                            percentage(count_success, count_total)
+                            "Failed: {} ({})",
+                            count_failure,
+                            percentage(count_failure, count_total)
                         ))],
                     },
                 ],

--- a/packages/hurl/src/report/report.css
+++ b/packages/hurl/src/report/report.css
@@ -1,18 +1,31 @@
-.date {
-    margin-bottom: 10px;
+body {
+    font-family: "Helvetica Neue", Arial, sans-serif;
+    font-size: 1.125rem;
+    line-height: 1.4;
 }
 
-thead {
-    font-weight: bolder;
-}
-
-td {
-    padding: 3px 5px;
+h2 {
+    color: #ff0288;
+    font-size: 2.5rem;
 }
 
 .summary {
-    padding: 10px;
+    margin: 32px 0 32px 0;
+    font-size: 1.25rem;
 }
+
+.date {
+    margin-bottom: 20px;
+}
+
+td {
+    padding: 4px 8px 4px 0;
+}
+
+thead {
+    font-weight: bold;
+}
+
 .success, .success a {
     color: green;
 }
@@ -20,8 +33,3 @@ td {
 .failure, .failure a {
     color: red;
 }
-
-
-
-
-


### PR DESCRIPTION
Add tiny cosmetic improvement to html report (us can be closed without merging):

Before:

<img width="1771" alt="Screenshot 2021-12-17 at 15 51 09" src="https://user-images.githubusercontent.com/16323814/146563309-ea003a10-ff07-4de2-aa57-3cdeb8a8c506.png">

After:

<img width="1260" alt="Screenshot 2021-12-17 at 14 58 33" src="https://user-images.githubusercontent.com/16323814/146563338-a085a17f-de57-468f-99a4-0e542aa3ece8.png">

