### PR TITLE
Add very verbose option

### DIFF
--- a/packages/hurl/src/cli/options.rs
+++ b/packages/hurl/src/cli/options.rs
@@ -299,7 +299,7 @@ pub fn app(version: &str) -> Command {
         )
 }
 
-pub fn parse_options(matches: ArgMatches) -> Result<CliOptions, CliError> {
+pub fn parse_options(matches: &ArgMatches) -> Result<CliOptions, CliError> {
     let cacert_file = match get_string(&matches, "cacert_file") {
         None => None,
         Some(filename) => {

--- a/packages/hurl/src/http/client.rs
+++ b/packages/hurl/src/http/client.rs
@@ -28,7 +28,7 @@ use super::options::ClientOptions;
 use super::request::*;
 use super::request_spec::*;
 use super::response::*;
-use crate::http::HttpError;
+use crate::http::{HttpError, Verbosity};
 use std::str::FromStr;
 use url::Url;
 
@@ -70,8 +70,11 @@ impl Client {
         }
     }
 
+    /// Execute an HTTP request and returns a list
     ///
-    /// Execute an http request
+    /// # Arguments
+    ///
+    /// * request - A request specification
     ///
     pub fn execute_with_redirect(
         &mut self,
@@ -153,7 +156,7 @@ impl Client {
 
         self.set_headers(request);
 
-        let verbose = self.options.verbose;
+        let verbose = self.options.verbosity != None;
         let mut request_headers: Vec<Header> = vec![];
 
         let start = Instant::now();
@@ -493,7 +496,7 @@ impl Client {
     /// Add cookie to Cookiejar
     ///
     pub fn add_cookie(&mut self, cookie: Cookie) {
-        if self.options.verbose {
+        if self.options.verbosity != None {
             eprintln!("* add to cookie store: {}", cookie);
         }
         self.handle
@@ -505,7 +508,7 @@ impl Client {
     /// Clear cookie storage
     ///
     pub fn clear_cookie_storage(&mut self) {
-        if self.options.verbose {
+        if self.options.verbosity != None {
             eprintln!("* clear cookie storage");
         }
         self.handle.cookie_list("ALL").unwrap();

--- a/packages/hurl/src/http/client.rs
+++ b/packages/hurl/src/http/client.rs
@@ -254,6 +254,11 @@ impl Client {
             body,
             duration,
         };
+
+        if self.options.verbosity == Some(Verbosity::VeryVerbose) {
+            response.log_body();
+        }
+
         Ok((request, response))
     }
 
@@ -632,6 +637,47 @@ pub fn decode_header(data: &[u8]) -> Option<String> {
                 None
             }
         },
+    }
+}
+
+impl Response {
+    ///
+    /// Log a response body as text if possible, or a slice of body bytes.
+    ///
+    /// # Arguments
+    ///
+    /// * `response` - The HTTP response
+    fn log_body(&self) {
+        eprintln!("* Response:");
+
+        // We try to decode the HTTP body as text if the response has a text kind content type.
+        // If it ok, we print each line of the body in debug format. Otherwise, we
+        // print the body first 64 bytes.
+        if let Some(content_type) = self.content_type() {
+            if !content_type.contains("text") {
+                self.log_bytes(64);
+                return;
+            }
+        }
+        match self.text() {
+            Ok(text) => text.split('\n').for_each(|l| eprintln!("* {}", l)),
+            Err(_) => self.log_bytes(64),
+        }
+    }
+
+    ///
+    /// Log a response bytes with a maximum size.
+    ///
+    /// # Arguments
+    ///
+    /// * `max` - The maximum number if bytes to log
+    fn log_bytes(&self, max: usize) {
+        let bytes = if self.body.len() > max {
+            &self.body[..max]
+        } else {
+            &self.body
+        };
+        eprintln!("* Bytes <{}...>", hex::encode(bytes))
     }
 }
 

--- a/packages/hurl/src/http/mod.rs
+++ b/packages/hurl/src/http/mod.rs
@@ -20,7 +20,7 @@ pub use self::client::Client;
 pub use self::cookie::{CookieAttribute, ResponseCookie};
 pub use self::core::{Cookie, Header, Param, RequestCookie};
 pub use self::error::HttpError;
-pub use self::options::ClientOptions;
+pub use self::options::{ClientOptions, Verbosity};
 pub use self::request::Request;
 #[cfg(test)]
 pub use self::request_spec::tests::*;

--- a/packages/hurl/src/http/options.rs
+++ b/packages/hurl/src/http/options.rs
@@ -26,7 +26,7 @@ pub struct ClientOptions {
     pub cookie_input_file: Option<String>,
     pub proxy: Option<String>,
     pub no_proxy: Option<String>,
-    pub verbose: bool,
+    pub verbosity: Option<Verbosity>,
     pub insecure: bool,
     pub timeout: Duration,
     pub connect_timeout: Duration,
@@ -34,6 +34,12 @@ pub struct ClientOptions {
     pub user_agent: Option<String>,
     pub compressed: bool,
     pub context_dir: PathBuf,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Verbosity {
+    Verbose,
+    VeryVerbose,
 }
 
 impl Default for ClientOptions {
@@ -45,7 +51,7 @@ impl Default for ClientOptions {
             cookie_input_file: None,
             proxy: None,
             no_proxy: None,
-            verbose: false,
+            verbosity: None,
             insecure: false,
             timeout: Duration::from_secs(300),
             connect_timeout: Duration::from_secs(300),
@@ -130,7 +136,7 @@ mod tests {
                 cookie_input_file: Some("cookie_file".to_string()),
                 proxy: Some("localhost:3128".to_string()),
                 no_proxy: None,
-                verbose: true,
+                verbosity: None,
                 insecure: true,
                 timeout: Duration::from_secs(10),
                 connect_timeout: Duration::from_secs(20),

--- a/packages/hurl/src/main.rs
+++ b/packages/hurl/src/main.rs
@@ -339,11 +339,13 @@ fn main() {
             && hurl_result.errors().is_empty()
             && !cli_options.interactive
         {
-            // default
-            // last entry + response + body
+            // By default, we output the body response bytes of the last entry
             if let Some(entry_result) = hurl_result.entries.last() {
                 if let Some(response) = entry_result.response.clone() {
                     let mut output = vec![];
+
+                    // If include options is set, we output the HTTP response headers
+                    // with status and version (to mimic curl outputs)
                     if cli_options.include {
                         let status_line =
                             format!("HTTP/{} {}\n", response.version, response.status);

--- a/packages/hurl/src/main.rs
+++ b/packages/hurl/src/main.rs
@@ -86,7 +86,7 @@ fn execute(
     filename: &str,
     contents: String,
     current_dir: &Path,
-    cli_options: CliOptions,
+    cli_options: &CliOptions,
     log_verbose: &impl Fn(&str),
     log_error_message: &impl Fn(bool, &str),
     progress: Option<Progress>,
@@ -123,7 +123,7 @@ fn execute(
             if let Some(n) = cli_options.max_redirect {
                 log_verbose(format!("    max redirect: {}", n).as_str());
             }
-            if let Some(proxy) = cli_options.proxy.clone() {
+            if let Some(proxy) = &cli_options.proxy {
                 log_verbose(format!("    proxy: {}", proxy).as_str());
             }
 
@@ -145,19 +145,19 @@ fn execute(
                 }
             }
 
-            let cacert_file = cli_options.cacert_file;
+            let cacert_file = cli_options.cacert_file.clone();
             let follow_location = cli_options.follow_location;
             let verbose = cli_options.verbose;
             let insecure = cli_options.insecure;
             let max_redirect = cli_options.max_redirect;
-            let proxy = cli_options.proxy;
-            let no_proxy = cli_options.no_proxy;
-            let cookie_input_file = cli_options.cookie_input_file;
+            let proxy = cli_options.proxy.clone();
+            let no_proxy = cli_options.no_proxy.clone();
+            let cookie_input_file = cli_options.cookie_input_file.clone();
 
             let timeout = cli_options.timeout;
             let connect_timeout = cli_options.connect_timeout;
-            let user = cli_options.user;
-            let user_agent = cli_options.user_agent;
+            let user = cli_options.user.clone();
+            let user_agent = cli_options.user_agent.clone();
             let compressed = cli_options.compressed;
             let context_dir = match cli_options.file_root {
                 None => {
@@ -199,19 +199,24 @@ fn execute(
             } else {
                 || false
             };
+            let fail_fast = cli_options.fail_fast;
+            let variables = cli_options.variables.clone();
+            let to_entry = cli_options.to_entry;
+            let context_dir = context_dir.to_path_buf();
+            let ignore_asserts = cli_options.ignore_asserts;
             let options = RunnerOptions {
-                fail_fast: cli_options.fail_fast,
-                variables: cli_options.variables,
-                to_entry: cli_options.to_entry,
-                context_dir: context_dir.to_path_buf(),
-                ignore_asserts: cli_options.ignore_asserts,
+                fail_fast,
+                variables,
+                to_entry,
+                context_dir,
+                ignore_asserts,
                 pre_entry,
                 post_entry,
             };
             let result = runner::run_hurl_file(
                 hurl_file,
                 &mut client,
-                filename.to_string(),
+                filename,
                 &options,
                 &log_verbose,
                 &log_error_message,
@@ -261,7 +266,7 @@ fn main() {
     let log_verbose = cli::make_logger_verbose(verbose);
     let color = cli::output_color(matches.clone());
     let log_error_message = cli::make_logger_error_message(color);
-    let cli_options = unwrap_or_exit(cli::parse_options(matches.clone()), &log_error_message);
+    let cli_options = unwrap_or_exit(cli::parse_options(&matches), &log_error_message);
 
     let mut filenames = vec![];
     if let Some(values) = cli::get_strings(&matches, "INPUT") {
@@ -323,7 +328,7 @@ fn main() {
             filename,
             contents.clone(),
             current_dir,
-            cli_options.clone(),
+            &cli_options,
             &log_verbose,
             &log_error_message,
             progress,

--- a/packages/hurl/src/runner/core.rs
+++ b/packages/hurl/src/runner/core.rs
@@ -30,6 +30,7 @@ pub struct RunnerOptions {
     pub to_entry: Option<usize>,
     pub context_dir: PathBuf,
     pub ignore_asserts: bool,
+    pub very_verbose: bool, // If true, log body response in verbose mode.
     pub pre_entry: fn(Entry) -> bool,
     pub post_entry: fn() -> bool,
 }

--- a/packages/hurl/src/runner/entry.rs
+++ b/packages/hurl/src/runner/entry.rs
@@ -139,7 +139,7 @@ pub fn run(
         let mut errors = vec![];
         let time_in_ms = http_response.duration.as_millis();
 
-        // Last call
+        // We runs capture and asserts on the last HTTP request/response chains.
         if i == calls.len() - 1 {
             captures = match entry.response.clone() {
                 None => vec![],

--- a/packages/hurl/src/runner/entry.rs
+++ b/packages/hurl/src/runner/entry.rs
@@ -87,7 +87,7 @@ pub fn run(
         } else {
             log_error_message(
                 true,
-                format!("cookie string can not be parsed: '{}'", s).as_str(),
+                format!("Cookie string can not be parsed: '{}'", s).as_str(),
             );
         }
     }
@@ -101,7 +101,7 @@ pub fn run(
         log_verbose(cookie.to_string().as_str());
     }
     log_verbose("");
-    log_request(log_verbose, &http_request);
+    log_request_spec(log_verbose, &http_request);
     log_verbose(
         format!(
             "Request can be run with the following curl command:\n* {}\n*",
@@ -157,7 +157,7 @@ pub fn run(
                     }
                 },
             };
-            // update variables now!
+            // Update variables now!
             for capture_result in captures.clone() {
                 variables.insert(capture_result.name, capture_result.value);
             }
@@ -189,7 +189,7 @@ pub fn run(
                 .collect();
 
             if !captures.is_empty() {
-                log_verbose("Captures");
+                log_verbose("Captures:");
                 for capture in captures.clone() {
                     log_verbose(format!("{}: {}", capture.name, capture.value).as_str());
                 }
@@ -211,37 +211,44 @@ pub fn run(
     entry_results
 }
 
-pub fn log_request(log_verbose: impl Fn(&str), request: &http::RequestSpec) {
+/// Log a HTTP request spec
+///
+/// # Arguments
+///
+/// * log_verbose - a log function
+/// * request - an HTTP request spec
+///
+fn log_request_spec(log_verbose: impl Fn(&str), request: &http::RequestSpec) {
     log_verbose("Request:");
     log_verbose(format!("{} {}", request.method, request.url).as_str());
-    for header in request.headers.clone() {
+    for header in &request.headers {
         log_verbose(header.to_string().as_str());
     }
     if !request.querystring.is_empty() {
         log_verbose("[QueryStringParams]");
-        for param in request.querystring.clone() {
+        for param in &request.querystring {
             log_verbose(param.to_string().as_str());
         }
     }
     if !request.form.is_empty() {
         log_verbose("[FormParams]");
-        for param in request.form.clone() {
+        for param in &request.form {
             log_verbose(param.to_string().as_str());
         }
     }
     if !request.multipart.is_empty() {
         log_verbose("[MultipartFormData]");
-        for param in request.multipart.clone() {
+        for param in &request.multipart {
             log_verbose(param.to_string().as_str());
         }
     }
     if !request.cookies.is_empty() {
         log_verbose("[Cookies]");
-        for cookie in request.cookies.clone() {
+        for cookie in &request.cookies {
             log_verbose(cookie.to_string().as_str());
         }
     }
-    if let Some(s) = request.content_type.clone() {
+    if let Some(s) = &request.content_type {
         log_verbose("");
         log_verbose(format!("Implicit content-type={}", s).as_str());
     }

--- a/packages/hurl/src/runner/hurl_file.rs
+++ b/packages/hurl/src/runner/hurl_file.rs
@@ -35,7 +35,7 @@ use super::entry;
 /// use hurl::runner;
 ///
 /// // Parse Hurl file
-/// let filename = "sample.hurl".to_string();
+/// let filename = "sample.hurl";
 /// let s = r#"
 /// GET http://localhost:8000/hello
 /// HTTP/1.0 200
@@ -59,6 +59,7 @@ use super::entry;
 ///        to_entry: None,
 ///        context_dir: PathBuf::new(),
 ///        ignore_asserts: false,
+///        very_verbose: false,
 ///        pre_entry: |_| true,
 ///        post_entry: || true,
 ///  };

--- a/packages/hurl/src/runner/hurl_file.rs
+++ b/packages/hurl/src/runner/hurl_file.rs
@@ -80,7 +80,7 @@ use super::entry;
 pub fn run(
     hurl_file: HurlFile,
     http_client: &mut http::Client,
-    filename: String,
+    filename: &str,
     options: &RunnerOptions,
     log_verbose: &impl Fn(&str),
     log_error_message: &impl Fn(bool, &str),
@@ -143,6 +143,7 @@ pub fn run(
         .is_none();
 
     let cookies = http_client.get_cookie_storage();
+    let filename = filename.to_string();
     HurlResult {
         filename,
         entries,

--- a/packages/hurl/tests/runner.rs
+++ b/packages/hurl/tests/runner.rs
@@ -56,6 +56,7 @@ fn test_hurl_file() {
         to_entry: None,
         context_dir: PathBuf::new(),
         ignore_asserts: false,
+        very_verbose: false,
         pre_entry: |_| true,
         post_entry: || true,
     };
@@ -68,7 +69,7 @@ fn test_hurl_file() {
         hurl_file,
         &mut client,
         //&mut variables,
-        filename.to_string(),
+        filename,
         &options,
         &log_verbose,
         &log_error_message,
@@ -186,6 +187,7 @@ fn test_hello() {
         to_entry: None,
         context_dir: PathBuf::new(),
         ignore_asserts: false,
+        very_verbose: false,
         pre_entry: |_| true,
         post_entry: || true,
     };
@@ -195,7 +197,7 @@ fn test_hello() {
     let _hurl_log = runner::run_hurl_file(
         hurl_file,
         &mut client,
-        String::from("filename"),
+        "filename",
         &options,
         &log_verbose,
         &log_error_message,


### PR DESCRIPTION
When very-verbose is used, the HTTP body response is logged.

For instance, this Hurl file:

```
GET https://google.fr
GET https://www.google.fr
```

Then:

```
$ hurl --very-verbose --no-output google.hurl
* Options:
*     fail fast: true
*     insecure: false
*     follow redirect: false
*     max redirect: 50
* ------------------------------------------------------------------------------
* Executing entry 1
*
* Cookie store:
*
* Request:
* GET https://google.fr
*
* Request can be run with the following curl command:
* curl 'https://google.fr'
*
> GET / HTTP/2
> Host: google.fr
> accept: */*
> user-agent: hurl/1.7.0-snapshot
>
< HTTP/2 301
< location: https://www.google.fr/
< content-type: text/html; charset=UTF-8
< date: Fri, 17 Jun 2022 16:33:29 GMT
< expires: Fri, 17 Jun 2022 16:33:29 GMT
< cache-control: private, max-age=2592000
< server: gws
< content-length: 219
< x-xss-protection: 0
< x-frame-options: SAMEORIGIN
< set-cookie: CONSENT=PENDING+410; expires=Sun, 16-Jun-2024 16:33:29 GMT; path=/; domain=.google.fr; Secure
< p3p: CP="This is not a P3P policy! See g.co/p3phelp for more info."
< alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000,h3-Q050=":443"; ma=2592000,h3-Q046=":443"; ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"
<
* Response:
* <HTML><HEAD><meta http-equiv="content-type" content="text/html;charset=utf-8">
* <TITLE>301 Moved</TITLE></HEAD><BODY>
* <H1>301 Moved</H1>
* The document has moved
* <A HREF="https://www.google.fr/">here</A>.
* </BODY></HTML>
*
*
* ------------------------------------------------------------------------------
* Executing entry 2
*
* Cookie store:
* .google.fr	TRUE	/	TRUE	1718555609	CONSENT	PENDING+410
*
* Request:
* GET https://www.google.fr
*
* Request can be run with the following curl command:
* curl 'https://www.google.fr' --cookie 'CONSENT=PENDING+410'
*
> GET / HTTP/2
> Host: www.google.fr
> accept: */*
> cookie: CONSENT=PENDING+410
> user-agent: hurl/1.7.0-snapshot
>
< HTTP/2 302
< location: https://consent.google.fr/ml?continue=https://www.google.fr/&gl=FR&m=0&pc=shp&uxe=eomts&hl=fr&src=1
< cache-control: private
< content-type: text/html; charset=UTF-8
< p3p: CP="This is not a P3P policy! See g.co/p3phelp for more info."
< date: Fri, 17 Jun 2022 16:33:30 GMT
< server: gws
< content-length: 320
< x-xss-protection: 0
< x-frame-options: SAMEORIGIN
< set-cookie: AEC=AakniGNnBsOhc1n2_fQYHcgP-06I1JW2Xd8O06ld4Kj63T4F5OEgBQ6OM40; expires=Wed, 14-Dec-2022 16:33:30 GMT; path=/; domain=.google.fr; Secure; HttpOnly; SameSite=lax
< set-cookie: __Secure-ENID=5.SE=FkdNVgpVUXvNRdod5VAqb2rTYFo87Kqig-lSJwLl1wxHHwyRDbFaruKm3Ud-bZ14F6s-zB2xL5T2w8BUfLpNnMXu9xpdhEcZcGb55i6-zmHBB-gC1NWiicj7n0uYfFZfLPgl4tCSxpkf4Vx4jBtEBfMQKOyRuNGHxgUHL7PhvJM; expires=Tue, 18-Jul-2023 08:51:48 GMT; path=/; domain=.google.fr; Secure; HttpOnly; SameSite=lax
< alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000,h3-Q050=":443"; ma=2592000,h3-Q046=":443"; ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"
<
* Response:
* <HTML><HEAD><meta http-equiv="content-type" content="text/html;charset=utf-8">
* <TITLE>302 Moved</TITLE></HEAD><BODY>
* <H1>302 Moved</H1>
* The document has moved
* <A HREF="https://consent.google.fr/ml?continue=https://www.google.fr/&amp;gl=FR&amp;m=0&amp;pc=shp&amp;uxe=eomts&amp;hl=fr&amp;src=1">here</A>.
* </BODY></HTML>
*
*
```

With a binary response, we print a slice of the bytes response:

```
$ echo 'GET https://upload.wikimedia.org/wikipedia/commons/0/0b/Cat_poster_1.jpg' | hurl --very-verbose --no-output
* Options:
*     fail fast: true
*     insecure: false
*     follow redirect: true
*     max redirect: 50
* ------------------------------------------------------------------------------
* Executing entry 1
*
* Cookie store:
*
* Request:
* GET https://upload.wikimedia.org/wikipedia/commons/0/0b/Cat_poster_1.jpg
*
* Request can be run with the following curl command:
* curl 'https://upload.wikimedia.org/wikipedia/commons/0/0b/Cat_poster_1.jpg' -L
*
> GET /wikipedia/commons/0/0b/Cat_poster_1.jpg HTTP/2
> Host: upload.wikimedia.org
> accept: */*
> user-agent: hurl/1.7.0-snapshot
>
< HTTP/2 200
< date: Fri, 17 Jun 2022 10:39:09 GMT
< content-type: image/jpeg
< content-length: 11423554
< x-object-meta-sha1base36: 9kwnvtjql4m0nfnxlmc3dg05hf5kw37
< last-modified: Fri, 04 Oct 2013 03:44:09 GMT
< accept-ranges: bytes
< etag: c0baab607a97839c9a328b4310713307
< server: ATS/8.0.8
< age: 22227
< x-cache: cp6006 hit, cp6003 pass
< x-cache-status: hit-local
< server-timing: cache;desc="hit-local", host;desc="cp6003"
< strict-transport-security: max-age=106384710; includeSubDomains; preload
< report-to: { "group": "wm_nel", "max_age": 86400, "endpoints": [{ "url": "https://intake-logging.wikimedia.org/v1/events?stream=w3c.reportingapi.network_error&schema_uri=/w3c/reportingapi/network_error/1.0.0" }] }
< nel: { "report_to": "wm_nel", "max_age": 86400, "failure_fraction": 0.05, "success_fraction": 0.0}
< accept-ch: Sec-CH-UA-Arch,Sec-CH-UA-Bitness,Sec-CH-UA-Full-Version-List,Sec-CH-UA-Model,Sec-CH-UA-Platform-Version
< permissions-policy: interest-cohort=(),ch-ua-arch=(self "intake-analytics.wikimedia.org"),ch-ua-bitness=(self "intake-analytics.wikimedia.org"),ch-ua-full-version-list=(self "intake-analytics.wikimedia.org"),ch-ua-model=(self "intake-analytics.wikimedia.org"),ch-ua-platform-version=(self "intake-analytics.wikimedia.org")
< x-client-ip: 80.12.66.161
< access-control-allow-origin: *
< access-control-expose-headers: Age, Date, Content-Length, Content-Range, X-Content-Duration, X-Cache
< timing-allow-origin: *
<
* Response:
* Bytes <ffd8ffe000104a46494600010101009600960000ffdb004300010101010101010101010101010101010101010101010101010101010101010101010101010101...>
*
```

There is no integration test for this PR as testing stderr in verbose more has a lot of variances.

