### PR TITLE
Rationalize log functions usages.

### DIFF
--- a/integration/tests_ok/color.err
+++ b/integration/tests_ok/color.err
@@ -1,6 +1,6 @@
-* Options:
-*     fail fast: true
-*     insecure: false
-*     follow redirect: false
-*     max redirect: 50
+[1;34m*[0m Options:
+[1;34m*[0m     fail fast: true
+[1;34m*[0m     insecure: false
+[1;34m*[0m     follow redirect: false
+[1;34m*[0m     max redirect: 50
 [1;33mwarning[0m: no entry have been executed for file tests_ok/color.hurl

--- a/packages/hurl/src/cli/mod.rs
+++ b/packages/hurl/src/cli/mod.rs
@@ -19,20 +19,16 @@
 use std::error::Error;
 
 pub use self::fs::read_to_string;
-pub use self::logger::{
-    error_string, log_info, make_logger_error_message, make_logger_parser_error,
-    make_logger_runner_error, make_logger_verbose,
-};
 pub use self::options::app;
 pub use self::options::output_color;
 pub use self::options::parse_options;
 pub use self::options::{CliOptions, OutputType};
 pub use self::variables::parse as parse_variable;
 pub use self::variables::parse_value as parse_variable_value;
+pub use crate::util::logger::{error_string, Logger};
 
 mod fs;
 pub mod interactive;
-mod logger;
 mod options;
 mod variables;
 pub use self::options::{get_strings, has_flag};

--- a/packages/hurl/src/http/debug.rs
+++ b/packages/hurl/src/http/debug.rs
@@ -15,30 +15,31 @@
  * limitations under the License.
  *
  */
+use crate::cli::Logger;
 use crate::http::Header;
 
 /// Debug log HTTP request headers.
-pub fn log_headers_out(headers: &[Header]) {
+pub fn log_headers_out(headers: &[Header], logger: &Logger) {
     for header in headers {
-        eprintln!("> {}", header);
+        logger.info(format!("> {}", header).as_str());
     }
-    eprintln!(">")
+    logger.info(">")
 }
 
 /// Debug log HTTP response headers.
-pub fn log_headers_in(headers: &[Header]) {
+pub fn log_headers_in(headers: &[Header], logger: &Logger) {
     for header in headers {
-        eprintln!("< {}", header);
+        logger.info(format!("< {}", header).as_str());
     }
-    eprintln!("<")
+    logger.info("<")
 }
 
 /// Debug log text.
-pub fn log_text(text: &str) {
+pub fn log_text(text: &str, logger: &Logger) {
     if text.is_empty() {
-        eprintln!("*");
+        logger.debug("");
     } else {
-        text.split('\n').for_each(|l| eprintln!("* {}", l))
+        text.split('\n').for_each(|l| logger.debug(l))
     }
 }
 
@@ -48,15 +49,16 @@ pub fn log_text(text: &str) {
 ///
 /// * `bytes`- the bytes to log
 /// * `max` - The maximum number if bytes to log
-pub fn log_bytes(bytes: &[u8], max: usize) {
+pub fn log_bytes(bytes: &[u8], max: usize, logger: &Logger) {
     let bytes = if bytes.len() > max {
         &bytes[..max]
     } else {
         bytes
     };
+
     if bytes.is_empty() {
-        eprintln!("*");
+        logger.debug("");
     } else {
-        eprintln!("* Bytes <{}...>", hex::encode(bytes));
+        logger.debug(format!("Bytes <{}...>", hex::encode(bytes)).as_str());
     }
 }

--- a/packages/hurl/src/http/request_debug.rs
+++ b/packages/hurl/src/http/request_debug.rs
@@ -16,30 +16,31 @@
  *
  */
 
+use crate::cli::Logger;
 use crate::http::{debug, mimetype, Request};
 
 impl Request {
     /// Log request headers.
-    pub fn log_headers(&self) {
-        debug::log_headers_out(&self.headers)
+    pub fn log_headers(&self, logger: &Logger) {
+        debug::log_headers_out(&self.headers, logger)
     }
 
     /// Log request body.
-    pub fn log_body(&self) {
-        debug::log_text("Request body:");
+    pub fn log_body(&self, logger: &Logger) {
+        logger.debug("Request body:");
 
         // We try to decode the HTTP body as text if the response has a text kind content type.
         // If it ok, we print each line of the body in debug format. Otherwise, we
         // print the body first 64 bytes.
         if let Some(content_type) = self.content_type() {
             if !mimetype::is_kind_of_text(&content_type) {
-                debug::log_bytes(&self.body, 64);
+                debug::log_bytes(&self.body, 64, logger);
                 return;
             }
         }
         match self.text() {
-            Ok(text) => debug::log_text(&text),
-            Err(_) => debug::log_bytes(&self.body, 64),
+            Ok(text) => debug::log_text(&text, logger),
+            Err(_) => debug::log_bytes(&self.body, 64, logger),
         }
     }
 }

--- a/packages/hurl/src/http/response_debug.rs
+++ b/packages/hurl/src/http/response_debug.rs
@@ -16,34 +16,31 @@
  *
  */
 
+use crate::cli::Logger;
 use crate::http::{debug, mimetype, Response};
 
 impl Response {
     /// Log response headers.
-    pub fn log_headers(&self) {
-        debug::log_headers_in(&self.headers)
+    pub fn log_headers(&self, logger: &Logger) {
+        debug::log_headers_in(&self.headers, logger)
     }
 
     /// Log a response body as text if possible, or a slice of body bytes.
-    ///
-    /// # Arguments
-    ///
-    /// * `response` - The HTTP response
-    pub fn log_body(&self) {
-        debug::log_text("Response body:");
+    pub fn log_body(&self, logger: &Logger) {
+        logger.debug("Response body:");
 
         // We try to decode the HTTP body as text if the request has a text kind content type.
         // If it ok, we print each line of the body in debug format. Otherwise, we
         // print the body first 64 bytes.
         if let Some(content_type) = self.content_type() {
             if !mimetype::is_kind_of_text(&content_type) {
-                debug::log_bytes(&self.body, 64);
+                debug::log_bytes(&self.body, 64, logger);
                 return;
             }
         }
         match self.text() {
-            Ok(text) => debug::log_text(&text),
-            Err(_) => debug::log_bytes(&self.body, 64),
+            Ok(text) => debug::log_text(&text, logger),
+            Err(_) => debug::log_bytes(&self.body, 64, logger),
         }
     }
 }

--- a/packages/hurl/src/json/result.rs
+++ b/packages/hurl/src/json/result.rs
@@ -22,7 +22,7 @@ use crate::http::{
 use crate::runner::{AssertResult, CaptureResult, EntryResult, HurlResult};
 
 impl HurlResult {
-    pub fn to_json(&self, lines: &[String]) -> serde_json::Value {
+    pub fn to_json(&self, lines: &Vec<&str>) -> serde_json::Value {
         let mut map = serde_json::Map::new();
         map.insert(
             "filename".to_string(),
@@ -31,7 +31,7 @@ impl HurlResult {
         let entries = self
             .entries
             .iter()
-            .map(|e| e.clone().to_json(lines, self.filename.clone()))
+            .map(|e| e.clone().to_json(lines, &self.filename))
             .collect();
         map.insert("entries".to_string(), serde_json::Value::Array(entries));
         map.insert(
@@ -49,7 +49,7 @@ impl HurlResult {
 }
 
 impl EntryResult {
-    fn to_json(&self, lines: &[String], filename: String) -> serde_json::Value {
+    fn to_json(&self, lines: &Vec<&str>, filename: &str) -> serde_json::Value {
         let mut map = serde_json::Map::new();
         if let Some(request) = &self.request {
             map.insert("request".to_string(), request.to_json());
@@ -62,7 +62,7 @@ impl EntryResult {
         let asserts = self
             .asserts
             .iter()
-            .map(|a| a.clone().to_json(lines, filename.clone()))
+            .map(|a| a.clone().to_json(lines, filename))
             .collect();
         map.insert("asserts".to_string(), asserts);
         map.insert(
@@ -249,7 +249,7 @@ impl CaptureResult {
 }
 
 impl AssertResult {
-    fn to_json(&self, lines: &[String], filename: String) -> serde_json::Value {
+    fn to_json(&self, lines: &Vec<&str>, filename: &str) -> serde_json::Value {
         let mut map = serde_json::Map::new();
 
         let success = self.clone().error().is_none();

--- a/packages/hurl/src/report/junit/testcase.rs
+++ b/packages/hurl/src/report/junit/testcase.rs
@@ -33,14 +33,14 @@ impl Testcase {
     ///
     /// create an XML Junit <testcase> from an Hurl result
     ///
-    pub fn from_hurl_result(hurl_result: &HurlResult, lines: &[String]) -> Testcase {
+    pub fn from_hurl_result(hurl_result: &HurlResult, lines: &Vec<&str>) -> Testcase {
         let id = hurl_result.filename.clone();
         let time_in_ms = hurl_result.time_in_ms;
         let mut failures = vec![];
         let mut errors = vec![];
 
         for error in hurl_result.errors() {
-            let message = cli::error_string(lines, hurl_result.filename.clone(), &error);
+            let message = cli::error_string(lines, &hurl_result.filename, &error);
             if error.assert {
                 failures.push(message);
             } else {
@@ -127,10 +127,7 @@ mod test {
 
     #[test]
     fn test_create_testcase_failure() {
-        let lines = vec![
-            "GET http://localhost:8000/not_found".to_string(),
-            "HTTP/1.0 200".to_string(),
-        ];
+        let lines = vec!["GET http://localhost:8000/not_found", "HTTP/1.0 200"];
         let hurl_result = HurlResult {
             filename: "test.hurl".to_string(),
             entries: vec![EntryResult {
@@ -169,7 +166,7 @@ mod test {
 
     #[test]
     fn test_create_testcase_error() {
-        let lines = vec!["GET http://unknown".to_string()];
+        let lines = vec!["GET http://unknown"];
         let hurl_result = HurlResult {
             filename: "test.hurl".to_string(),
             entries: vec![EntryResult {

--- a/packages/hurl/src/util/mod.rs
+++ b/packages/hurl/src/util/mod.rs
@@ -17,4 +17,5 @@
  */
 pub use self::path::is_descendant;
 
+pub mod logger;
 mod path;

--- a/packages/hurl/tests/libcurl.rs
+++ b/packages/hurl/tests/libcurl.rs
@@ -16,6 +16,7 @@
  *
  */
 
+use hurl::cli::Logger;
 use std::default::Default;
 use std::time::Duration;
 
@@ -52,13 +53,14 @@ fn default_get_request(url: String) -> RequestSpec {
 #[test]
 fn test_hello() {
     let mut client = default_client();
+    let logger = Logger::default();
     let request_spec = default_get_request("http://localhost:8000/hello".to_string());
     assert_eq!(
         client.curl_command_line(&request_spec),
         "curl 'http://localhost:8000/hello'".to_string()
     );
 
-    let (request, response) = client.execute(&request_spec).unwrap();
+    let (request, response) = client.execute(&request_spec, &logger).unwrap();
     assert_eq!(request.method, "GET".to_string());
     assert_eq!(request.url, "http://localhost:8000/hello".to_string());
     assert_eq!(request.headers.len(), 3);
@@ -94,6 +96,7 @@ fn test_hello() {
 #[test]
 fn test_put() {
     let mut client = default_client();
+    let logger = Logger::default();
     let request_spec = RequestSpec {
         method: Method::Put,
         url: "http://localhost:8000/put".to_string(),
@@ -110,7 +113,7 @@ fn test_put() {
         "curl 'http://localhost:8000/put' -X PUT".to_string()
     );
 
-    let (request, response) = client.execute(&request_spec).unwrap();
+    let (request, response) = client.execute(&request_spec, &logger).unwrap();
     assert_eq!(request.method, "PUT".to_string());
     assert_eq!(request.url, "http://localhost:8000/put".to_string());
     assert!(request.headers.contains(&Header {
@@ -129,6 +132,7 @@ fn test_put() {
 #[test]
 fn test_patch() {
     let mut client = default_client();
+    let logger = Logger::default();
     let request_spec = RequestSpec {
         method: Method::Patch,
         url: "http://localhost:8000/patch/file.txt".to_string(),
@@ -158,7 +162,7 @@ fn test_patch() {
         "curl 'http://localhost:8000/patch/file.txt' -X PATCH -H 'Host: www.example.com' -H 'Content-Type: application/example' -H 'If-Match: \"e0023aa4e\"'".to_string()
     );
 
-    let (request, response) = client.execute(&request_spec).unwrap();
+    let (request, response) = client.execute(&request_spec, &logger).unwrap();
     assert_eq!(request.method, "PATCH".to_string());
     assert_eq!(
         request.url,
@@ -184,6 +188,7 @@ fn test_patch() {
 #[test]
 fn test_custom_headers() {
     let mut client = default_client();
+    let logger = Logger::default();
     let request_spec = RequestSpec {
         method: Method::Get,
         url: "http://localhost:8000/custom-headers".to_string(),
@@ -207,7 +212,7 @@ fn test_custom_headers() {
         "curl 'http://localhost:8000/custom-headers' -H 'Fruit: Raspberry' -H 'Fruit: Apple' -H 'Fruit: Banana' -H 'Fruit: Grape' -H 'Color: Green'".to_string()
     );
 
-    let (request, response) = client.execute(&request_spec).unwrap();
+    let (request, response) = client.execute(&request_spec, &logger).unwrap();
     assert_eq!(request.method, "GET".to_string());
     assert_eq!(
         request.url,
@@ -228,6 +233,7 @@ fn test_custom_headers() {
 #[test]
 fn test_querystring_params() {
     let mut client = default_client();
+    let logger = Logger::default();
     let request_spec = RequestSpec {
         method: Method::Get,
         url: "http://localhost:8000/querystring-params".to_string(),
@@ -260,7 +266,7 @@ fn test_querystring_params() {
         client.curl_command_line(&request_spec),
         "curl 'http://localhost:8000/querystring-params?param1=value1&param2=&param3=a%3Db&param4=1%2C2%2C3'".to_string()
     );
-    let (request, response) = client.execute(&request_spec).unwrap();
+    let (request, response) = client.execute(&request_spec, &logger).unwrap();
     assert_eq!(request.method, "GET".to_string());
     assert_eq!(request.url, "http://localhost:8000/querystring-params?param1=value1&param2=&param3=a%3Db&param4=1%2C2%2C3".to_string());
     assert_eq!(request.headers.len(), 3);
@@ -276,6 +282,7 @@ fn test_querystring_params() {
 #[test]
 fn test_form_params() {
     let mut client = default_client();
+    let logger = Logger::default();
     let request_spec = RequestSpec {
         method: Method::Post,
         url: "http://localhost:8000/form-params".to_string(),
@@ -317,7 +324,7 @@ fn test_form_params() {
         "curl 'http://localhost:8000/form-params' --data 'param1=value1' --data 'param2=' --data 'param3=a%3Db' --data 'param4=a%253db' --data 'values[0]=0' --data 'values[1]=1'".to_string()
     );
 
-    let (request, response) = client.execute(&request_spec).unwrap();
+    let (request, response) = client.execute(&request_spec, &logger).unwrap();
     assert_eq!(request.method, "POST".to_string());
     assert_eq!(request.url, "http://localhost:8000/form-params".to_string());
     assert!(request.headers.contains(&Header {
@@ -330,7 +337,7 @@ fn test_form_params() {
 
     // make sure you can reuse client for other request
     let request = default_get_request("http://localhost:8000/hello".to_string());
-    let (request, response) = client.execute(&request).unwrap();
+    let (request, response) = client.execute(&request, &logger).unwrap();
     assert_eq!(request.method, "GET".to_string());
     assert_eq!(request.url, "http://localhost:8000/hello".to_string());
     assert_eq!(request.headers.len(), 3);
@@ -345,9 +352,9 @@ fn test_form_params() {
 #[test]
 fn test_redirect() {
     let request_spec = default_get_request("http://localhost:8000/redirect".to_string());
-
+    let logger = Logger::default();
     let mut client = default_client();
-    let (request, response) = client.execute(&request_spec).unwrap();
+    let (request, response) = client.execute(&request_spec, &logger).unwrap();
     assert_eq!(request.method, "GET".to_string());
     assert_eq!(request.url, "http://localhost:8000/redirect".to_string());
     assert_eq!(request.headers.len(), 3);
@@ -363,19 +370,21 @@ fn test_redirect() {
 #[test]
 fn test_follow_location() {
     let request_spec = default_get_request("http://localhost:8000/redirect".to_string());
-
+    let logger = Logger::default();
     let options = ClientOptions {
         follow_location: true,
         ..Default::default()
     };
     let mut client = Client::init(options);
-    assert_eq!(client.options.curl_args(), vec!["-L".to_string(),]);
+    assert_eq!(client.options.curl_args(), vec!["-L".to_string()]);
     assert_eq!(
         client.curl_command_line(&request_spec),
         "curl 'http://localhost:8000/redirect' -L".to_string()
     );
 
-    let calls = client.execute_with_redirect(&request_spec).unwrap();
+    let calls = client
+        .execute_with_redirect(&request_spec, &logger)
+        .unwrap();
     assert_eq!(calls.len(), 2);
 
     let (request1, response1) = calls.get(0).unwrap();
@@ -398,7 +407,7 @@ fn test_follow_location() {
 
     // make sure that the redirect count is reset to 0
     let request = default_get_request("http://localhost:8000/hello".to_string());
-    let calls = client.execute_with_redirect(&request).unwrap();
+    let calls = client.execute_with_redirect(&request, &logger).unwrap();
     let (_, response) = calls.get(0).unwrap();
     assert_eq!(response.status, 200);
     assert_eq!(response.body, b"Hello World!".to_vec());
@@ -413,13 +422,17 @@ fn test_max_redirect() {
         ..Default::default()
     };
     let mut client = Client::init(options);
+    let logger = Logger::default();
 
     let request_spec = default_get_request("http://localhost:8000/redirect/15".to_string());
     assert_eq!(
         client.curl_command_line(&request_spec),
         "curl 'http://localhost:8000/redirect/15' -L --max-redirs 10".to_string()
     );
-    let error = client.execute_with_redirect(&request_spec).err().unwrap();
+    let error = client
+        .execute_with_redirect(&request_spec, &logger)
+        .err()
+        .unwrap();
     assert_eq!(error, HttpError::TooManyRedirect);
 
     let request_spec = default_get_request("http://localhost:8000/redirect/8".to_string());
@@ -427,7 +440,9 @@ fn test_max_redirect() {
         client.curl_command_line(&request_spec),
         "curl 'http://localhost:8000/redirect/8' -L --max-redirs 10".to_string()
     );
-    let calls = client.execute_with_redirect(&request_spec).unwrap();
+    let calls = client
+        .execute_with_redirect(&request_spec, &logger)
+        .unwrap();
     let (request, response) = calls.last().unwrap();
     assert_eq!(request.url, "http://localhost:8000/redirect/0".to_string());
     assert_eq!(response.status, 200);
@@ -441,6 +456,7 @@ fn test_max_redirect() {
 #[test]
 fn test_multipart_form_data() {
     let mut client = default_client();
+    let logger = Logger::default();
     let request_spec = RequestSpec {
         method: Method::Post,
         url: "http://localhost:8000/multipart-form-data".to_string(),
@@ -480,7 +496,7 @@ fn test_multipart_form_data() {
         "curl 'http://localhost:8000/multipart-form-data' -F 'key1=value1' -F 'upload1=@data.txt;type=text/plain' -F 'upload2=@data.html;type=text/html' -F 'upload3=@data.txt;type=text/html'".to_string()
     );
 
-    let (request, response) = client.execute(&request_spec).unwrap();
+    let (request, response) = client.execute(&request_spec, &logger).unwrap();
     assert!(request.headers.contains(&Header {
         name: "Content-Length".to_string(),
         value: "627".to_string(),
@@ -490,7 +506,7 @@ fn test_multipart_form_data() {
 
     // make sure you can reuse client for other request
     let request_spec = default_get_request("http://localhost:8000/hello".to_string());
-    let (request, response) = client.execute(&request_spec).unwrap();
+    let (request, response) = client.execute(&request_spec, &logger).unwrap();
     assert_eq!(request.method, "GET".to_string());
     assert_eq!(response.status, 200);
     assert_eq!(response.body, b"Hello World!".to_vec());
@@ -503,6 +519,7 @@ fn test_multipart_form_data() {
 #[test]
 fn test_post_bytes() {
     let mut client = default_client();
+    let logger = Logger::default();
     let request_spec = RequestSpec {
         method: Method::Post,
         url: "http://localhost:8000/post-base64".to_string(),
@@ -518,7 +535,7 @@ fn test_post_bytes() {
         client.curl_command_line(&request_spec),
         "curl 'http://localhost:8000/post-base64' -H 'Content-Type: application/octet-stream' --data $'\\x48\\x65\\x6c\\x6c\\x6f\\x20\\x57\\x6f\\x72\\x6c\\x64\\x21'".to_string()
     );
-    let (request, response) = client.execute(&request_spec).unwrap();
+    let (request, response) = client.execute(&request_spec, &logger).unwrap();
     assert!(request.headers.contains(&Header {
         name: "Content-Length".to_string(),
         value: "12".to_string(),
@@ -533,6 +550,7 @@ fn test_post_bytes() {
 #[test]
 fn test_expect() {
     let mut client = default_client();
+    let logger = Logger::default();
     let request_spec = RequestSpec {
         method: Method::Post,
         url: "http://localhost:8000/expect".to_string(),
@@ -552,7 +570,7 @@ fn test_expect() {
         "curl 'http://localhost:8000/expect' -H 'Expect: 100-continue' -H 'Content-Type:' --data 'data'".to_string()
     );
 
-    let (request, response) = client.execute(&request_spec).unwrap();
+    let (request, response) = client.execute(&request_spec, &logger).unwrap();
     assert!(request.headers.contains(&Header {
         name: "Expect".to_string(),
         value: "100-continue".to_string(),
@@ -569,6 +587,7 @@ fn test_basic_authentication() {
         ..Default::default()
     };
     let mut client = Client::init(options);
+    let logger = Logger::default();
     let request_spec = RequestSpec {
         method: Method::Get,
         url: "http://localhost:8000/basic-authentication".to_string(),
@@ -585,7 +604,7 @@ fn test_basic_authentication() {
         "curl 'http://localhost:8000/basic-authentication' --user 'bob@email.com:secret'"
             .to_string()
     );
-    let (request, response) = client.execute(&request_spec).unwrap();
+    let (request, response) = client.execute(&request_spec, &logger).unwrap();
     assert!(request.headers.contains(&Header {
         name: "Authorization".to_string(),
         value: "Basic Ym9iQGVtYWlsLmNvbTpzZWNyZXQ=".to_string(),
@@ -610,7 +629,7 @@ fn test_basic_authentication() {
         request_spec.curl_args(&ContextDir::default()),
         vec!["'http://bob%40email.com:secret@localhost:8000/basic-authentication'".to_string()]
     );
-    let (request, response) = client.execute(&request_spec).unwrap();
+    let (request, response) = client.execute(&request_spec, &logger).unwrap();
     assert!(request.headers.contains(&Header {
         name: "Authorization".to_string(),
         value: "Basic Ym9iQGVtYWlsLmNvbTpzZWNyZXQ=".to_string(),
@@ -627,8 +646,9 @@ fn test_cacert() {
         ..Default::default()
     };
     let mut client = Client::init(options);
+    let logger = Logger::default();
     let request_spec = default_get_request("https://localhost:8001/hello".to_string());
-    let (_, response) = client.execute(&request_spec).unwrap();
+    let (_, response) = client.execute(&request_spec, &logger).unwrap();
     assert_eq!(response.status, 200);
 }
 
@@ -637,8 +657,9 @@ fn test_cacert() {
 #[test]
 fn test_error_could_not_resolve_host() {
     let mut client = default_client();
+    let logger = Logger::default();
     let request = default_get_request("http://unknown".to_string());
-    let error = client.execute(&request).err().unwrap();
+    let error = client.execute(&request, &logger).err().unwrap();
     assert!(matches!(error, HttpError::Libcurl { .. }));
     if let HttpError::Libcurl {
         code,
@@ -655,8 +676,9 @@ fn test_error_could_not_resolve_host() {
 #[test]
 fn test_error_fail_to_connect() {
     let mut client = default_client();
+    let logger = Logger::default();
     let request_spec = default_get_request("http://localhost:9999".to_string());
-    let error = client.execute(&request_spec).err().unwrap();
+    let error = client.execute(&request_spec, &logger).err().unwrap();
     assert!(matches!(error, HttpError::Libcurl { .. }));
     if let HttpError::Libcurl {
         code,
@@ -675,7 +697,7 @@ fn test_error_fail_to_connect() {
     };
     let mut client = Client::init(options);
     let request = default_get_request("http://localhost:8000/hello".to_string());
-    let error = client.execute(&request).err().unwrap();
+    let error = client.execute(&request, &logger).err().unwrap();
     assert!(matches!(error, HttpError::Libcurl { .. }));
     if let HttpError::Libcurl {
         code,
@@ -697,8 +719,9 @@ fn test_error_could_not_resolve_proxy_name() {
         ..Default::default()
     };
     let mut client = Client::init(options);
+    let logger = Logger::default();
     let request_spec = default_get_request("http://localhost:8000/hello".to_string());
-    let error = client.execute(&request_spec).err().unwrap();
+    let error = client.execute(&request_spec, &logger).err().unwrap();
     assert!(matches!(error, HttpError::Libcurl { .. }));
     if let HttpError::Libcurl {
         code,
@@ -716,8 +739,9 @@ fn test_error_could_not_resolve_proxy_name() {
 fn test_error_ssl() {
     let options = ClientOptions::default();
     let mut client = Client::init(options);
+    let logger = Logger::default();
     let request_spec = default_get_request("https://localhost:8001/hello".to_string());
-    let error = client.execute(&request_spec).err().unwrap();
+    let error = client.execute(&request_spec, &logger).err().unwrap();
     if let HttpError::Libcurl {
         code,
         description,
@@ -745,8 +769,9 @@ fn test_timeout() {
         ..Default::default()
     };
     let mut client = Client::init(options);
+    let logger = Logger::default();
     let request_spec = default_get_request("http://localhost:8000/timeout".to_string());
-    let error = client.execute(&request_spec).err().unwrap();
+    let error = client.execute(&request_spec, &logger).err().unwrap();
     assert!(matches!(error, HttpError::Libcurl { .. }));
     if let HttpError::Libcurl {
         code,
@@ -767,6 +792,7 @@ fn test_accept_encoding() {
         ..Default::default()
     };
     let mut client = Client::init(options);
+    let logger = Logger::default();
 
     let request_spec = RequestSpec {
         method: Method::Get,
@@ -779,7 +805,7 @@ fn test_accept_encoding() {
         body: Body::Binary(vec![]),
         content_type: None,
     };
-    let (request, response) = client.execute(&request_spec).unwrap();
+    let (request, response) = client.execute(&request_spec, &logger).unwrap();
     assert!(request.headers.contains(&Header {
         name: "Accept-Encoding".to_string(),
         value: "gzip, deflate, br".to_string(),
@@ -798,12 +824,13 @@ fn test_connect_timeout() {
         ..Default::default()
     };
     let mut client = Client::init(options);
+    let logger = Logger::default();
     let request_spec = default_get_request("http://10.0.0.0".to_string());
     assert_eq!(
         client.curl_command_line(&request_spec),
         "curl 'http://10.0.0.0' --connect-timeout 1".to_string()
     );
-    let error = client.execute(&request_spec).err().unwrap();
+    let error = client.execute(&request_spec, &logger).err().unwrap();
     assert!(matches!(error, HttpError::Libcurl { .. }));
     if let HttpError::Libcurl {
         code,
@@ -834,6 +861,7 @@ fn test_connect_timeout() {
 #[test]
 fn test_cookie() {
     let mut client = default_client();
+    let logger = Logger::default();
     let request_spec = RequestSpec {
         method: Method::Get,
         url: "http://localhost:8000/cookies/set-request-cookie1-valueA".to_string(),
@@ -856,7 +884,7 @@ fn test_cookie() {
 
     //assert_eq!(request.cookies(), vec!["cookie1=valueA".to_string(),]);
 
-    let (request, response) = client.execute(&request_spec).unwrap();
+    let (request, response) = client.execute(&request_spec, &logger).unwrap();
     assert!(request.headers.contains(&Header {
         name: "Cookie".to_string(),
         value: "cookie1=valueA".to_string(),
@@ -875,13 +903,14 @@ fn test_cookie() {
         body: Body::Binary(vec![]),
         content_type: None,
     };
-    let (_request, response) = client.execute(&request_spec).unwrap();
+    let (_request, response) = client.execute(&request_spec, &logger).unwrap();
     assert_eq!(response.status, 200);
 }
 
 #[test]
 fn test_multiple_request_cookies() {
     let mut client = default_client();
+    let logger = Logger::default();
     let request_spec = RequestSpec {
         method: Method::Get,
         url: "http://localhost:8000/cookies/set-multiple-request-cookies".to_string(),
@@ -911,7 +940,7 @@ fn test_multiple_request_cookies() {
         "curl 'http://localhost:8000/cookies/set-multiple-request-cookies' --cookie 'user1=Bob; user2=Bill; user3=Bruce'".to_string()
     );
 
-    let (request, response) = client.execute(&request_spec).unwrap();
+    let (request, response) = client.execute(&request_spec, &logger).unwrap();
     assert!(request.headers.contains(&Header {
         name: "Cookie".to_string(),
         value: "user1=Bob; user2=Bill; user3=Bruce".to_string(),
@@ -923,9 +952,10 @@ fn test_multiple_request_cookies() {
 #[test]
 fn test_cookie_storage() {
     let mut client = default_client();
+    let logger = Logger::default();
     let request_spec =
         default_get_request("http://localhost:8000/cookies/set-session-cookie2-valueA".to_string());
-    let (request, response) = client.execute(&request_spec).unwrap();
+    let (request, response) = client.execute(&request_spec, &logger).unwrap();
     assert_eq!(
         request.url,
         "http://localhost:8000/cookies/set-session-cookie2-valueA".to_string()
@@ -951,7 +981,7 @@ fn test_cookie_storage() {
     let request_spec = default_get_request(
         "http://localhost:8000/cookies/assert-that-cookie2-is-valueA".to_string(),
     );
-    let (request, response) = client.execute(&request_spec).unwrap();
+    let (request, response) = client.execute(&request_spec, &logger).unwrap();
     assert!(request.headers.contains(&Header {
         name: "Cookie".to_string(),
         value: "cookie2=valueA".to_string(),
@@ -967,6 +997,7 @@ fn test_cookie_file() {
         ..Default::default()
     };
     let mut client = Client::init(options);
+    let logger = Logger::default();
     let request_spec = default_get_request(
         "http://localhost:8000/cookies/assert-that-cookie2-is-valueA".to_string(),
     );
@@ -975,7 +1006,7 @@ fn test_cookie_file() {
         "curl 'http://localhost:8000/cookies/assert-that-cookie2-is-valueA' --cookie tests/cookies.txt".to_string()
     );
 
-    let (request, response) = client.execute(&request_spec).unwrap();
+    let (request, response) = client.execute(&request_spec, &logger).unwrap();
     assert_eq!(
         request.url,
         "http://localhost:8000/cookies/assert-that-cookie2-is-valueA"
@@ -1001,12 +1032,13 @@ fn test_proxy() {
         ..Default::default()
     };
     let mut client = Client::init(options);
+    let logger = Logger::default();
     let request_spec = default_get_request("http://localhost:8000/proxy".to_string());
     assert_eq!(
         client.curl_command_line(&request_spec),
         "curl 'http://localhost:8000/proxy' --proxy 'localhost:8888'".to_string()
     );
-    let (request, response) = client.execute(&request_spec).unwrap();
+    let (request, response) = client.execute(&request_spec, &logger).unwrap();
     assert_eq!(request.url, "http://localhost:8000/proxy");
     assert_eq!(response.status, 200);
 }
@@ -1020,6 +1052,7 @@ fn test_insecure() {
         ..Default::default()
     };
     let mut client = Client::init(options);
+    let logger = Logger::default();
     assert_eq!(client.options.curl_args(), vec!["--insecure".to_string()]);
     let request_spec = default_get_request("https://localhost:8001/hello".to_string());
     assert_eq!(
@@ -1027,7 +1060,7 @@ fn test_insecure() {
         "curl 'https://localhost:8001/hello' --insecure".to_string()
     );
 
-    let (request, response) = client.execute(&request_spec).unwrap();
+    let (request, response) = client.execute(&request_spec, &logger).unwrap();
     assert_eq!(request.url, "https://localhost:8001/hello");
     assert_eq!(response.status, 200);
 }

--- a/packages/hurl/tests/runner.rs
+++ b/packages/hurl/tests/runner.rs
@@ -17,6 +17,7 @@
  */
 
 use hurl::cli;
+use hurl::cli::Logger;
 use hurl::http;
 use hurl::http::ContextDir;
 use hurl::runner;
@@ -25,23 +26,7 @@ use hurl_core::ast::*;
 use hurl_core::parser;
 use std::collections::HashMap;
 
-fn log_verbose(message: &str) {
-    if message.is_empty() {
-        eprintln!("*");
-    } else {
-        eprintln!("* {}", message);
-    }
-}
-
-pub fn log_error_message(_warning: bool, message: &str) {
-    eprintln!("{}", message);
-}
-
-pub fn log_runner_error(error: &runner::Error, _warning: bool) {
-    eprintln!("* {:#?}", error);
-}
-
-// can be used for debugging
+// Can be used for debugging
 #[test]
 fn test_hurl_file() {
     let filename = "../../integration/tests_ok/bom.hurl";
@@ -50,6 +35,7 @@ fn test_hurl_file() {
     let variables = HashMap::new();
     let options = http::ClientOptions::default();
     let mut client = http::Client::init(options);
+    let logger = Logger::default();
     let mut lines: Vec<&str> = regex::Regex::new(r"\n|\r\n")
         .unwrap()
         .split(&content)
@@ -68,21 +54,7 @@ fn test_hurl_file() {
         post_entry: || true,
     };
 
-    let log_verbose: fn(&str) = log_verbose;
-    let log_error_message: fn(bool, &str) = log_error_message;
-    let log_runner_error: fn(&runner::Error, bool) = log_runner_error;
-
-    let _hurl_log = runner::run(
-        hurl_file,
-        &mut client,
-        //&mut variables,
-        filename,
-        &options,
-        &log_verbose,
-        &log_error_message,
-        &log_runner_error,
-    );
-    //   assert_eq!(1,2)
+    let _hurl_log = runner::run(hurl_file, &lines, filename, &mut client, &options, &logger);
 }
 
 #[cfg(test)]
@@ -150,6 +122,7 @@ fn hello_request() -> Request {
 fn test_hello() {
     let options = http::ClientOptions::default();
     let mut client = http::Client::init(options);
+    let logger = Logger::default();
     let source_info = SourceInfo {
         start: Pos { line: 1, column: 1 },
         end: Pos { line: 1, column: 1 },
@@ -198,16 +171,14 @@ fn test_hello() {
         pre_entry: |_| true,
         post_entry: || true,
     };
-    let log_verbose: fn(&str) = log_verbose;
-    let log_error_message: fn(bool, &str) = log_error_message;
-    let log_runner_error: fn(&runner::Error, bool) = log_runner_error;
-    let _hurl_log = runner::run(
+
+    // FIXME => compute lines
+    runner::run(
         hurl_file,
-        &mut client,
+        &vec![],
         "filename",
+        &mut client,
         &options,
-        &log_verbose,
-        &log_error_message,
-        &log_runner_error,
+        &logger,
     );
 }

--- a/packages/hurl_core/src/format/html.rs
+++ b/packages/hurl_core/src/format/html.rs
@@ -15,8 +15,6 @@
  * limitations under the License.
  *
  */
-//use hurlfmt::format::text::format_token;
-//use hurlfmt::format::token::Tokenizable;
 use crate::ast::*;
 
 pub trait Htmlable {


### PR DESCRIPTION
This PR to make some modifications about the way we log.

In function signature:

Before:

```rust
pub fn run(
    hurl_file: HurlFile,
    http_client: &mut http::Client,
    filename: &str,
    options: &RunnerOptions,
    log_verbose: &impl Fn(&str),
    log_error_message: &impl Fn(bool, &str),
    log_error: &impl Fn(&Error, bool),
) -> HurlResult {
 ```

After:

```rust
pub fn run(
    hurl_file: HurlFile,
    lines: &Vec<&str>,
    filename: &str,
    http_client: &mut http::Client,
    options: &RunnerOptions,
    logger: &Logger,
) -> HurlResult {
```

There was no clear differences between `log_error_message`, `log_error` etc... and some duplications on logger codes. Now, user must provides a logger struct.

In the code, when we want to log:

Before:

```rust
log_verbose("");
log_verbose("Cookie store:");
for cookie in http_client.get_cookie_storage() {
    log_verbose(cookie.to_string().as_str());
}
```

After:

```rust
logger.debug("");
logger.debug("Cookie store:");
for cookie in http_client.get_cookie_storage() {
    logger.debug(cookie.to_string().as_str());
}
```


To note: there was hardcoded `eprintln` in `hurl`(and there is still some), that would make difficult to use `hurl` as a lib if one doesn't want log.

# To discuss:

1. is is worth it ?
2. Add `filename` and `lines` field to `HurlFile`? Currently, we have this signature:
```rust
pub fn run(
    hurl_file: HurlFile,
    lines: &Vec<&str>,
    filename: &str,
    http_client: &mut http::Client,
    options: &RunnerOptions,
    logger: &Logger,
) -> HurlResult {
```

May be we can include `lines` and `filename` in `HurlFile`?

```rust
#[derive(Clone, Debug, PartialEq, Eq)]
pub struct HurlFile {
    pub entries: Vec<Entry>,
    pub line_terminators: Vec<LineTerminator>,
    pub filename: String,
    pub lines: Vec<String>
}
```

It makes no sense to have an instance of `HurlFile` with a different vec of `lines` so we may add `filename` and `lines` to `HurlFile` and simplify functions signature.





