### PR TITLE
Use Path/PathBuf struct when appropriates.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
             pip3 install lxml bs4 --quiet
             echo "================= Integration tests ================="            
             python3 ./integration.py
-            ./test_curl_commands.sh tests/*.curl
+            ./test_curl_commands.sh $(find ./tests -maxdepth 1 -type f -name '*.curl' ! -name '*windows*')
             python3 ./test_html_output.py tests/*.html
             xmllint --noout tests/*.html
       - store_artifacts:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,7 +127,7 @@ jobs:
          cd integration
          pip install lxml bs4
          ./integration.py
-         ./test_curl_commands.sh tests/*.curl
+         ./test_curl_commands.sh $(find ./tests -maxdepth 1 -type f -name '*.curl' ! -name '*windows*')
          ./test_html_output.py tests/*.html
          xmllint --noout tests/*.html
          ./report.sh

--- a/integration/test_hurl.py
+++ b/integration/test_hurl.py
@@ -33,11 +33,19 @@ def get_os():
 
 
 def test(hurl_file):
-  
-    options_file = hurl_file.replace('.hurl','.options')
-    curl_file = hurl_file.replace('.hurl','.curl')
-    json_output_file = hurl_file.replace('.hurl','.output.json')
-    profile_file = hurl_file.replace('.hurl','.profile')
+
+    options_file = hurl_file.replace('.hurl', '.options')
+
+    # For .curl file, we can have specific os expected file in order to test
+    # os differences like included path (/ vs \ path components separator)
+    os_curl_file = hurl_file.replace('.hurl', '.' + get_os() + '.curl')
+    if os.path.exists(os_curl_file):
+        curl_file = os_curl_file
+    else:
+        curl_file = hurl_file.replace('.hurl', '.curl')
+
+    json_output_file = hurl_file.replace('.hurl', '.output.json')
+    profile_file = hurl_file.replace('.hurl', '.profile')
 
     options = []
     if os.path.exists(options_file):

--- a/integration/tests/multipart_form_data.windows.curl
+++ b/integration/tests/multipart_form_data.windows.curl
@@ -1,0 +1,1 @@
+curl 'http://localhost:8000/multipart-form-data' -F 'key1=value1' -F 'upload1=@tests\data.txt;type=text/plain' -F 'upload2=@tests\data.html;type=text/html' -F 'upload3=@tests\data.txt;type=text/html'

--- a/integration/tests/post_file.windows.curl
+++ b/integration/tests/post_file.windows.curl
@@ -1,0 +1,2 @@
+curl 'http://localhost:8000/post-file' -H 'Content-Type:' --data '@tests\data.bin'
+curl 'http://localhost:8000/post-file' -H 'Content-Type:' --data '@tests\post_file_with space'

--- a/packages/hurl/src/http/client.rs
+++ b/packages/hurl/src/http/client.rs
@@ -519,7 +519,8 @@ impl Client {
     ///
     pub fn curl_command_line(&mut self, http_request: &RequestSpec) -> String {
         let mut arguments = vec!["curl".to_string()];
-        arguments.append(&mut http_request.curl_args(self.options.context_dir.clone()));
+        let context_dir = &self.options.context_dir;
+        arguments.append(&mut http_request.curl_args(context_dir));
 
         let cookies = all_cookies(self.get_cookie_storage(), http_request);
         if !cookies.is_empty() {

--- a/packages/hurl/src/http/options.rs
+++ b/packages/hurl/src/http/options.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+use std::path::PathBuf;
 use std::time::Duration;
 
 #[derive(Debug, Clone)]
@@ -32,7 +33,7 @@ pub struct ClientOptions {
     pub user: Option<String>,
     pub user_agent: Option<String>,
     pub compressed: bool,
-    pub context_dir: String,
+    pub context_dir: PathBuf,
 }
 
 impl Default for ClientOptions {
@@ -51,7 +52,7 @@ impl Default for ClientOptions {
             user: None,
             user_agent: None,
             compressed: false,
-            context_dir: ".".to_string(),
+            context_dir: PathBuf::new(),
         }
     }
 }
@@ -136,7 +137,7 @@ mod tests {
                 user: Some("user:password".to_string()),
                 user_agent: Some("my-useragent".to_string()),
                 compressed: true,
-                context_dir: "".to_string()
+                context_dir: PathBuf::new()
             }
             .curl_args(),
             [

--- a/packages/hurl/src/main.rs
+++ b/packages/hurl/src/main.rs
@@ -160,14 +160,13 @@ fn execute(
             let context_dir = match cli_options.file_root {
                 None => {
                     if filename == "-" {
-                        current_dir.to_str().unwrap().to_string()
+                        current_dir
                     } else {
                         let path = Path::new(filename);
-                        let parent = path.parent();
-                        parent.unwrap().to_str().unwrap().to_string()
+                        path.parent().unwrap()
                     }
                 }
-                Some(filename) => filename,
+                Some(ref filename) => Path::new(filename),
             };
             let options = http::ClientOptions {
                 cacert_file,
@@ -183,7 +182,7 @@ fn execute(
                 user,
                 user_agent,
                 compressed,
-                context_dir: context_dir.clone(),
+                context_dir: context_dir.to_path_buf(),
             };
 
             let mut client = http::Client::init(options);
@@ -202,7 +201,7 @@ fn execute(
                 fail_fast: cli_options.fail_fast,
                 variables: cli_options.variables,
                 to_entry: cli_options.to_entry,
-                context_dir,
+                context_dir: context_dir.to_path_buf(),
                 ignore_asserts: cli_options.ignore_asserts,
                 pre_entry,
                 post_entry,

--- a/packages/hurl/src/runner/core.rs
+++ b/packages/hurl/src/runner/core.rs
@@ -16,6 +16,7 @@
  *
  */
 use std::collections::HashMap;
