### PR TITLE
Add basic Syntax highlighting for VIM

### DIFF
--- a/contrib/vim/README.md
+++ b/contrib/vim/README.md
@@ -1,0 +1,16 @@
+Install vim syntaxt highlighting for Hurl
+
+```
+mkdir -p ~/.vim/{ftdetect,syntax}
+cp ftdetect/hurl.vim ~/.vim/ftdetect
+cp syntax/hurl.vim ~/.vim/syntax
+```
+
+Activate syntax highlighting in your ~/.vimrc
+```
+syntax on
+```
+
+
+
+

--- a/contrib/vim/ftdetect/hurl.vim
+++ b/contrib/vim/ftdetect/hurl.vim
@@ -1,0 +1,2 @@
+autocmd BufRead,BufNewFile *.hurl set filetype=hurl
+

--- a/contrib/vim/syntax/hurl.vim
+++ b/contrib/vim/syntax/hurl.vim
@@ -1,0 +1,38 @@
+" Vim syntax file
+" Language: Hurl (https://hurl.dev)
+
+if exists("b:current_syntax")
+  finish
+endif
+
+syntax match Method  "^GET"
+syntax match Method  "^POST"
+syntax match Method  "^PUT"
+syntax match Method  "^DELETE"
+syntax match Method  "^CONNECT"
+syntax match Method  "^OPTIONS"
+syntax match Method  "^TRACE"
+syntax match Method  "^PATCH"
+
+syntax match Comment "#.*$"
+syntax match EscapeNumberSign  "\\#"
+syntax match EscapeQuote  "\\\"" 
+syntax match Section "\[[A-Za-z]*\]"
+syntax match Number  "\s[0-9]*"
+
+syntax region String start='"' end='"'  contains=EscapeQuote
+syntax region String start='```' end='```'
+syntax region Json   start='{' end='}'
+
+
+" colors
+highlight Comment             ctermfg=grey
+highlight Method              ctermfg=yellow
+highlight Section             ctermfg=magenta
+highlight String              ctermfg=green
+highlight Json                ctermfg=green
+highlight Number              ctermfg=lightblue
+highlight EscapeNumberSign    ctermfg=white
+highlight EscapeQuote         ctermfg=green
+
+

--- a/contrib/vim/test.hurl
+++ b/contrib/vim/test.hurl
@@ -1,0 +1,29 @@
+# This is a comment
+GET http://example.com
+Header1: Value1
+Header2: a\#    # value with \#
+Header3: GET   
+
+HTTP/1.1 200
+[Asserts]
+body not contains "#"            # Other comment
+body not contains "[Asserts]"
+body not contains "200"
+body not contains "GET"
+body not contains "\"\#"
+
+
+POST http://example.com
+{
+  "id": 123,
+  "message": "Hello"
+}
+
+
+POST http://example.com
+```
+Hello
+```
+
+
+


### PR DESCRIPTION
This is a first basic version to get syntax highlighting in VIM.

VIM Syntax highlighting is flexible but quite complicated. 
This first version needs to be improved in order to deal with more edge cases.

A sample Hurl file is given in order to show the current capability of the syntax highlighting.
![vim](https://user-images.githubusercontent.com/682123/172066514-6063e8f1-b936-43f2-88a2-9edf146e2ada.png)
