### PR TITLE
Fix multiple input files support

### DIFF
--- a/packages/hurl/src/cli/options.rs
+++ b/packages/hurl/src/cli/options.rs
@@ -81,7 +81,7 @@ pub fn app(version: &str) -> Command {
             clap::Arg::new("INPUT")
                 .help("Sets the input file to use")
                 .required(false)
-                .action(ArgAction::Append),
+                .multiple_values(true),
         )
         .arg(
             clap::Arg::new("cacert_file")


### PR DESCRIPTION
Use multiple_values method instead of deprecated multiple_occurences method.

Closes #652.