### PR TITLE
Fix curl command check error output.

### DIFF
--- a/integration/test_hurl.py
+++ b/integration/test_hurl.py
@@ -134,14 +134,14 @@ def test(hurl_file):
         ]
 
         if len(actual_commands) != len(expected_commands):
-            print("Assert error at %s" % (f))
+            print("curl commands error at %s" % (curl_file))
             print("expected: %d commands" % len(expected_commands))
             print("actual:   %d commands" % len(actual_commands))
             sys.exit(1)
 
         for i in range(len(expected_commands)):
             if actual_commands[i] != expected_commands[i]:
-                print("Assert error at %s:%i" % (curl_file, i + 1))
+                print("curl command error at %s:%i" % (curl_file, i + 1))
                 print("expected: %s" % expected_commands[i])
                 print("actual:   %s" % actual_commands[i])
                 sys.exit(1)


### PR DESCRIPTION
When we check the curl commands of a given Hurl file, the current check output, when in error, is 

```
Assert error at tests_ok/assert_xpath.err
expected: 1 commands
actual:   4 commands
```

This PR fixes with this message:

```
curl commands error at tests_ok/assert_xpath.curl
expected: 1 commands
actual:   4 commands
```
