### PR TITLE
Fix clippy 1.59 warnings.

### DIFF
--- a/packages/hurl/src/http/request_spec.rs
+++ b/packages/hurl/src/http/request_spec.rs
@@ -195,7 +195,7 @@ impl RequestSpec {
                     arguments.push(format!(
                         "{}'{}'",
                         prefix,
-                        s.replace("\\", "\\\\").replace("\n", "\\n")
+                        s.replace('\\', "\\\\").replace('\n', "\\n")
                     ))
                 }
                 Body::Binary(bytes) => arguments.push(format!("$'{}'", encode_bytes(bytes))),

--- a/packages/hurl_core/src/format/html.rs
+++ b/packages/hurl_core/src/format/html.rs
@@ -846,7 +846,7 @@ fn add_line_terminators(buffer: &mut String, line_terminators: Vec<LineTerminato
 }
 
 fn encode_html(s: String) -> String {
-    s.replace(">", "&gt;").replace("<", "&lt;")
+    s.replace('>', "&gt;").replace('<', "&lt;")
 }
 
 fn multilines(s: String) -> String {


### PR DESCRIPTION
Mainly https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern.