### PR TITLE
Fix new clippy warnings on 1.58.

### DIFF
--- a/packages/hurl/src/cli/fs.rs
+++ b/packages/hurl/src/cli/fs.rs
@@ -36,7 +36,7 @@ pub fn read_to_string(filename: &str) -> Result<String, CliError> {
         let mut contents = String::new();
         return if let Err(e) = std::io::stdin().read_to_string(&mut contents) {
             Err(CliError {
-                message: format!("Input stream can not be read - {}", e.to_string()),
+                message: format!("Input stream can not be read - {}", e),
             })
         } else {
             return Ok(contents);

--- a/packages/hurl/src/http/request_spec.rs
+++ b/packages/hurl/src/http/request_spec.rs
@@ -97,8 +97,8 @@ impl fmt::Display for Method {
 impl fmt::Display for MultipartParam {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            MultipartParam::Param(param) => write!(f, "{}", param.to_string()),
-            MultipartParam::FileParam(param) => write!(f, "{}", param.to_string()),
+            MultipartParam::Param(param) => write!(f, "{}", param),
+            MultipartParam::FileParam(param) => write!(f, "{}", param),
         }
     }
 }
@@ -132,9 +132,9 @@ impl RequestSpec {
         let url = if querystring.as_str() == "" {
             self.url.to_string()
         } else if self.url.to_string().contains('?') {
-            format!("{}&{}", self.url.to_string(), querystring)
+            format!("{}&{}", self.url, querystring)
         } else {
-            format!("{}?{}", self.url.to_string(), querystring)
+            format!("{}?{}", self.url, querystring)
         };
         let mut arguments = vec![format!("'{}'", url)];
 

--- a/packages/hurl/src/http/version.rs
+++ b/packages/hurl/src/http/version.rs
@@ -33,23 +33,23 @@ pub fn libcurl_version_info() -> Vec<String> {
         versions.push(s.to_string());
     }
     if let Some(s) = version.libz_version() {
-        versions.push(format!("zlib/{}", s.to_string()));
+        versions.push(format!("zlib/{}", s));
     }
     if let Some(s) = version.brotli_version() {
-        versions.push(format!("brotli/{}", s.to_string()));
+        versions.push(format!("brotli/{}", s));
     }
     if let Some(s) = version.zstd_version() {
         versions.push(s.to_string());
     }
     if let Some(s) = version.ares_version() {
-        versions.push(format!("c-ares/{}", s.to_string()));
+        versions.push(format!("c-ares/{}", s));
     }
     if let Some(s) = version.libidn_version() {
-        versions.push(format!("libidn2/{}", s.to_string()));
+        versions.push(format!("libidn2/{}", s));
     }
     if let Some(s) = version.iconv_version_num() {
         if s != 0 {
-            versions.push(format!("iconv/{}", s.to_string()));
+            versions.push(format!("iconv/{}", s));
         }
     }
     if let Some(s) = version.libssh_version() {
@@ -62,10 +62,10 @@ pub fn libcurl_version_info() -> Vec<String> {
         versions.push(s.to_string());
     }
     if let Some(s) = version.hyper_version() {
-        versions.push(format!("hyper/{}", s.to_string()));
+        versions.push(format!("hyper/{}", s));
     }
     if let Some(s) = version.gsasl_version() {
-        versions.push(format!("libgsal/{}", s.to_string()));
+        versions.push(format!("libgsal/{}", s));
     }
     versions
 }

--- a/packages/hurl/src/main.rs
+++ b/packages/hurl/src/main.rs
@@ -119,7 +119,7 @@ fn execute(
             log_verbose(format!("insecure: {}", cli_options.insecure).as_str());
             log_verbose(format!("follow redirect: {}", cli_options.follow_location).as_str());
             if let Some(n) = cli_options.max_redirect {
-                log_verbose(format!("max redirect: {}", n.to_string()).as_str());
+                log_verbose(format!("max redirect: {}", n).as_str());
             }
             if let Some(proxy) = cli_options.proxy.clone() {
                 log_verbose(format!("proxy: {}", proxy).as_str());
@@ -135,12 +135,8 @@ fn execute(
             if let Some(to_entry) = cli_options.to_entry {
                 if to_entry < hurl_file.entries.len() {
                     log_verbose(
-                        format!(
-                            "executing {}/{} entries",
-                            to_entry.to_string(),
-                            hurl_file.entries.len().to_string()
-                        )
-                        .as_str(),
+                        format!("executing {}/{} entries", to_entry, hurl_file.entries.len())
+                            .as_str(),
                     );
                 } else {
                     log_verbose("executing all entries");
@@ -338,11 +334,8 @@ fn main() {
                 if let Some(response) = entry_result.response.clone() {
                     let mut output = vec![];
                     if cli_options.include {
-                        let status_line = format!(
-                            "HTTP/{} {}\n",
-                            response.version.to_string(),
-                            response.status.to_string()
-                        );
+                        let status_line =
+                            format!("HTTP/{} {}\n", response.version, response.status);
                         output.append(&mut status_line.into_bytes());
                         for header in response.headers.clone() {
                             let header_line = format!("{}: {}\n", header.name, header.value);
@@ -457,7 +450,7 @@ fn main() {
 fn exit_code(hurl_results: Vec<HurlResult>) -> i32 {
     let mut count_errors_runner = 0;
     let mut count_errors_assert = 0;
-    for hurl_result in hurl_results.clone() {
+    for hurl_result in hurl_results {
         let errors = hurl_result.clone().errors();
         if errors.is_empty() {
         } else if errors.iter().filter(|e| !e.assert).cloned().count() == 0 {

--- a/packages/hurl/src/report/junit/testcase.rs
+++ b/packages/hurl/src/report/junit/testcase.rs
@@ -39,7 +39,7 @@ impl Testcase {
         let mut failures = vec![];
         let mut errors = vec![];
 
-        for error in hurl_result.errors().clone() {
+        for error in hurl_result.errors() {
             let message = cli::error_string(lines, hurl_result.filename.clone(), &error);
             if error.assert {
                 failures.push(message);

--- a/packages/hurl/src/runner/error.rs
+++ b/packages/hurl/src/runner/error.rs
@@ -69,7 +69,7 @@ impl Error for runner::Error {
             RunnerError::AssertVersion { actual, .. } => format!("actual value is <{}>", actual),
             RunnerError::AssertStatus { actual, .. } => format!("actual value is <{}>", actual),
             RunnerError::PredicateValue(value) => {
-                format!("actual value is <{}>", value.to_string())
+                format!("actual value is <{}>", value)
             }
             RunnerError::InvalidRegex {} => "Regex expression is not valid".to_string(),
             RunnerError::FileReadAccess { value } => format!("File {} can not be read", value),

--- a/packages/hurl/src/runner/predicate.rs
+++ b/packages/hurl/src/runner/predicate.rs
@@ -92,8 +92,8 @@ struct AssertResult {
 impl Value {
     pub fn display(self) -> String {
         match self {
-            Value::Bool(v) => format!("bool <{}>", v.to_string()),
-            Value::Integer(v) => format!("int <{}>", v.to_string()),
+            Value::Bool(v) => format!("bool <{}>", v),
+            Value::Integer(v) => format!("int <{}>", v),
             Value::String(v) => format!("string <{}>", v),
             Value::Float(f) => format!("float <{}>", format_float(f)),
             Value::List(values) => format!(
@@ -191,7 +191,7 @@ fn expected(
             } else {
                 panic!();
             };
-            Ok(format!("count equals to <{}>", expected.to_string()))
+            Ok(format!("count equals to <{}>", expected))
         }
         PredicateFuncValue::StartWith {
             value: expected, ..

--- a/packages/hurl_core/src/ast/display.rs
+++ b/packages/hurl_core/src/ast/display.rs
@@ -37,7 +37,7 @@ impl fmt::Display for Method {
 
 impl fmt::Display for Version {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.value.to_string())
+        write!(f, "{}", self.value)
     }
 }
 
@@ -55,7 +55,7 @@ impl fmt::Display for VersionValue {
 
 impl fmt::Display for Status {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.value.to_string())
+        write!(f, "{}", self.value)
     }
 }
 
@@ -63,7 +63,7 @@ impl fmt::Display for StatusValue {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             StatusValue::Any => write!(f, "*"),
-            StatusValue::Specific(v) => write!(f, "{}", v.to_string()),
+            StatusValue::Specific(v) => write!(f, "{}", v),
         }
     }
 }
@@ -82,7 +82,7 @@ impl fmt::Display for TemplateElement {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let s = match self {
             TemplateElement::String { value, .. } => value.clone(),
-            TemplateElement::Expression(value) => format!("{{{{{}}}}}", value.to_string()),
+            TemplateElement::Expression(value) => format!("{{{{{}}}}}", value),
         };
         write!(f, "{}", s)
     }
@@ -104,7 +104,7 @@ impl fmt::Display for CookiePath {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut buf = self.name.to_string();
         if let Some(attribute) = self.attribute.clone() {
-            let s = format!("[{}]", attribute.to_string());
+            let s = format!("[{}]", attribute);
             buf.push_str(s.as_str());
         }
         write!(f, "{}", buf)

--- a/packages/hurl_core/src/ast/json.rs
+++ b/packages/hurl_core/src/ast/json.rs
@@ -76,9 +76,9 @@ pub struct ObjectElement {
 impl fmt::Display for JsonValue {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let s = match self {
-            Value::Expression(expr) => format!("{{{{{}}}}}", expr.to_string()),
+            Value::Expression(expr) => format!("{{{{{}}}}}", expr),
             Value::Number(s) => s.to_string(),
-            Value::String(template) => format!("\"{}\"", template.to_string()),
+            Value::String(template) => format!("\"{}\"", template),
             Value::Boolean(value) => {
                 if *value {
                     "true".to_string()
@@ -135,7 +135,7 @@ impl fmt::Display for ObjectElement {
 impl JsonValue {
     pub fn encoded(&self) -> String {
         match self {
-            Value::Expression(expr) => format!("{{{{{}}}}}", expr.to_string()),
+            Value::Expression(expr) => format!("{{{{{}}}}}", expr),
             Value::Number(s) => s.to_string(),
             Value::String(template) => template.encoded(),
             Value::Boolean(value) => {
@@ -207,7 +207,7 @@ impl TemplateElement {
     fn encoded(&self) -> String {
         match self {
             TemplateElement::String { encoded, .. } => encoded.to_string(),
-            TemplateElement::Expression(expr) => format!("{{{{{}}}}}", expr.to_string()),
+            TemplateElement::Expression(expr) => format!("{{{{{}}}}}", expr),
         }
     }
 }

--- a/packages/hurl_core/src/format/html.rs
+++ b/packages/hurl_core/src/format/html.rs
@@ -132,7 +132,7 @@ impl Htmlable for Response {
 
 impl Htmlable for Method {
     fn to_html(&self) -> String {
-        return format!("<span class=\"method\">{}</span>", self.to_string());
+        return format!("<span class=\"method\">{}</span>", self);
     }
 }
 
@@ -147,7 +147,7 @@ impl Htmlable for Version {
 
 impl Htmlable for Status {
     fn to_html(&self) -> String {
-        format!("<span class=\"number\">{}</span>", self.value.to_string())
+        format!("<span class=\"number\">{}</span>", self.value)
     }
 }
 
@@ -629,7 +629,7 @@ impl Htmlable for PredicateValue {
             PredicateValue::Raw(value) => value.to_html(),
             PredicateValue::Integer(value) => format!("<span class=\"number\">{}</span>", value),
             PredicateValue::Float(value) => {
-                format!("<span class=\"number\">{}</span>", value.to_string())
+                format!("<span class=\"number\">{}</span>", value)
             }
             PredicateValue::Bool(value) => format!("<span class=\"boolean\">{}</span>", value),
             PredicateValue::Hex(value) => value.to_html(),
@@ -809,7 +809,7 @@ impl Htmlable for Template {
         for element in self.elements.clone() {
             let elem_str = match element {
                 TemplateElement::String { encoded, .. } => encoded,
-                TemplateElement::Expression(expr) => format!("{{{{{}}}}}", expr.to_string()),
+                TemplateElement::Expression(expr) => format!("{{{{{}}}}}", expr),
             };
             s.push_str(elem_str.as_str())
         }
@@ -828,7 +828,7 @@ impl Htmlable for Expr {
 }
 
 fn add_line_terminators(buffer: &mut String, line_terminators: Vec<LineTerminator>) {
-    for line_terminator in line_terminators.clone() {
+    for line_terminator in line_terminators {
         buffer.push_str("<span class=\"line\">");
         if line_terminator.newline.value.is_empty() {
             buffer.push_str("<br>");

--- a/packages/hurlfmt/src/format/json.rs
+++ b/packages/hurlfmt/src/format/json.rs
@@ -490,7 +490,7 @@ impl ToJson for hurl_core::ast::JsonValue {
                     .map(|elem| (elem.name.to_string(), elem.value.to_json()))
                     .collect(),
             ),
-            JsonValue::Expression(exp) => JValue::String(format!("{{{{{}}}}}", exp.to_string())),
+            JsonValue::Expression(exp) => JValue::String(format!("{{{{{}}}}}", exp)),
         }
     }
 }

--- a/packages/hurlfmt/src/main.rs
+++ b/packages/hurlfmt/src/main.rs
@@ -158,7 +158,7 @@ fn main() {
         if let Err(e) = io::stdin().read_to_string(&mut contents) {
             log_error_message(
                 false,
-                format!("Input stream can not be read - {}", e.to_string()).as_str(),
+                format!("Input stream can not be read - {}", e).as_str(),
             );
             std::process::exit(2);
         }


### PR DESCRIPTION
Mainly unnecessary calls to to_string on types that implements Display traits <https://rust-lang.github.io/rust-clippy/master/index.html#to_string_in_format_args>.