### PR TITLE
Use minimal chrono features (to remove potential CVE in time crate)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,7 +133,6 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
- "time",
  "winapi",
 ]
 
@@ -357,7 +356,7 @@ checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -882,17 +881,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
-name = "time"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -975,12 +963,6 @@ checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/packages/hurl/Cargo.toml
+++ b/packages/hurl/Cargo.toml
@@ -20,7 +20,7 @@ strict = []
 atty = "0.2.14"
 base64 = "0.13.0"
 brotli = "3.3.4"
-chrono = "0.4.19"
+chrono = { version = "0.4.19", default-features = false, features = ["clock"] }
 clap = { version = "3.2.5", features = ["cargo"] }
 colored = "2.0.0"
 curl = "0.4.43"


### PR DESCRIPTION
As suggested in https://github.com/rusqlite/rusqlite/pull/1031/files.