### PR TITLE
Validate Grammar and generate HTML

### DIFF
--- a/docs/spec/README
+++ b/docs/spec/README
@@ -1,0 +1,8 @@
+This grammar can be validated and converted to HTML with the cli from
+https://github.com/fabricereix/grammar
+
+Validate and generate HTML
+
+```
+./generate_html.sh
+```

--- a/docs/spec/generate_html.sh
+++ b/docs/spec/generate_html.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+set -o pipefail
+
+# Check version
+# A specific version defines both the grammar format and the HTML output
+actual_version=$(grammar --version | cut  -d" " -f2)
+expected_version="0.1.0"
+if [ "$actual_version" != "$expected_version" ] ; then
+  echo "version mismatch"
+  echo "expected: $expected_version"
+  echo "actual:   $actual_version"
+  exit 1
+fi
+cat <<END >hurl.grammar.html
+<link rel="stylesheet" type="text/css" href="style.css">
+END
+grammar <hurl.grammar >>hurl.grammar.html

--- a/docs/spec/style.css
+++ b/docs/spec/style.css
@@ -1,0 +1,56 @@
+html {
+    font-family: Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;
+}
+
+body {
+    font-size: 1.4rem;
+}
+
+a {
+    color: #20609f
+}
+
+a:visited {
+    color: #20609f
+}
+
+code {
+    white-space:normal;
+}
+.grammar-usedby {
+    color: #999;
+    font-size: 1.1rem;
+}
+
+.grammar-ruleset {
+    margin-bottom: 40px;
+
+}
+
+.grammar-rule {
+   margin-top: 10px;
+   margin-bottom: 20px;
+
+}
+.grammar-rule-id {
+    font-weight: bold;
+}
+
+.grammar-rule-expression {
+    margin-left: 20px;
+}
+.grammar-literal {
+    color: blueviolet;
+}
+
+.grammar-regex {
+    color: darkcyan
+}
+
+.grammar-nonterminal {
+
+}
+
+.grammar-symbol {
+
+}


### PR DESCRIPTION
Add script to validate grammar and generate HTML.

The next step is to customize the CSS so that the HTML can be added in the doc.
