### PR TITLE
Uniform Hurl build on test CI.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,12 +106,14 @@ jobs:
     - name: Install
       run: |
         sudo apt update
-        sudo apt install libxml2-utils
+        sudo apt install libcurl4-openssl-dev libxml2-utils
         python3 -m pip install --upgrade pip --quiet
         ci/install_rust_latest.sh
     - name: Build
       run: |
-        cargo build --verbose --locked
+        cargo build --release --verbose --locked
+        target/release/hurl --version
+        curl --version
     - name: Test Prequisites
       run: |
         ci/test_prerequisites.sh
@@ -251,7 +253,9 @@ jobs:
         cargo --version     
     - name: Build
       run: |
-        cargo build --verbose
+        cargo build --release --verbose --locked
+        target/release/hurl --version
+        curl --version
     - name: Test Prequisites
       run: |
         pip3 install Flask
@@ -324,10 +328,12 @@ jobs:
         cargo test --features strict --tests
     - name: Run Integration tests
       run: |
-        cargo build --release --verbose
+        cargo build --release --verbose --locked
+        target\release\hurl.exe --version
         $execdir=[System.Environment]::SystemDirectory
         Get-ChildItem -Path ".\target\release" -Recurse -Include *.dll -File | Copy-Item -Destination "${execdir}"
         Get-ChildItem -Path ".\target\release" -Recurse -Include hurl*.exe -File | Copy-Item -Destination "${execdir}"
+
         cd .\integration
         Start-Job -Name mitmdump -ScriptBlock { mitmdump --listen-port 8888 --modify-header "/From-Proxy/Hello" }
         Start-Job -Name server -ScriptBlock { python server.py > server.log }

--- a/ci/build_and_test.sh
+++ b/ci/build_and_test.sh
@@ -2,9 +2,12 @@
 set -e
 
 echo "----- build -----"
+# Directive for ShellCheck SC1090:
 # shellcheck source=/dev/null
 source ~/.cargo/env
-cargo build --verbose
+cargo build --release --verbose --locked
+target/release/hurl --version
+curl --version
 
 ci/test_prerequisites.sh
 


### PR DESCRIPTION
Test build are done with --release and --locked.

Hurl and curl version are outputed just after build.

Ex on [Ubuntu](https://github.com/Orange-OpenSource/hurl/runs/5632708092?check_suite_focus=true
):

```
hurl 1.7.0-snapshot libcurl/7.68.0 OpenSSL/1.1.1f zlib/1.2.11 brotli/1.0.3840 libidn2/2.2.0 libssh/0.9.3/openssl/zlib 1.40.0
curl 7.68.0 (x86_64-pc-linux-gnu) libcurl/7.68.0 OpenSSL/1.1.1f zlib/1.2.11 brotli/1.0.7 libidn2/2.2.0 libpsl/0.21.0 
```

Hurl uses libcurl 7.68.0 (while curl crate has a static version of libcurl/7.81.0)

On macOS GitHub image:

```
hurl 1.7.0-snapshot libcurl/7.64.1 (SecureTransport) LibreSSL/2.8.3 zlib/1.2.11
curl 7.82.0 (x86_64-apple-darwin20.6.0) libcurl/7.82.0 (SecureTransport) OpenSSL/1.1.1m zlib/1.2.11 brotli/1.0.9 zstd/1.5.2 libidn2/2.3.2 libssh2/1.10.0 nghttp2/1.47.0 librtmp/2.3 OpenLDAP/2.6.1
```

Hurl uses the system libcurl (7.64.1) while curl 7.82.0 is installed via brew.


