### PR TITLE
Clean logger

### DIFF
--- a/integration/tests_ok/color.err
+++ b/integration/tests_ok/color.err
@@ -3,4 +3,4 @@
 [1;34m*[0m     insecure: false
 [1;34m*[0m     follow redirect: false
 [1;34m*[0m     max redirect: 50
-[1;33mwarning[0m: no entry have been executed for file tests_ok/color.hurl
+[1;33mwarning[0m: No entry have been executed for file tests_ok/color.hurl

--- a/packages/hurl/src/cli/mod.rs
+++ b/packages/hurl/src/cli/mod.rs
@@ -25,7 +25,7 @@ pub use self::options::parse_options;
 pub use self::options::{CliOptions, OutputType};
 pub use self::variables::parse as parse_variable;
 pub use self::variables::parse_value as parse_variable_value;
-pub use crate::util::logger::{error_string, Logger};
+pub use crate::util::logger::{error_string, error_string_no_color, Logger};
 
 mod fs;
 pub mod interactive;

--- a/packages/hurl/src/json/result.rs
+++ b/packages/hurl/src/json/result.rs
@@ -16,6 +16,7 @@
  *
  */
 
+use crate::cli;
 use crate::http::{
     Cookie, Header, Param, Request, RequestCookie, Response, ResponseCookie, Version,
 };
@@ -256,7 +257,7 @@ impl AssertResult {
         map.insert("success".to_string(), serde_json::Value::Bool(success));
 
         if let Some(err) = self.clone().error() {
-            let message = crate::cli::error_string(filename, content, &err);
+            let message = cli::error_string_no_color(filename, content, &err);
             map.insert("message".to_string(), serde_json::Value::String(message));
         }
         map.insert(

--- a/packages/hurl/src/report/junit/testcase.rs
+++ b/packages/hurl/src/report/junit/testcase.rs
@@ -40,7 +40,7 @@ impl Testcase {
         let mut errors = vec![];
 
         for error in hurl_result.errors() {
-            let message = cli::error_string(&hurl_result.filename, content, &error);
+            let message = cli::error_string_no_color(&hurl_result.filename, content, &error);
             if error.assert {
                 failures.push(message);
             } else {

--- a/packages/hurl/src/runner/hurl_file.rs
+++ b/packages/hurl/src/runner/hurl_file.rs
@@ -19,7 +19,7 @@ use std::collections::HashMap;
 use std::time::Instant;
 
 use crate::cli::Logger;
-use crate::{cli, http};
+use crate::http;
 use hurl_core::ast::*;
 
 use super::core::*;
@@ -57,7 +57,7 @@ use super::entry;
 /// // Create an HTTP client
 /// let options = http::ClientOptions::default();
 /// let mut client = http::Client::init(options);
-/// let logger = Logger::default();
+/// let logger = Logger::new(false, false, filename, s);
 ///
 /// // Define runner options
 /// let variables = std::collections::HashMap::new();
@@ -76,7 +76,6 @@ use super::entry;
 /// let hurl_results = runner::run(
 ///     &hurl_file,
 ///     filename,
-///     s,
 ///     &mut client,
 ///     &options,
 ///     &logger,
@@ -88,7 +87,6 @@ use super::entry;
 pub fn run(
     hurl_file: &HurlFile,
     filename: &str,
-    content: &str,
     http_client: &mut http::Client,
     options: &RunnerOptions,
     logger: &Logger,
@@ -131,8 +129,7 @@ pub fn run(
 
         for entry_result in entry_results.clone() {
             for e in entry_result.errors.clone() {
-                let error_message = cli::error_string(filename, content, &e);
-                logger.error(format!("{}\n", &error_message).as_str());
+                logger.error_rich(&e);
             }
             entries.push(entry_result.clone());
         }

--- a/packages/hurl/tests/libcurl.rs
+++ b/packages/hurl/tests/libcurl.rs
@@ -53,7 +53,7 @@ fn default_get_request(url: String) -> RequestSpec {
 #[test]
 fn test_hello() {
     let mut client = default_client();
-    let logger = Logger::default();
+    let logger = Logger::new(false, false, "", "");
     let request_spec = default_get_request("http://localhost:8000/hello".to_string());
     assert_eq!(
         client.curl_command_line(&request_spec),
@@ -96,7 +96,7 @@ fn test_hello() {
 #[test]
 fn test_put() {
     let mut client = default_client();
-    let logger = Logger::default();
+    let logger = Logger::new(false, false, "", "");
     let request_spec = RequestSpec {
         method: Method::Put,
         url: "http://localhost:8000/put".to_string(),
@@ -132,7 +132,7 @@ fn test_put() {
 #[test]
 fn test_patch() {
     let mut client = default_client();
-    let logger = Logger::default();
+    let logger = Logger::new(false, false, "", "");
     let request_spec = RequestSpec {
         method: Method::Patch,
         url: "http://localhost:8000/patch/file.txt".to_string(),
@@ -188,7 +188,7 @@ fn test_patch() {
 #[test]
 fn test_custom_headers() {
     let mut client = default_client();
-    let logger = Logger::default();
+    let logger = Logger::new(false, false, "", "");
     let request_spec = RequestSpec {
         method: Method::Get,
         url: "http://localhost:8000/custom-headers".to_string(),
@@ -233,7 +233,7 @@ fn test_custom_headers() {
 #[test]
 fn test_querystring_params() {
     let mut client = default_client();
-    let logger = Logger::default();
+    let logger = Logger::new(false, false, "", "");
     let request_spec = RequestSpec {
         method: Method::Get,
         url: "http://localhost:8000/querystring-params".to_string(),
@@ -282,7 +282,7 @@ fn test_querystring_params() {
 #[test]
 fn test_form_params() {
     let mut client = default_client();
-    let logger = Logger::default();
+    let logger = Logger::new(false, false, "", "");
     let request_spec = RequestSpec {
         method: Method::Post,
         url: "http://localhost:8000/form-params".to_string(),
@@ -352,7 +352,7 @@ fn test_form_params() {
 #[test]
 fn test_redirect() {
     let request_spec = default_get_request("http://localhost:8000/redirect".to_string());
-    let logger = Logger::default();
+    let logger = Logger::new(false, false, "", "");
     let mut client = default_client();
     let (request, response) = client.execute(&request_spec, &logger).unwrap();
     assert_eq!(request.method, "GET".to_string());
@@ -370,7 +370,7 @@ fn test_redirect() {
 #[test]
 fn test_follow_location() {
     let request_spec = default_get_request("http://localhost:8000/redirect".to_string());
-    let logger = Logger::default();
+    let logger = Logger::new(false, false, "", "");
     let options = ClientOptions {
         follow_location: true,
         ..Default::default()
@@ -422,7 +422,7 @@ fn test_max_redirect() {
         ..Default::default()
     };
     let mut client = Client::init(options);
-    let logger = Logger::default();
+    let logger = Logger::new(false, false, "", "");
 
     let request_spec = default_get_request("http://localhost:8000/redirect/15".to_string());
     assert_eq!(
@@ -456,7 +456,7 @@ fn test_max_redirect() {
 #[test]
 fn test_multipart_form_data() {
     let mut client = default_client();
-    let logger = Logger::default();
+    let logger = Logger::new(false, false, "", "");
     let request_spec = RequestSpec {
         method: Method::Post,
         url: "http://localhost:8000/multipart-form-data".to_string(),
@@ -519,7 +519,7 @@ fn test_multipart_form_data() {
 #[test]
 fn test_post_bytes() {
     let mut client = default_client();
-    let logger = Logger::default();
+    let logger = Logger::new(false, false, "", "");
     let request_spec = RequestSpec {
         method: Method::Post,
         url: "http://localhost:8000/post-base64".to_string(),
@@ -550,7 +550,7 @@ fn test_post_bytes() {
 #[test]
 fn test_expect() {
     let mut client = default_client();
-    let logger = Logger::default();
+    let logger = Logger::new(false, false, "", "");
     let request_spec = RequestSpec {
         method: Method::Post,
         url: "http://localhost:8000/expect".to_string(),
@@ -587,7 +587,7 @@ fn test_basic_authentication() {
         ..Default::default()
     };
     let mut client = Client::init(options);
-    let logger = Logger::default();
+    let logger = Logger::new(false, false, "", "");
     let request_spec = RequestSpec {
         method: Method::Get,
         url: "http://localhost:8000/basic-authentication".to_string(),
@@ -646,7 +646,7 @@ fn test_cacert() {
         ..Default::default()
     };
     let mut client = Client::init(options);
-    let logger = Logger::default();
+    let logger = Logger::new(false, false, "", "");
     let request_spec = default_get_request("https://localhost:8001/hello".to_string());
     let (_, response) = client.execute(&request_spec, &logger).unwrap();
     assert_eq!(response.status, 200);
@@ -657,7 +657,7 @@ fn test_cacert() {
 #[test]
 fn test_error_could_not_resolve_host() {
     let mut client = default_client();
-    let logger = Logger::default();
+    let logger = Logger::new(false, false, "", "");
     let request = default_get_request("http://unknown".to_string());
     let error = client.execute(&request, &logger).err().unwrap();
     assert!(matches!(error, HttpError::Libcurl { .. }));
@@ -676,7 +676,7 @@ fn test_error_could_not_resolve_host() {
 #[test]
 fn test_error_fail_to_connect() {
     let mut client = default_client();
-    let logger = Logger::default();
+    let logger = Logger::new(false, false, "", "");
     let request_spec = default_get_request("http://localhost:9999".to_string());
     let error = client.execute(&request_spec, &logger).err().unwrap();
     assert!(matches!(error, HttpError::Libcurl { .. }));
@@ -719,7 +719,7 @@ fn test_error_could_not_resolve_proxy_name() {
         ..Default::default()
     };
     let mut client = Client::init(options);
-    let logger = Logger::default();
+    let logger = Logger::new(false, false, "", "");
     let request_spec = default_get_request("http://localhost:8000/hello".to_string());
     let error = client.execute(&request_spec, &logger).err().unwrap();
     assert!(matches!(error, HttpError::Libcurl { .. }));
@@ -739,7 +739,7 @@ fn test_error_could_not_resolve_proxy_name() {
 fn test_error_ssl() {
     let options = ClientOptions::default();
     let mut client = Client::init(options);
-    let logger = Logger::default();
+    let logger = Logger::new(false, false, "", "");
     let request_spec = default_get_request("https://localhost:8001/hello".to_string());
     let error = client.execute(&request_spec, &logger).err().unwrap();
     if let HttpError::Libcurl {
@@ -769,7 +769,7 @@ fn test_timeout() {
         ..Default::default()
     };
     let mut client = Client::init(options);
-    let logger = Logger::default();
+    let logger = Logger::new(false, false, "", "");
     let request_spec = default_get_request("http://localhost:8000/timeout".to_string());
     let error = client.execute(&request_spec, &logger).err().unwrap();
     assert!(matches!(error, HttpError::Libcurl { .. }));
@@ -792,7 +792,7 @@ fn test_accept_encoding() {
         ..Default::default()
     };
     let mut client = Client::init(options);
-    let logger = Logger::default();
+    let logger = Logger::new(false, false, "", "");
 
     let request_spec = RequestSpec {
         method: Method::Get,
@@ -824,7 +824,7 @@ fn test_connect_timeout() {
         ..Default::default()
     };
     let mut client = Client::init(options);
-    let logger = Logger::default();
+    let logger = Logger::new(false, false, "", "");
     let request_spec = default_get_request("http://10.0.0.0".to_string());
     assert_eq!(
         client.curl_command_line(&request_spec),
@@ -861,7 +861,7 @@ fn test_connect_timeout() {
 #[test]
 fn test_cookie() {
     let mut client = default_client();
-    let logger = Logger::default();
+    let logger = Logger::new(false, false, "", "");
     let request_spec = RequestSpec {
         method: Method::Get,
         url: "http://localhost:8000/cookies/set-request-cookie1-valueA".to_string(),
@@ -910,7 +910,7 @@ fn test_cookie() {
 #[test]
 fn test_multiple_request_cookies() {
     let mut client = default_client();
-    let logger = Logger::default();
+    let logger = Logger::new(false, false, "", "");
     let request_spec = RequestSpec {
         method: Method::Get,
         url: "http://localhost:8000/cookies/set-multiple-request-cookies".to_string(),
@@ -952,7 +952,7 @@ fn test_multiple_request_cookies() {
 #[test]
 fn test_cookie_storage() {
     let mut client = default_client();
-    let logger = Logger::default();
+    let logger = Logger::new(false, false, "", "");
     let request_spec =
         default_get_request("http://localhost:8000/cookies/set-session-cookie2-valueA".to_string());
     let (request, response) = client.execute(&request_spec, &logger).unwrap();
@@ -997,7 +997,7 @@ fn test_cookie_file() {
         ..Default::default()
     };
     let mut client = Client::init(options);
-    let logger = Logger::default();
+    let logger = Logger::new(false, false, "", "");
     let request_spec = default_get_request(
         "http://localhost:8000/cookies/assert-that-cookie2-is-valueA".to_string(),
     );
@@ -1032,7 +1032,7 @@ fn test_proxy() {
         ..Default::default()
     };
     let mut client = Client::init(options);
-    let logger = Logger::default();
+    let logger = Logger::new(false, false, "", "");
     let request_spec = default_get_request("http://localhost:8000/proxy".to_string());
     assert_eq!(
         client.curl_command_line(&request_spec),
@@ -1052,7 +1052,7 @@ fn test_insecure() {
         ..Default::default()
     };
     let mut client = Client::init(options);
-    let logger = Logger::default();
+    let logger = Logger::new(false, false, "", "");
     assert_eq!(client.options.curl_args(), vec!["--insecure".to_string()]);
     let request_spec = default_get_request("https://localhost:8001/hello".to_string());
     assert_eq!(

--- a/packages/hurl/tests/runner.rs
+++ b/packages/hurl/tests/runner.rs
@@ -35,7 +35,7 @@ fn test_hurl_file() {
     let variables = HashMap::new();
     let options = http::ClientOptions::default();
     let mut client = http::Client::init(options);
-    let logger = Logger::default();
+    let logger = Logger::new(false, false, filename, &content);
 
     let options = RunnerOptions {
         fail_fast: false,
@@ -48,14 +48,7 @@ fn test_hurl_file() {
         post_entry: || true,
     };
 
-    let _hurl_log = runner::run(
-        &hurl_file,
-        filename,
-        &content,
-        &mut client,
-        &options,
-        &logger,
-    );
+    let _hurl_log = runner::run(&hurl_file, filename, &mut client, &options, &logger);
 }
 
 #[cfg(test)]
@@ -123,12 +116,14 @@ fn hello_request() -> Request {
 fn test_hello() {
     let options = http::ClientOptions::default();
     let mut client = http::Client::init(options);
-    let logger = Logger::default();
 
     // We construct a Hurl file ast "by hand", with fake source info.
     // In this particular case, the raw content is empty as the Hurl file hasn't
     // been built from a text content.
     let content = "";
+    let filename = "filename";
+    let logger = Logger::new(false, false, filename, content);
+
     let source_info = SourceInfo {
         start: Pos { line: 1, column: 1 },
         end: Pos { line: 1, column: 1 },
@@ -178,12 +173,5 @@ fn test_hello() {
         post_entry: || true,
     };
 
-    runner::run(
-        &hurl_file,
-        "filename",
-        content,
-        &mut client,
-        &options,
-        &logger,
-    );
+    runner::run(&hurl_file, "filename", &mut client, &options, &logger);
 }


### PR DESCRIPTION
This PR crates 2 loggers:
- a basic logger (info, debug, error) for basic error (file not here etc...)
- a dedicated Hurl logger for a file (info, debug, error + error_rich to display beautiful parser / runtime error string)