### PR TITLE
Skip Tests on Archlinux

### DIFF
--- a/ci/build_and_test.sh
+++ b/ci/build_and_test.sh
@@ -8,6 +8,12 @@ cargo build --verbose
 
 ci/test_prerequisites.sh
 
+# current bug with curl to be fixed
+# https://github.com/curl/curl/issues/8559
+if test -f /etc/arch-release; then
+   exit 0
+fi
+
 echo "----- unit tests  -----"
 cargo test --features strict --tests
 


### PR DESCRIPTION
current curl issue
https://github.com/curl/curl/issues/8559

Reproducible in a docker container
```
curl 'https://localhost:8001/hello' --cacert ssl/cert.pem
curl: (27) Out of memory
```
