### PR TITLE
Fix crates_update.sh to be supported on macOS.

### DIFF
--- a/bin/crates_update.sh
+++ b/bin/crates_update.sh
@@ -60,8 +60,8 @@ update_crate_version_in_toml() {
     toml_file="$4"
 
     # update crate version in toml
-    sed -i "s/${crate} = { version = \"${actual_version}\"/${crate} = { version = \"${last_version}\"/g" "${toml_file}"
-    sed -i "s/${crate} = \"${actual_version}\"/${crate} = \"${last_version}\"/g" "${toml_file}"
+    sed -i "" "s/${crate} = { version = \"${actual_version}\"/${crate} = { version = \"${last_version}\"/g" "${toml_file}"
+    sed -i "" "s/${crate} = \"${actual_version}\"/${crate} = \"${last_version}\"/g" "${toml_file}"
     if grep --extended-regexp --silent "${crate}.*=.*${last_version}" "${toml_file}"; then
         echo "${color_blue}updated to ${last_version}${color_reset}"
     else


### PR DESCRIPTION
sed -i "" "foo" instead of sed -i "foo"