### PR TITLE
Reactivate ArchLinux integration tests.

### DIFF
--- a/ci/build_and_test.sh
+++ b/ci/build_and_test.sh
@@ -11,12 +11,6 @@ curl --version
 
 ci/test_prerequisites.sh
 
-# current bug with curl to be fixed
-# https://github.com/curl/curl/issues/8559
-if test -f /etc/arch-release; then
-   exit 0
-fi
-
 echo "----- unit tests  -----"
 cargo test --features strict --tests
 


### PR DESCRIPTION
Following https://github.com/curl/curl/issues/8559 fix, ArchLinux tests should be ok now.