### PR TITLE
Use new line for splitting options.

### DIFF
--- a/integration/report.sh
+++ b/integration/report.sh
@@ -9,7 +9,7 @@ export HURL_name=Bob
 find tests -name "*.hurl" | sort | while read -r hurl_file; do
     options=("--report-html build/html" "--report-junit build/tests.xml" "--json" )
     if test -f "${hurl_file%.*}.options"; then
-        options+=("$(cat "${hurl_file%.*}.options")")
+        options+=("$(< "${hurl_file%.*}.options" tr '\n' ' ') ")
     fi
     cmd="hurl $hurl_file ${options[*]}"
     echo "$cmd"

--- a/integration/ssl/cacert.options
+++ b/integration/ssl/cacert.options
@@ -1,1 +1,2 @@
---cacert ssl/cert.pem
+--cacert
+ssl/cert.pem

--- a/integration/test_hurl.py
+++ b/integration/test_hurl.py
@@ -41,7 +41,7 @@ def test(hurl_file):
 
     options = []
     if os.path.exists(options_file):
-         options = open(options_file).read().strip().split(' ')
+         options = open(options_file).read().strip().split('\n')
     if os.path.exists(curl_file):
         options.append('--verbose')
 

--- a/integration/tests/basic_authentication.options
+++ b/integration/tests/basic_authentication.options
@@ -1,1 +1,2 @@
---user bob:secret
+--user
+bob:secret

--- a/integration/tests/cookie_file.options
+++ b/integration/tests/cookie_file.options
@@ -1,1 +1,2 @@
---cookie tests/cookie_file.cookies
+--cookie
+tests/cookie_file.cookies

--- a/integration/tests/error_body_json.options
+++ b/integration/tests/error_body_json.options
@@ -1,1 +1,2 @@
---variable success=invalid
+--variable
+success=invalid

--- a/integration/tests/error_connect_timeout.options
+++ b/integration/tests/error_connect_timeout.options
@@ -1,2 +1,3 @@
---connect-timeout 1
+--connect-timeout
+1
 

--- a/integration/tests/error_max_redirect.options
+++ b/integration/tests/error_max_redirect.options
@@ -1,2 +1,4 @@
---location --max-redirs 5
+--location
+--max-redirs
+5
 

--- a/integration/tests/error_timeout.options
+++ b/integration/tests/error_timeout.options
@@ -1,1 +1,2 @@
---max-time 1
+--max-time
+1

--- a/integration/tests/post_json.options
+++ b/integration/tests/post_json.options
@@ -1,1 +1,4 @@
---variable age=30 --variable strict=true
+--variable
+age=30
+--variable
+strict=true

--- a/integration/tests/proxy.options
+++ b/integration/tests/proxy.options
@@ -1,1 +1,2 @@
---proxy localhost:8888
+--proxy
+localhost:8888

--- a/integration/tests/variables.options
+++ b/integration/tests/variables.options
@@ -1,1 +1,4 @@
---variables-file tests/variables.properties --variable female=true
+--variables-file
+tests/variables.properties
+--variable
+female=true


### PR DESCRIPTION
This allows us to use options value with space in integration tests.