### PR TITLE
Modify Hurl file high level api

### DIFF
--- a/packages/hurl/src/json/result.rs
+++ b/packages/hurl/src/json/result.rs
@@ -22,7 +22,7 @@ use crate::http::{
 use crate::runner::{AssertResult, CaptureResult, EntryResult, HurlResult};
 
 impl HurlResult {
-    pub fn to_json(&self, lines: &Vec<&str>) -> serde_json::Value {
+    pub fn to_json(&self, content: &str) -> serde_json::Value {
         let mut map = serde_json::Map::new();
         map.insert(
             "filename".to_string(),
@@ -31,7 +31,7 @@ impl HurlResult {
         let entries = self
             .entries
             .iter()
-            .map(|e| e.clone().to_json(lines, &self.filename))
+            .map(|e| e.clone().to_json(&self.filename, content))
             .collect();
         map.insert("entries".to_string(), serde_json::Value::Array(entries));
         map.insert(
@@ -49,7 +49,7 @@ impl HurlResult {
 }
 
 impl EntryResult {
-    fn to_json(&self, lines: &Vec<&str>, filename: &str) -> serde_json::Value {
+    fn to_json(&self, filename: &str, content: &str) -> serde_json::Value {
         let mut map = serde_json::Map::new();
         if let Some(request) = &self.request {
             map.insert("request".to_string(), request.to_json());
@@ -62,7 +62,7 @@ impl EntryResult {
         let asserts = self
             .asserts
             .iter()
-            .map(|a| a.clone().to_json(lines, filename))
+            .map(|a| a.clone().to_json(filename, content))
             .collect();
         map.insert("asserts".to_string(), asserts);
         map.insert(
@@ -249,14 +249,14 @@ impl CaptureResult {
 }
 
 impl AssertResult {
-    fn to_json(&self, lines: &Vec<&str>, filename: &str) -> serde_json::Value {
+    fn to_json(&self, filename: &str, content: &str) -> serde_json::Value {
         let mut map = serde_json::Map::new();
 
         let success = self.clone().error().is_none();
         map.insert("success".to_string(), serde_json::Value::Bool(success));
 
         if let Some(err) = self.clone().error() {
-            let message = crate::cli::error_string(lines, filename, &err);
+            let message = crate::cli::error_string(filename, content, &err);
             map.insert("message".to_string(), serde_json::Value::String(message));
         }
         map.insert(

--- a/packages/hurl/src/report/junit/testcase.rs
+++ b/packages/hurl/src/report/junit/testcase.rs
@@ -33,14 +33,14 @@ impl Testcase {
     ///
     /// create an XML Junit <testcase> from an Hurl result
     ///
-    pub fn from_hurl_result(hurl_result: &HurlResult, lines: &Vec<&str>) -> Testcase {
+    pub fn from_hurl_result(hurl_result: &HurlResult, content: &str) -> Testcase {
         let id = hurl_result.filename.clone();
         let time_in_ms = hurl_result.time_in_ms;
         let mut failures = vec![];
         let mut errors = vec![];
 
         for error in hurl_result.errors() {
-            let message = cli::error_string(lines, &hurl_result.filename, &error);
+            let message = cli::error_string(&hurl_result.filename, content, &error);
             if error.assert {
                 failures.push(message);
             } else {
@@ -105,7 +105,6 @@ mod test {
 
     #[test]
     fn test_create_testcase_success() {
-        let lines = vec![];
         let hurl_result = HurlResult {
             filename: "test.hurl".to_string(),
             entries: vec![],
@@ -115,7 +114,8 @@ mod test {
         };
 
         let mut buffer = Vec::new();
-        Testcase::from_hurl_result(&hurl_result, &lines)
+        let content = "";
+        Testcase::from_hurl_result(&hurl_result, &content)
             .to_xml()
             .write(&mut buffer)
             .unwrap();
@@ -127,7 +127,9 @@ mod test {
 
     #[test]
     fn test_create_testcase_failure() {
-        let lines = vec!["GET http://localhost:8000/not_found", "HTTP/1.0 200"];
+        let content = r#"GET http://localhost:8000/not_found
+HTTP/1.0 200
+"#;
         let hurl_result = HurlResult {
             filename: "test.hurl".to_string(),
             entries: vec![EntryResult {
@@ -149,7 +151,7 @@ mod test {
             cookies: vec![],
         };
         let mut buffer = Vec::new();
-        Testcase::from_hurl_result(&hurl_result, &lines)
+        Testcase::from_hurl_result(&hurl_result, &content)
             .to_xml()
             .write(&mut buffer)
             .unwrap();
@@ -166,7 +168,7 @@ mod test {
 
     #[test]
     fn test_create_testcase_error() {
-        let lines = vec!["GET http://unknown"];
+        let content = "GET http://unknown";
         let hurl_result = HurlResult {
             filename: "test.hurl".to_string(),
             entries: vec![EntryResult {
@@ -189,7 +191,7 @@ mod test {
             cookies: vec![],
         };
         let mut buffer = Vec::new();
-        Testcase::from_hurl_result(&hurl_result, &lines)
+        Testcase::from_hurl_result(&hurl_result, content)
             .to_xml()
             .write(&mut buffer)
             .unwrap();

--- a/packages/hurl/src/runner/hurl_file.rs
+++ b/packages/hurl/src/runner/hurl_file.rs
@@ -25,7 +25,16 @@ use hurl_core::ast::*;
 use super::core::*;
 use super::entry;
 
-/// Run a Hurl file with the hurl http client
+/// Runs a Hurl file with the Hurl HTTP client.
+///
+/// # Arguments
+///
+/// * `hurl_file` - The Hurl file ast
+/// * `filename` - Filename of the Hurl file, "-" is used for stdin
+/// * `content` - Content of the Hurl file
+/// * `http_client` - The HTTP client used to run this Hurl file
+/// * `options` - Options for this run
+/// * `logger` - The logger
 ///
 /// # Example
 ///
@@ -48,7 +57,6 @@ use super::entry;
 /// // Create an HTTP client
 /// let options = http::ClientOptions::default();
 /// let mut client = http::Client::init(options);
-///
 /// let logger = Logger::default();
 ///
 /// // Define runner options
@@ -64,13 +72,11 @@ use super::entry;
 ///        post_entry: || true,
 ///  };
 ///
-/// // FIXME: put lines in hurl_file?
-///
 /// // Run the hurl file
 /// let hurl_results = runner::run(
-///     hurl_file,
-///     &vec!(),
+///     &hurl_file,
 ///     filename,
+///     s,
 ///     &mut client,
 ///     &options,
 ///     &logger,
@@ -80,9 +86,9 @@ use super::entry;
 /// ```
 ///
 pub fn run(
-    hurl_file: HurlFile,
-    lines: &Vec<&str>,
+    hurl_file: &HurlFile,
     filename: &str,
+    content: &str,
     http_client: &mut http::Client,
     options: &RunnerOptions,
     logger: &Logger,
@@ -125,7 +131,7 @@ pub fn run(
 
         for entry_result in entry_results.clone() {
             for e in entry_result.errors.clone() {
-                let error_message = cli::error_string(lines, filename, &e);
+                let error_message = cli::error_string(filename, content, &e);
                 logger.error(format!("{}\n", &error_message).as_str());
             }
             entries.push(entry_result.clone());

--- a/packages/hurl/tests/runner.rs
+++ b/packages/hurl/tests/runner.rs
@@ -36,12 +36,6 @@ fn test_hurl_file() {
     let options = http::ClientOptions::default();
     let mut client = http::Client::init(options);
     let logger = Logger::default();
-    let mut lines: Vec<&str> = regex::Regex::new(r"\n|\r\n")
-        .unwrap()
-        .split(&content)
-        .collect();
-    // edd an empty line at the end?
-    lines.push("");
 
     let options = RunnerOptions {
         fail_fast: false,
@@ -54,7 +48,14 @@ fn test_hurl_file() {
         post_entry: || true,
     };
 
-    let _hurl_log = runner::run(hurl_file, &lines, filename, &mut client, &options, &logger);
+    let _hurl_log = runner::run(
+        &hurl_file,
+        filename,
+        &content,
+        &mut client,
+        &options,
+        &logger,
+    );
 }
 
 #[cfg(test)]
@@ -123,6 +124,11 @@ fn test_hello() {
     let options = http::ClientOptions::default();
     let mut client = http::Client::init(options);
     let logger = Logger::default();
+
+    // We construct a Hurl file ast "by hand", with fake source info.
+    // In this particular case, the raw content is empty as the Hurl file hasn't
+    // been built from a text content.
+    let content = "";
     let source_info = SourceInfo {
         start: Pos { line: 1, column: 1 },
         end: Pos { line: 1, column: 1 },
@@ -172,11 +178,10 @@ fn test_hello() {
         post_entry: || true,
     };
 
-    // FIXME => compute lines
     runner::run(
-        hurl_file,
-        &vec![],
+        &hurl_file,
         "filename",
+        content,
         &mut client,
         &options,
         &logger,

--- a/packages/hurl_core/src/parser/mod.rs
+++ b/packages/hurl_core/src/parser/mod.rs
@@ -17,11 +17,11 @@
  */
 use crate::ast::HurlFile;
 
-pub type ParseResult<'a, T> = std::result::Result<T, Error>;
-pub type ParseFunc<'a, T> = fn(&mut reader::Reader) -> ParseResult<'a, T>;
+pub type ParseResult<'a, T> = Result<T, Error>;
+pub type ParseFunc<'a, T> = fn(&mut Reader) -> ParseResult<'a, T>;
 
 pub fn parse_hurl_file(s: &str) -> ParseResult<'static, HurlFile> {
-    let mut reader = reader::Reader::init(s);
+    let mut reader = Reader::init(s);
     parsers::hurl_file(&mut reader)
 }
 


### PR DESCRIPTION
This PR to modify high level api usage: when we `run` a `HurlFile`we must pass the raw text content `&str` instead of a `Vec<&str>`of lines.

# Rational

- lines are only needed when we display an error. So there is no need to split the content if everything is ok. BTW, content was unnecessary splitted twice in `main.rs`
- as an api, it's easier fir the user understand to use the raw content as a parameter, instead of an array of lines.

# To be discuss

We don't included `content` and `filename` in the `HurlFile`  ast as sometimes we work on an AST without having any "content" (in lint for instance)
