### PR TITLE
Clean http package error code

### DIFF
--- a/packages/hurl/src/http/client.rs
+++ b/packages/hurl/src/http/client.rs
@@ -28,9 +28,9 @@ use super::options::ClientOptions;
 use super::request::*;
 use super::request_spec::*;
 use super::response::*;
+use crate::http::HttpError;
 use std::str::FromStr;
 use url::Url;
-use crate::http::HttpError;
 
 #[derive(Debug)]
 pub struct Client {
@@ -222,7 +222,11 @@ impl Client {
                     None => e.description().to_string(),
                     Some(s) => s.to_string(),
                 };
-                return Err(HttpError::Libcurl { code, description, url });
+                return Err(HttpError::Libcurl {
+                    code,
+                    description,
+                    url,
+                });
             }
         }
 

--- a/packages/hurl/src/http/client.rs
+++ b/packages/hurl/src/http/client.rs
@@ -30,14 +30,7 @@ use super::request_spec::*;
 use super::response::*;
 use std::str::FromStr;
 use url::Url;
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum HttpError {
-    StatuslineIsMissing,
-    CouldNotParseResponse,
-    TooManyRedirect,
-    Libcurl { code: i32, description: String },
-}
+use crate::http::HttpError;
 
 #[derive(Debug)]
 pub struct Client {
@@ -229,13 +222,13 @@ impl Client {
                     None => e.description().to_string(),
                     Some(s) => s.to_string(),
                 };
-                return Err(HttpError::Libcurl { code, description });
+                return Err(HttpError::Libcurl { code, description, url });
             }
         }
 
         let status = self.handle.response_code().unwrap();
         let version = match status_lines.last() {
-            None => return Err(HttpError::StatuslineIsMissing {}),
+            None => return Err(HttpError::StatuslineIsMissing { url }),
             Some(status_line) => self.parse_response_version(status_line.clone())?,
         };
         let headers = self.parse_response_headers(&headers);

--- a/packages/hurl/src/http/error.rs
+++ b/packages/hurl/src/http/error.rs
@@ -1,0 +1,43 @@
+/*
+* Hurl (https://hurl.dev)
+* Copyright (C) 2022 Orange
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*          http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum HttpError {
+    CouldNotParseResponse,
+    CouldNotUncompressResponse {
+        description: String,
+    },
+    InvalidCharset {
+        charset: String,
+    },
+    InvalidDecoding {
+        charset: String,
+    },
+    Libcurl {
+        code: i32,
+        description: String,
+        url: String,
+    },
+    StatuslineIsMissing {
+        url: String,
+    },
+    TooManyRedirect,
+    UnsupportedContentEncoding {
+        description: String,
+    },
+}

--- a/packages/hurl/src/http/mod.rs
+++ b/packages/hurl/src/http/mod.rs
@@ -16,8 +16,9 @@
  *
  */
 
-pub use self::client::{Client, HttpError};
+pub use self::client::Client;
 pub use self::core::{Cookie, Header, Param, RequestCookie};
+pub use self::error::HttpError;
 pub use self::options::ClientOptions;
 pub use self::request::Request;
 #[cfg(test)]
@@ -31,6 +32,7 @@ pub use self::version::libcurl_version_info;
 mod client;
 mod content_decoding;
 mod core;
+mod error;
 mod options;
 mod request;
 mod request_spec;

--- a/packages/hurl/src/main.rs
+++ b/packages/hurl/src/main.rs
@@ -30,7 +30,7 @@ use hurl::http;
 use hurl::report;
 use hurl::report::canonicalize_filename;
 use hurl::runner;
-use hurl::runner::{HurlResult, RunnerOptions};
+use hurl::runner::{HurlResult, RunnerError, RunnerOptions};
 use hurl_core::ast::{Pos, SourceInfo};
 use hurl_core::error::Error;
 use hurl_core::parser;
@@ -360,7 +360,7 @@ fn main() {
                                             start: Pos { line: 0, column: 0 },
                                             end: Pos { line: 0, column: 0 },
                                         },
-                                        inner: e,
+                                        inner: RunnerError::from(e),
                                         assert: false,
                                     }
                                     .fixme()

