### PR TITLE
Delete deprecated html report options.

### DIFF
--- a/docs/hurl.md
+++ b/docs/hurl.md
@@ -177,12 +177,6 @@ However, to avoid your shell accidentally expanding glob patterns before Hurl ha
 
 Usage help. This lists all current command line options with a short description.
 
-### --html <dir> {#html}
-
-Generate html report in dir.
-
-If the html report already exists, it will be updated with the new test results.
-
 ### --ignore-asserts {#ignore-asserts}
 
 Ignore all asserts defined in the Hurl file.
@@ -199,7 +193,6 @@ This is similar to a break point, You can then continue (Press C) or quit (Press
 ### --json {#json}
 
 Output each hurl file result to JSON. The format is very closed to HAR format. 
-
 
 ### -k, --insecure {#insecure}
 
@@ -245,6 +238,18 @@ Write output to <file> instead of stdout.
 ### --progress {#progress}
 
 Print filename and status for each test (on stderr)
+
+### --report-junit <file> {#report-junit}
+
+Generate JUNIT <file>.
+
+If the <file> report already exists, it will be updated with the new test results.
+
+### --report-html <dir> {#report-html}
+
+Generate HTML report in dir.
+
+If the HTML report already exists, it will be updated with the new test results.
 
 ### --summary {#summary}
 

--- a/packages/hurl/src/cli/options.rs
+++ b/packages/hurl/src/cli/options.rs
@@ -145,13 +145,6 @@ pub fn app(version: &str) -> App {
                 .help("Specify input files that match the given blob. Multiple glob flags may be used."),
         )
         .arg(
-            clap::Arg::new("html")
-                .long("html")
-                .value_name("DIR")
-                .help("Generate html report to dir")
-                .takes_value(true),
-        )
-        .arg(
             clap::Arg::new("include")
                 .short('i')
                 .long("include")
@@ -340,17 +333,7 @@ pub fn parse_options(matches: ArgMatches) -> Result<CliOptions, CliError> {
     let file_root = matches.value_of("file_root").map(|value| value.to_string());
     let follow_location = matches.is_present("follow_location");
     let glob_files = match_glob_files(matches.clone())?;
-    // deprecated
-    // Support --report-html and --html only for the current version
-    if matches.is_present("html") {
-        eprintln!("The option --html is deprecated. It has been renamed to --report-html.");
-        eprintln!("It will be removed in the next version");
-    }
-    let report_html = if let Some(dir) = matches.value_of("html") {
-        Some(dir)
-    } else {
-        matches.value_of("report_html")
-    };
+    let report_html = matches.value_of("report_html");
     let html_dir = if let Some(dir) = report_html {
         let path = Path::new(dir);
         if !path.exists() {


### PR DESCRIPTION
Remove deprecated `--html` option (replace by `--report-html`).