### PR TITLE
Use slices parameter in get_header_values.

### DIFF
--- a/packages/hurl/src/http/client.rs
+++ b/packages/hurl/src/http/client.rs
@@ -305,7 +305,7 @@ impl Client {
                 .unwrap();
         }
 
-        if get_header_values(request.headers.clone(), "Content-Type".to_string()).is_empty() {
+        if get_header_values(&request.headers, "Content-Type").is_empty() {
             if let Some(s) = request.content_type.clone() {
                 list.append(format!("Content-Type: {}", s).as_str())
                     .unwrap();
@@ -314,24 +314,24 @@ impl Client {
             }
         }
 
-        if get_header_values(request.headers.clone(), "Expect".to_string()).is_empty() {
+        if get_header_values(&request.headers, "Expect").is_empty() {
             list.append("Expect:").unwrap(); // remove header Expect
         }
 
-        if get_header_values(request.headers.clone(), "User-Agent".to_string()).is_empty() {
+        if get_header_values(&request.headers, "User-Agent").is_empty() {
             list.append(format!("User-Agent: hurl/{}", clap::crate_version!()).as_str())
                 .unwrap();
         }
 
         if let Some(user) = self.options.user.clone() {
             let authorization = base64::encode(user.as_bytes());
-            if get_header_values(request.headers.clone(), "Authorization".to_string()).is_empty() {
+            if get_header_values(&request.headers, "Authorization").is_empty() {
                 list.append(format!("Authorization: Basic {}", authorization).as_str())
                     .unwrap();
             }
         }
         if self.options.compressed
-            && get_header_values(request.headers.clone(), "Accept-Encoding".to_string()).is_empty()
+            && get_header_values(&request.headers, "Accept-Encoding").is_empty()
         {
             list.append("Accept-Encoding: gzip, deflate, br").unwrap();
         }
@@ -459,7 +459,7 @@ impl Client {
         if !(300..400).contains(&response_code) {
             return None;
         }
-        let location = match get_header_values(response.headers, "Location".to_string()).get(0) {
+        let location = match get_header_values(&response.headers, "Location").get(0) {
             None => return None,
             Some(value) => value.clone(),
         };

--- a/packages/hurl/src/http/core.rs
+++ b/packages/hurl/src/http/core.rs
@@ -145,13 +145,13 @@ impl FromStr for Cookie {
 }
 
 ///
-/// return a list of headers values for the given header name
+/// Return a list of headers values for the given header name.
 ///
-pub fn get_header_values(headers: Vec<Header>, expected_name: String) -> Vec<String> {
+pub fn get_header_values(headers: &[Header], expected_name: &str) -> Vec<String> {
     headers
         .iter()
         .filter_map(|Header { name, value }| {
-            if name.clone() == expected_name {
+            if name == expected_name {
                 Some(value.to_string())
             } else {
                 None

--- a/packages/hurl/src/http/response.rs
+++ b/packages/hurl/src/http/response.rs
@@ -53,7 +53,7 @@ impl Response {
     /// return a list of headers values for the given header name
     ///
     pub fn get_header_values(&self, expected_name: String) -> Vec<String> {
-        get_header_values(self.headers.clone(), expected_name)
+        get_header_values(&self.headers, &expected_name)
     }
 
     ///


### PR DESCRIPTION
Change function signature from

```rust 
pub fn get_header_values(headers: Vec<Header>, expected_name: String) -> Vec<String> {
```

to 

```rust 
pub fn get_header_values(headers: &[Header], expected_name: &str) -> Vec<String> {
```

(no need to transfer ownership)