--- a/packages/hurl/src/runner/entry.rs
+++ b/packages/hurl/src/runner/entry.rs
@@ -18,7 +18,6 @@
 use std::collections::HashMap;
 
 use crate::http;
-use crate::http::HttpError;
 use hurl_core::ast::*;
 
 use super::core::*;
@@ -114,18 +113,7 @@ pub fn run(
     let calls = match http_client.execute_with_redirect(&http_request) {
         Ok(calls) => calls,
         Err(http_error) => {
-            let runner_error = match http_error {
-                HttpError::TooManyRedirect => RunnerError::TooManyRedirect,
-                HttpError::CouldNotParseResponse => RunnerError::CouldNotParseResponse,
-                HttpError::StatuslineIsMissing => RunnerError::HttpConnection {
-                    message: "status line is missing".to_string(),
-                    url: http_request.url.clone(),
-                },
-                HttpError::Libcurl { code, description } => RunnerError::HttpConnection {
-                    message: format!("({}) {}", code, description),
-                    url: http_request.url.clone(),
-                },
-            };
+            let runner_error = RunnerError::from(http_error);
             return vec![EntryResult {
                 request: None,
                 response: None,

--- a/packages/hurl/src/runner/error.rs
+++ b/packages/hurl/src/runner/error.rs
@@ -1,8 +1,8 @@
+use crate::http::HttpError;
 use crate::runner;
 use crate::runner::RunnerError;
 use hurl_core::ast::SourceInfo;
 use hurl_core::error::Error;
-use crate::http::HttpError;
 
 /// Textual Output for runner errors
 impl Error for runner::Error {
@@ -145,7 +145,6 @@ impl Error for runner::Error {
         }
     }
 }
-
 
 impl From<HttpError> for RunnerError {
     /// Converts a HttpError to a RunnerError.

--- a/packages/hurl/src/runner/http_response.rs
+++ b/packages/hurl/src/runner/http_response.rs
@@ -16,12 +16,9 @@
  *
  */
 
-use encoding::{DecoderTrap, EncodingRef};
-
 use crate::http::Response;
 
 use super::cookie::ResponseCookie;
-use super::core::RunnerError;
 
 impl Response {
     pub fn cookies(&self) -> Vec<ResponseCookie> {
@@ -30,48 +27,6 @@ impl Response {
             .filter(|&h| h.name.to_lowercase().as_str() == "set-cookie")
             .filter_map(|h| ResponseCookie::parse(h.value.clone()))
             .collect()
-    }
-
-    ///
-    /// Return encoding of the response
-    ///
-    fn encoding(&self) -> Result<EncodingRef, RunnerError> {
-        match self.content_type() {
-            Some(content_type) => match mime_charset(content_type) {
-                Some(charset) => {
-                    match encoding::label::encoding_from_whatwg_label(charset.as_str()) {
-                        None => Err(RunnerError::InvalidCharset { charset }),
-                        Some(enc) => Ok(enc),
-                    }
-                }
-                None => Ok(encoding::all::UTF_8),
-            },
-            None => Ok(encoding::all::UTF_8),
-        }
-    }
-
-    ///
-    /// return response body as text
-    ///
-    pub fn text(&self) -> Result<String, RunnerError> {
-        let encoding = self.encoding()?;
-        let body = &self.uncompress_body()?;
-        match encoding.decode(body, DecoderTrap::Strict) {
-            Ok(s) => Ok(s),
-            Err(_) => Err(RunnerError::InvalidDecoding {
-                charset: encoding.name().to_string(),
-            }),
-        }
-    }
-
-    ///
-    /// return true if response is an html response
-    ///
-    pub fn is_html(&self) -> bool {
-        match self.content_type() {
-            None => false,
-            Some(s) => s.starts_with("text/html"),
-        }
     }
 
     ///
@@ -84,159 +39,5 @@ impl Response {
             }
         }
         None
-    }
-}
-
-///
-/// Extract charset from mime-type String
-///
-fn mime_charset(mime_type: String) -> Option<String> {
-    mime_type
-        .find("charset=")
-        .map(|index| mime_type[(index + 8)..].to_string())
-}
-
-#[cfg(test)]
-pub mod tests {
-    use super::*;
-    use crate::http::*;
-
-    #[test]
-    pub fn test_charset() {
-        assert_eq!(
-            mime_charset("text/plain; charset=utf-8".to_string()),
-            Some("utf-8".to_string())
-        );
-        assert_eq!(
-            mime_charset("text/plain; charset=ISO-8859-1".to_string()),
-            Some("ISO-8859-1".to_string())
-        );
-        assert_eq!(mime_charset("text/plain;".to_string()), None);
-    }
-
-    fn hello_response() -> Response {
-        Response {
-            version: Version::Http10,
-            status: 200,
-            headers: vec![],
-            body: b"Hello World!".to_vec(),
-            duration: Default::default(),
-        }
-    }
-
-    fn utf8_encoding_response() -> Response {
-        Response {
-            version: Version::Http10,
-            status: 200,
-            headers: vec![Header {
-                name: "Content-Type".to_string(),
-                value: "text/plain; charset=utf-8".to_string(),
-            }],
-            body: vec![0x63, 0x61, 0x66, 0xc3, 0xa9],
-            duration: Default::default(),
-        }
-    }
-
-    fn latin1_encoding_response() -> Response {
-        Response {
-            version: Version::Http10,
-            status: 200,
-            headers: vec![Header {
-                name: "Content-Type".to_string(),
-                value: "text/plain; charset=ISO-8859-1".to_string(),
-            }],
-            body: vec![0x63, 0x61, 0x66, 0xe9],
-            duration: Default::default(),
-        }
-    }
-
-    #[test]
-    pub fn test_content_type() {
-        assert_eq!(hello_response().content_type(), None);
-        assert_eq!(
-            utf8_encoding_response().content_type(),
-            Some("text/plain; charset=utf-8".to_string())
-        );
-        assert_eq!(
-            latin1_encoding_response().content_type(),
-            Some("text/plain; charset=ISO-8859-1".to_string())
-        );
-    }
-
-    #[test]
-    pub fn test_encoding() {
-        assert_eq!(hello_response().encoding().unwrap().name(), "utf-8");
-        assert_eq!(utf8_encoding_response().encoding().unwrap().name(), "utf-8");
-        assert_eq!(
-            latin1_encoding_response().encoding().unwrap().name(),
-            "windows-1252"
-        );
-    }
-
-    #[test]
-    pub fn test_text() {
-        assert_eq!(hello_response().text().unwrap(), "Hello World!".to_string());
-        assert_eq!(utf8_encoding_response().text().unwrap(), "café".to_string());
-        assert_eq!(
-            latin1_encoding_response().text().unwrap(),
-            "café".to_string()
-        );
-    }
-
-    #[test]
-    pub fn test_invalid_charset() {
-        assert_eq!(
-            Response {
-                version: Version::Http10,
-                status: 200,
-                headers: vec![Header {
-                    name: "Content-Type".to_string(),
-                    value: "test/plain; charset=xxx".to_string()
-                }],
-                body: b"Hello World!".to_vec(),
-                duration: Default::default()
-            }
-            .encoding()
-            .err()
-            .unwrap(),
-            RunnerError::InvalidCharset {
-                charset: "xxx".to_string()
-            }
-        );
-    }
-
-    #[test]
-    pub fn test_invalid_decoding() {
-        assert_eq!(
-            Response {
-                version: Version::Http10,
-                status: 200,
-                headers: vec![],
-                body: vec![0x63, 0x61, 0x66, 0xe9],
-                duration: Default::default()
-            }
-            .text()
-            .err()
-            .unwrap(),
-            RunnerError::InvalidDecoding {
-                charset: "utf-8".to_string()
-            }
-        );
-
-        assert_eq!(
-            Response {
-                version: Version::Http10,
-                status: 200,
-                headers: vec![Header {
-                    name: "Content-Type".to_string(),
-                    value: "text/plain; charset=ISO-8859-1".to_string()
-                }],
-                body: vec![0x63, 0x61, 0x66, 0xc3, 0xa9],
-                duration: Default::default()
-            }
-            .text()
-            .unwrap(),
-            "cafÃ©".to_string()
-        );
     }
 }

--- a/packages/hurl/src/runner/query.rs
+++ b/packages/hurl/src/runner/query.rs
@@ -98,7 +98,7 @@ pub fn eval_query_value(
                 Ok(s) => Ok(Some(Value::String(s))),
                 Err(inner) => Err(Error {
                     source_info: query.source_info,
-                    inner,
+                    inner: RunnerError::from(inner),
                     assert: false,
                 }),
             }
@@ -109,7 +109,7 @@ pub fn eval_query_value(
             match http_response.text() {
                 Err(inner) => Err(Error {
                     source_info: query.source_info,
-                    inner,
+                    inner: RunnerError::from(inner),
                     assert: false,
                 }),
                 Ok(xml) => {
@@ -159,7 +159,7 @@ pub fn eval_query_value(
                 Err(inner) => {
                     return Err(Error {
                         source_info: query.source_info,
-                        inner,
+                        inner: RunnerError::from(inner),
                         assert: false,
                     });
                 }
@@ -192,7 +192,7 @@ pub fn eval_query_value(
                 Err(inner) => {
                     return Err(Error {
                         source_info: query.source_info,
-                        inner,
+                        inner: RunnerError::from(inner),
                         assert: false,
                     });
                 }

--- a/packages/hurl/src/runner/query.rs
+++ b/packages/hurl/src/runner/query.rs
@@ -228,7 +228,7 @@ pub fn eval_query_value(
             Ok(s) => Ok(Some(Value::Bytes(s))),
             Err(inner) => Err(Error {
                 source_info: query.source_info,
-                inner,
+                inner: RunnerError::from(inner),
                 assert: false,
             }),
         },
@@ -238,7 +238,7 @@ pub fn eval_query_value(
                 Err(inner) => {
                     return Err(Error {
                         source_info: query.source_info,
-                        inner,
+                        inner: RunnerError::from(inner),
                         assert: false,
                     })
                 }
@@ -255,7 +255,7 @@ pub fn eval_query_value(
                 Err(inner) => {
                     return Err(Error {
                         source_info: query.source_info,
-                        inner,
+                        inner: RunnerError::from(inner),
                         assert: false,
                     })
                 }

--- a/packages/hurl/src/runner/response.rs
+++ b/packages/hurl/src/runner/response.rs
@@ -222,7 +222,7 @@ fn eval_implicit_body_asserts(
                         start: spec_body.space0.source_info.end.clone(),
                         end: spec_body.space0.source_info.end.clone(),
                     },
-                    inner: e,
+                    inner: RunnerError::from(e),
                     assert: true,
                 }),
             };
@@ -249,7 +249,7 @@ fn eval_implicit_body_asserts(
                         start: spec_body.space0.source_info.end.clone(),
                         end: spec_body.space0.source_info.end.clone(),
                     },
-                    inner: e,
+                    inner: RunnerError::from(e),
                     assert: true,
                 }),
             };
@@ -274,7 +274,7 @@ fn eval_implicit_body_asserts(
                         start: spec_body.space0.source_info.end.clone(),
                         end: spec_body.space0.source_info.end.clone(),
                     },
-                    inner: e,
+                    inner: RunnerError::from(e),
                     assert: true,
                 }),
             };

--- a/packages/hurl/src/runner/response.rs
+++ b/packages/hurl/src/runner/response.rs
@@ -157,7 +157,7 @@ fn eval_implicit_body_asserts(
                         start: spec_body.space0.source_info.end.clone(),
                         end: spec_body.space0.source_info.end.clone(),
                     },
-                    inner: e,
+                    inner: RunnerError::from(e),
                     assert: true,
                 }),
             };
