### PR TITLE
Improve "File not found" error message

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,6 +76,7 @@ jobs:
          ./test_curl_commands.sh $(find ./tests_failed -maxdepth 1 -type f -name '*.curl' ! -name '*windows*')
          ./test_html_output.py tests_failed/*.html
          xmllint --noout tests_failed/*.html
+         ./ad_hoc.sh
          ./report.sh
     - name: Archive production artifacts
       uses: actions/upload-artifact@v3

--- a/integration/ad_hoc.sh
+++ b/integration/ad_hoc.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# add more tests
+# that can be easily added in tests_ok/ and tests_failed/
+
+echo "Check file not found error"
+actual=$(hurl does_not_exist.hurl 2>&1)
+expected="error: hurl: cannot access 'does_not_exist.hurl': No such file or directory"
+if [ "$actual" != "$expected" ]; then
+    echo "Error differs:"
+    echo "actual: $actual"
+    echo "expected: $expected"
+    exit 1
+fi
+
+

--- a/packages/hurl/src/main.rs
+++ b/packages/hurl/src/main.rs
@@ -317,6 +317,14 @@ fn main() {
     let mut testcases = vec![];
 
     for (current, filename) in filenames.iter().enumerate() {
+        if !Path::new(filename).exists() {
+            let message = format!(
+                "hurl: cannot access '{}': No such file or directory",
+                filename
+            );
+            log_error_message(false, &message);
+            std::process::exit(EXIT_ERROR_PARSING);
+        }
         let contents = match cli::read_to_string(filename) {
             Ok(v) => v,
             Err(e) => {


### PR DESCRIPTION
I have added another script `ad_hoc.sh` to add tests that can not be easily added in `tests_ok/` and `tests_failed/`.
It could also include the test for multiple hurl files.
