### PR TITLE
Generalize tests for curl timeout error codes

### DIFF
--- a/packages/hurl/tests/libcurl.rs
+++ b/packages/hurl/tests/libcurl.rs
@@ -753,16 +753,12 @@ fn test_connect_timeout() {
     assert!(matches!(error, HttpError::Libcurl { .. }));
     if let HttpError::Libcurl { code, description } = error {
         eprintln!("description={}", description);
-        if cfg!(target_os = "macos") {
-            assert_eq!(code, 7);
-            assert_eq!(description, "Couldn't connect to server");
-        } else {
-            assert_eq!(code, 28);
-            assert!(
-                description.starts_with("Connection timed out")
-                    || description.starts_with("Connection timeout")
-            );
-        }
+        assert!(code == 7 || code == 28);
+        assert!(
+            description.starts_with("Couldn't connect to server")
+                || description.starts_with("Connection timed out")
+                || description.starts_with("Connection timeout")
+        );
     }
 }
 // endregion


### PR DESCRIPTION
PR split out from #506. On Monterey, I've observed that the library returns 28, causing these assertions to fail. However, in GH actions with the macos-latest environment, 7 is returned which passes. This change just asserts more generally for known exit codes and error messages across platforms, since it didn't seem the rest of the app was dependent on the specific error code/message.