@@ -176,7 +176,7 @@ fn eval_implicit_body_asserts(
                         start: spec_body.space0.source_info.end.clone(),
                         end: spec_body.space0.source_info.end.clone(),
                     },
-                    inner: e,
+                    inner: RunnerError::from(e),
                     assert: true,
                 }),
             };
@@ -198,7 +198,7 @@ fn eval_implicit_body_asserts(
                         start: spec_body.space0.source_info.end.clone(),
                         end: spec_body.space0.source_info.end.clone(),
                     },
-                    inner: e,
+                    inner: RunnerError::from(e),
                     assert: true,
                 }),
             };

--- a/packages/hurl/tests/libcurl.rs
+++ b/packages/hurl/tests/libcurl.rs
@@ -626,9 +626,10 @@ fn test_error_could_not_resolve_host() {
     let request = default_get_request("http://unknown".to_string());
     let error = client.execute(&request).err().unwrap();
     assert!(matches!(error, HttpError::Libcurl { .. }));
-    if let HttpError::Libcurl { code, description } = error {
+    if let HttpError::Libcurl { code, description, url } = error {
         assert_eq!(code, 6);
         assert_eq!(description, "Could not resolve host: unknown");
+        assert_eq!(url, "http://unknown");
     }
 }
 
@@ -638,9 +639,10 @@ fn test_error_fail_to_connect() {
     let request_spec = default_get_request("http://localhost:9999".to_string());
     let error = client.execute(&request_spec).err().unwrap();
     assert!(matches!(error, HttpError::Libcurl { .. }));
-    if let HttpError::Libcurl { code, description } = error {
+    if let HttpError::Libcurl { code, description, url } = error {
         assert_eq!(code, 7);
         assert!(description.starts_with("Failed to connect to localhost port 9999"));
+        assert_eq!(url, "http://localhost:9999");
     }
 
     let options = ClientOptions {
@@ -651,10 +653,11 @@ fn test_error_fail_to_connect() {
     let request = default_get_request("http://localhost:8000/hello".to_string());
     let error = client.execute(&request).err().unwrap();
     assert!(matches!(error, HttpError::Libcurl { .. }));
-    if let HttpError::Libcurl { code, description } = error {
+    if let HttpError::Libcurl { code, description, url } = error {
         assert_eq!(code, 7);
         eprintln!("description={}", description);
         assert!(description.starts_with("Failed to connect to localhost port 9999"));
+        assert_eq!(url, "http://localhost:8000/hello");
     }
 }
 
@@ -668,9 +671,10 @@ fn test_error_could_not_resolve_proxy_name() {
     let request_spec = default_get_request("http://localhost:8000/hello".to_string());
     let error = client.execute(&request_spec).err().unwrap();
     assert!(matches!(error, HttpError::Libcurl { .. }));
-    if let HttpError::Libcurl { code, description } = error {
+    if let HttpError::Libcurl { code, description, url } = error {
         assert_eq!(code, 5);
         assert_eq!(description, "Could not resolve proxy: unknown");
+        assert_eq!(url, "http://localhost:8000/hello");
     }
 }
 
@@ -680,7 +684,7 @@ fn test_error_ssl() {
     let mut client = Client::init(options);
     let request_spec = default_get_request("https://localhost:8001/hello".to_string());
     let error = client.execute(&request_spec).err().unwrap();
-    if let HttpError::Libcurl { code, description } = error {
+    if let HttpError::Libcurl { code, description, url } = error {
         assert_eq!(code, 60);
         let descriptions = [
             // Windows messages:
@@ -691,6 +695,7 @@ fn test_error_ssl() {
             "SSL certificate problem: self-signed certificate".to_string(),
         ];
         assert!(descriptions.contains(&description));
+        assert_eq!(url, "https://localhost:8001/hello");
     }
 }
 
@@ -704,9 +709,10 @@ fn test_timeout() {
     let request_spec = default_get_request("http://localhost:8000/timeout".to_string());
     let error = client.execute(&request_spec).err().unwrap();
     assert!(matches!(error, HttpError::Libcurl { .. }));
-    if let HttpError::Libcurl { code, description } = error {
+    if let HttpError::Libcurl { code, description, url } = error {
         assert_eq!(code, 28);
         assert!(description.starts_with("Operation timed out after "));
+        assert_eq!(url, "http://localhost:8000/timeout");
     }
 }
 
@@ -755,7 +761,7 @@ fn test_connect_timeout() {
     );
     let error = client.execute(&request_spec).err().unwrap();
     assert!(matches!(error, HttpError::Libcurl { .. }));
-    if let HttpError::Libcurl { code, description } = error {
+    if let HttpError::Libcurl { code, description, url } = error {
         eprintln!("description={}", description);
         // TODO: remove the 7 / "Couldn't connect to server" case
         // On Linux/Windows libcurl version, the correct error message
@@ -769,6 +775,7 @@ fn test_connect_timeout() {
                 || description.starts_with("Connection timed out")
                 || description.starts_with("Connection timeout")
         );
+        assert_eq!(url, "http://10.0.0.0");
     }
 }
 // endregion

--- a/packages/hurl/tests/libcurl.rs
+++ b/packages/hurl/tests/libcurl.rs
@@ -626,7 +626,12 @@ fn test_error_could_not_resolve_host() {
     let request = default_get_request("http://unknown".to_string());
     let error = client.execute(&request).err().unwrap();
     assert!(matches!(error, HttpError::Libcurl { .. }));
-    if let HttpError::Libcurl { code, description, url } = error {
+    if let HttpError::Libcurl {
+        code,
+        description,
+        url,
+    } = error
+    {
         assert_eq!(code, 6);
         assert_eq!(description, "Could not resolve host: unknown");
         assert_eq!(url, "http://unknown");
@@ -639,7 +644,12 @@ fn test_error_fail_to_connect() {
     let request_spec = default_get_request("http://localhost:9999".to_string());
     let error = client.execute(&request_spec).err().unwrap();
     assert!(matches!(error, HttpError::Libcurl { .. }));
-    if let HttpError::Libcurl { code, description, url } = error {
+    if let HttpError::Libcurl {
+        code,
+        description,
+        url,
+    } = error
+    {
         assert_eq!(code, 7);
         assert!(description.starts_with("Failed to connect to localhost port 9999"));
         assert_eq!(url, "http://localhost:9999");
@@ -653,7 +663,12 @@ fn test_error_fail_to_connect() {
     let request = default_get_request("http://localhost:8000/hello".to_string());
     let error = client.execute(&request).err().unwrap();
     assert!(matches!(error, HttpError::Libcurl { .. }));
-    if let HttpError::Libcurl { code, description, url } = error {
+    if let HttpError::Libcurl {
+        code,
+        description,
+        url,
+    } = error
+    {
         assert_eq!(code, 7);
         eprintln!("description={}", description);
         assert!(description.starts_with("Failed to connect to localhost port 9999"));
@@ -671,7 +686,12 @@ fn test_error_could_not_resolve_proxy_name() {
     let request_spec = default_get_request("http://localhost:8000/hello".to_string());
     let error = client.execute(&request_spec).err().unwrap();
     assert!(matches!(error, HttpError::Libcurl { .. }));
-    if let HttpError::Libcurl { code, description, url } = error {
+    if let HttpError::Libcurl {
+        code,
+        description,
+        url,
+    } = error
+    {
         assert_eq!(code, 5);
         assert_eq!(description, "Could not resolve proxy: unknown");
         assert_eq!(url, "http://localhost:8000/hello");
@@ -684,7 +704,12 @@ fn test_error_ssl() {
     let mut client = Client::init(options);
     let request_spec = default_get_request("https://localhost:8001/hello".to_string());
     let error = client.execute(&request_spec).err().unwrap();
-    if let HttpError::Libcurl { code, description, url } = error {
+    if let HttpError::Libcurl {
+        code,
+        description,
+        url,
+    } = error
+    {
         assert_eq!(code, 60);
         let descriptions = [
             // Windows messages:
@@ -709,7 +734,12 @@ fn test_timeout() {
     let request_spec = default_get_request("http://localhost:8000/timeout".to_string());
     let error = client.execute(&request_spec).err().unwrap();
     assert!(matches!(error, HttpError::Libcurl { .. }));
-    if let HttpError::Libcurl { code, description, url } = error {
+    if let HttpError::Libcurl {
+        code,
+        description,
+        url,
+    } = error
+    {
         assert_eq!(code, 28);
         assert!(description.starts_with("Operation timed out after "));
         assert_eq!(url, "http://localhost:8000/timeout");
@@ -761,7 +791,12 @@ fn test_connect_timeout() {
     );
     let error = client.execute(&request_spec).err().unwrap();
     assert!(matches!(error, HttpError::Libcurl { .. }));
-    if let HttpError::Libcurl { code, description, url } = error {
+    if let HttpError::Libcurl {
+        code,
+        description,
+        url,
+    } = error
+    {
         eprintln!("description={}", description);
         // TODO: remove the 7 / "Couldn't connect to server" case
         // On Linux/Windows libcurl version, the correct error message


### PR DESCRIPTION
This PR has two commits:
- first commit : use HttpError instead of RunnerError in http package
- second commit : move encoding, is_html, text functions from runner/http_response to http/content_decoding. 

In a following PR, we may split functions in http/content_decoding