### PR TITLE
git ignore target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,1 @@
-*.swp
-*.swo
-*.pyc
-
-target/
-.idea/
-.venv/
-build/
-node_modules/
-**/npm/bin/
-integration/*.log
+/target


### PR DESCRIPTION
New file '.gitignore' as created by `cargo init`.
It prevents `git status` reporting there is a target directory.