### PR TITLE
Add test for debugging

### DIFF
--- a/packages/hurl/tests/libcurl.rs
+++ b/packages/hurl/tests/libcurl.rs
@@ -984,3 +984,19 @@ fn test_version() {
     let versions = libcurl_version_info();
     eprintln!("{:?}", versions);
 }
+
+// This test function can be used to reproduce bug
+#[test]
+fn test_libcurl_directly() {
+    use curl;
+    use std::io::{stdout, Write};
+
+    let mut easy = curl::easy::Easy::new();
+    easy.url("http://localhost:8000/hello").unwrap();
+    easy.write_function(|data| {
+        stdout().write_all(data).unwrap();
+        Ok(data.len())
+    })
+    .unwrap();
+    easy.perform().unwrap();
+}


### PR DESCRIPTION
This test can be used to reproduced a bug related to libcurl
independently of Hurl.
