### PR TITLE
Add missing prefix for Hurl version output.

### DIFF
--- a/packages/hurl/src/http/version.rs
+++ b/packages/hurl/src/http/version.rs
@@ -39,7 +39,7 @@ pub fn libcurl_version_info() -> Vec<String> {
         versions.push(format!("brotli/{}", s));
     }
     if let Some(s) = version.zstd_version() {
-        versions.push(s.to_string());
+        versions.push(format!("zstd/{}", s));
     }
     if let Some(s) = version.ares_version() {
         versions.push(format!("c-ares/{}", s));
@@ -53,13 +53,13 @@ pub fn libcurl_version_info() -> Vec<String> {
         }
     }
     if let Some(s) = version.libssh_version() {
-        versions.push(s.to_string());
+        versions.push(format!("libssh/{}", s));
     }
     if let Some(s) = version.nghttp2_version() {
-        versions.push(s.to_string());
+        versions.push(format!("nghttp2/{}", s));
     }
     if let Some(s) = version.quic_version() {
-        versions.push(s.to_string());
+        versions.push(format!("quic/{}", s));
     }
     if let Some(s) = version.hyper_version() {
         versions.push(format!("hyper/{}", s));


### PR DESCRIPTION
This PR add some missing prefix for Hurl version output.

Before this PR:

```
$ hurl --version
hurl 1.6.1 libcurl/7.77.0 (SecureTransport) LibreSSL/2.8.3 zlib/1.2.11 1.42.0
```

After this PR:

```
$ hurl --version
hurl 1.7.0-snapshot libcurl/7.77.0 (SecureTransport) LibreSSL/2.8.3 zlib/1.2.11 nghttp2/1.42.0
```