+use std::path::PathBuf;
 
 use crate::http;
 use hurl_core::ast::{Entry, SourceInfo};
@@ -27,7 +28,7 @@ pub struct RunnerOptions {
     pub fail_fast: bool,
     pub variables: HashMap<String, Value>,
     pub to_entry: Option<usize>,
-    pub context_dir: String,
+    pub context_dir: PathBuf,
     pub ignore_asserts: bool,
     pub pre_entry: fn(Entry) -> bool,
     pub post_entry: fn() -> bool,

--- a/packages/hurl/src/runner/entry.rs
+++ b/packages/hurl/src/runner/entry.rs
@@ -59,7 +59,7 @@ pub fn run(
     let http_request = match eval_request(
         entry.request.clone(),
         variables,
-        options.context_dir.clone(),
+        options.context_dir.as_path(),
     ) {
         Ok(r) => r,
         Err(error) => {
@@ -182,7 +182,7 @@ pub fn run(
                         response,
                         variables,
                         http_response.clone(),
-                        options.context_dir.clone(),
+                        options.context_dir.as_path(),
                     ),
                 }
             };

--- a/packages/hurl/src/runner/hurl_file.rs
+++ b/packages/hurl/src/runner/hurl_file.rs
@@ -29,6 +29,7 @@ use super::entry;
 /// # Example
 ///
 /// ```
+/// use std::path::PathBuf;
 /// use hurl_core::parser;
 /// use hurl::http;
 /// use hurl::runner;
@@ -47,22 +48,7 @@ use super::entry;
 /// fn log_error(error: &runner::Error, _warning: bool) { eprintln!("* {:#?}", error); }
 ///
 /// // Create an http client
-/// let options = http::ClientOptions {
-///        cacert_file: None,
-///        follow_location: false,
-///        max_redirect: None,
-///        cookie_input_file: None,
-///        proxy: None,
-///        no_proxy: None,
-///        verbose: false,
-///        insecure: false,
-///        timeout: Default::default(),
-///        connect_timeout: Default::default(),
-///        user: None,
-///        user_agent: None,
-///        compressed: false,
-///        context_dir: "".to_string(),
-/// };
+/// let options = http::ClientOptions::default();
 /// let mut client = http::Client::init(options);
 ///
 /// // Define runner options
@@ -71,7 +57,7 @@ use super::entry;
 ///        fail_fast: false,
 ///        variables,
 ///        to_entry: None,
-///        context_dir: "current_dir".to_string(),
+///        context_dir: PathBuf::new(),
 ///        ignore_asserts: false,
 ///        pre_entry: |_| true,
 ///        post_entry: || true,

--- a/packages/hurl/src/runner/multipart.rs
+++ b/packages/hurl/src/runner/multipart.rs
@@ -33,7 +33,7 @@ use super::value::Value;
 pub fn eval_multipart_param(
     multipart_param: MultipartParam,
     variables: &HashMap<String, Value>,
-    context_dir: String,
+    context_dir: &Path,
 ) -> Result<http::MultipartParam, Error> {
     match multipart_param {
         MultipartParam::Param(KeyValue { key, value, .. }) => {
@@ -50,7 +50,7 @@ pub fn eval_multipart_param(
 
 pub fn eval_file_param(
     file_param: FileParam,
-    context_dir: String,
+    context_dir: &Path,
 ) -> Result<http::FileParam, Error> {
     let name = file_param.key.value;
 
@@ -59,7 +59,7 @@ pub fn eval_file_param(
     let absolute_filename = if path.is_absolute() {
         filename.value.clone()
     } else {
-        Path::new(context_dir.as_str())
+        context_dir
             .join(filename.value.clone())
             .to_str()
             .unwrap()
@@ -179,7 +179,7 @@ mod tests {
                     },
                     line_terminator0: line_terminator,
                 },
-                "tests".to_string()
+                Path::new("tests")
             )
             .unwrap(),
             http::FileParam {

--- a/packages/hurl/src/runner/response.rs
+++ b/packages/hurl/src/runner/response.rs
@@ -16,6 +16,7 @@
  *
  */
 use std::collections::HashMap;
+use std::path::Path;
 
 use crate::http;
 use hurl_core::ast::*;
@@ -32,7 +33,7 @@ pub fn eval_asserts(
     response: Response,
     variables: &HashMap<String, Value>,
     http_response: http::Response,
-    context_dir: String,
+    context_dir: &Path,
 ) -> Vec<AssertResult> {
     let mut asserts = vec![];
 
@@ -292,7 +293,7 @@ mod tests {
     #[test]
     pub fn test_eval_asserts() {
         let variables = HashMap::new();
-        let context_dir = "undefined".to_string();
+        let context_dir = Path::new("");
         assert_eq!(
             eval_asserts(
                 user_response(),

--- a/packages/hurl/tests/libcurl.rs
+++ b/packages/hurl/tests/libcurl.rs
@@ -1,4 +1,5 @@
 use std::default::Default;
+use std::path::Path;
 use std::time::Duration;
 
 use hurl::http::*;
@@ -591,7 +592,7 @@ fn test_basic_authentication() {
         content_type: None,
     };
     assert_eq!(
-        request_spec.curl_args(".".to_string()),
+        request_spec.curl_args(Path::new("")),
         vec!["'http://bob:secret@localhost:8000/basic-authentication'".to_string()]
     );
     let (request, response) = client.execute(&request_spec).unwrap();

--- a/packages/hurl/tests/runner.rs
+++ b/packages/hurl/tests/runner.rs
@@ -22,6 +22,7 @@ use hurl::runner::RunnerOptions;
 use hurl_core::ast::*;
 use hurl_core::parser;
 use std::collections::HashMap;
+use std::path::PathBuf;
 
 pub fn log_verbose(message: &str) {
     eprintln!("* {}", message);
@@ -53,7 +54,7 @@ fn test_hurl_file() {
         fail_fast: false,
         variables,
         to_entry: None,
-        context_dir: "current_dir".to_string(),
+        context_dir: PathBuf::new(),
         ignore_asserts: false,
         pre_entry: |_| true,
         post_entry: || true,
@@ -183,7 +184,7 @@ fn test_hello() {
         fail_fast: true,
         variables,
         to_entry: None,
-        context_dir: "current_dir".to_string(),
+        context_dir: PathBuf::new(),
         ignore_asserts: false,
         pre_entry: |_| true,
         post_entry: || true,


### PR DESCRIPTION
We use `PathBuf` in `ClientOptions` and in `RunnerOptions`;  an `&Path` in functions if possible.