### PR TITLE
Make verbose and very-verbose logs more colored.

### DIFF
--- a/integration/tests_ok/color.err
+++ b/integration/tests_ok/color.err
@@ -1,4 +1,4 @@
-[1;34m*[0m Options:
+[1;34m*[0m [1mOptions:[0m
 [1;34m*[0m     fail fast: true
 [1;34m*[0m     insecure: false
 [1;34m*[0m     follow redirect: false

--- a/integration/tests_ok/verbose.err.pattern
+++ b/integration/tests_ok/verbose.err.pattern
@@ -19,6 +19,8 @@
 > Accept: */*
 > User-Agent: hurl/~~~
 >
+* Response:
+*
 < HTTP/1.0 200 OK
 < Content-Type: text/html; charset=utf-8
 < Content-Length: 12

--- a/integration/tests_ok/very_verbose.err.pattern
+++ b/integration/tests_ok/very_verbose.err.pattern
@@ -21,6 +21,8 @@
 >
 * Request body:
 *
+* Response:
+*
 < HTTP/1.0 301 MOVED PERMANENTLY
 < Content-Type: text/html; charset=utf-8
 < Content-Length: 205
@@ -46,6 +48,8 @@
 > User-Agent: hurl/~~~-snapshot
 >
 * Request body:
+*
+* Response:
 *
 < HTTP/1.0 200 OK
 < Content-Type: text/html; charset=utf-8
@@ -73,6 +77,8 @@
 > User-Agent: hurl/~~~-snapshot
 >
 * Request body:
+*
+* Response:
 *
 < HTTP/1.0 200 OK
 < Content-Type: text/html; charset=ISO-8859-1
@@ -110,6 +116,8 @@
 *     "foo": "bar",
 *     "baz": true
 * }
+* Response:
+*
 < HTTP/1.0 200 OK
 < Content-Type: text/html; charset=utf-8
 < Content-Length: 17
@@ -137,6 +145,8 @@
 > User-Agent: hurl/~~~-snapshot
 >
 * Request body:
+*
+* Response:
 *
 < HTTP/1.0 200 OK
 < Content-Type: image/jpeg
@@ -171,6 +181,8 @@
 >
 * Request body:
 * Bytes <~~~~~...>
+* Response:
+*
 < HTTP/1.0 200 OK
 < Content-Type: text/html; charset=utf-8
 < Content-Length: 0
@@ -199,6 +211,8 @@
 > User-Agent: hurl/~~~-snapshot
 >
 * Request body:
+*
+* Response:
 *
 < HTTP/1.0 200 OK
 < Content-Type: text/html; charset=utf-8

--- a/packages/hurl/src/http/debug.rs
+++ b/packages/hurl/src/http/debug.rs
@@ -16,23 +16,6 @@
  *
  */
 use crate::cli::Logger;
-use crate::http::Header;
-
-/// Debug log HTTP request headers.
-pub fn log_headers_out(headers: &[Header], logger: &Logger) {
-    for header in headers {
-        logger.info(format!("> {}", header).as_str());
-    }
-    logger.info(">")
-}
-
-/// Debug log HTTP response headers.
-pub fn log_headers_in(headers: &[Header], logger: &Logger) {
-    for header in headers {
-        logger.info(format!("< {}", header).as_str());
-    }
-    logger.info("<")
-}
 
 /// Debug log text.
 pub fn log_text(text: &str, logger: &Logger) {

--- a/packages/hurl/src/http/request_debug.rs
+++ b/packages/hurl/src/http/request_debug.rs
@@ -20,14 +20,9 @@ use crate::cli::Logger;
 use crate::http::{debug, mimetype, Request};
 
 impl Request {
-    /// Log request headers.
-    pub fn log_headers(&self, logger: &Logger) {
-        debug::log_headers_out(&self.headers, logger)
-    }
-
     /// Log request body.
     pub fn log_body(&self, logger: &Logger) {
-        logger.debug("Request body:");
+        logger.debug_important("Request body:");
 
         // We try to decode the HTTP body as text if the response has a text kind content type.
         // If it ok, we print each line of the body in debug format. Otherwise, we

--- a/packages/hurl/src/http/response_debug.rs
+++ b/packages/hurl/src/http/response_debug.rs
@@ -20,14 +20,9 @@ use crate::cli::Logger;
 use crate::http::{debug, mimetype, Response};
 
 impl Response {
-    /// Log response headers.
-    pub fn log_headers(&self, logger: &Logger) {
-        debug::log_headers_in(&self.headers, logger)
-    }
-
     /// Log a response body as text if possible, or a slice of body bytes.
     pub fn log_body(&self, logger: &Logger) {
-        logger.debug("Response body:");
+        logger.debug_important("Response body:");
 
         // We try to decode the HTTP body as text if the request has a text kind content type.
         // If it ok, we print each line of the body in debug format. Otherwise, we

--- a/packages/hurl/src/main.rs
+++ b/packages/hurl/src/main.rs
@@ -112,7 +112,7 @@ fn execute(
             std::process::exit(EXIT_ERROR_PARSING);
         }
         Ok(hurl_file) => {
-            logger.debug("Options:");
+            logger.debug_important("Options:");
             logger.debug(format!("    fail fast: {}", cli_options.fail_fast).as_str());
             logger.debug(format!("    insecure: {}", cli_options.insecure).as_str());
             logger.debug(format!("    follow redirect: {}", cli_options.follow_location).as_str());
@@ -123,9 +123,9 @@ fn execute(
                 logger.debug(format!("    proxy: {}", proxy).as_str());
             }
             if !cli_options.variables.is_empty() {
-                logger.debug("Variables:");
+                logger.debug_important("Variables:");
                 for (name, value) in cli_options.variables.clone() {
-                    logger.debug(format!("    {}={}", name, value).as_str());
+                    logger.debug(format!("    {}: {}", name, value).as_str());
                 }
             }
             if let Some(to_entry) = cli_options.to_entry {

--- a/packages/hurl/src/runner/entry.rs
+++ b/packages/hurl/src/runner/entry.rs
@@ -69,8 +69,10 @@ pub fn run(
         }
     };
 
-    logger.debug("------------------------------------------------------------------------------");
-    logger.debug(format!("Executing entry {}", entry_index + 1).as_str());
+    logger.debug_important(
+        "------------------------------------------------------------------------------",
+    );
+    logger.debug_important(format!("Executing entry {}", entry_index + 1).as_str());
 
     //
     // Experimental features
@@ -89,7 +91,7 @@ pub fn run(
     }
 
     logger.debug("");
-    logger.debug("Cookie store:");
+    logger.debug_important("Cookie store:");
     for cookie in http_client.get_cookie_storage() {
         logger.debug(cookie.to_string().as_str());
     }
@@ -178,7 +180,7 @@ pub fn run(
                 .collect();
 
             if !captures.is_empty() {
-                logger.debug("Captures:");
+                logger.debug_important("Captures:");
                 for capture in captures.clone() {
                     logger.debug(format!("{}: {}", capture.name, capture.value).as_str());
                 }
@@ -208,7 +210,7 @@ pub fn run(
 /// * `logger` - A logger
 ///
 fn log_request_spec(request: &http::RequestSpec, logger: &Logger) {
-    logger.debug("Request:");
+    logger.debug_important("Request:");
     logger.debug(format!("{} {}", request.method, request.url).as_str());
     for header in &request.headers {
         logger.debug(header.to_string().as_str());


### PR DESCRIPTION
With `--very-verbose`:

Before:

<img width="1093" alt="Screenshot 2022-08-05 at 16 58 10" src="https://user-images.githubusercontent.com/16323814/183104510-2c8169b2-0c40-4b7f-bb38-1810384870f8.png">

After:

<img width="1058" alt="Screenshot 2022-08-05 at 16 58 33" src="https://user-images.githubusercontent.com/16323814/183104675-724230e8-7766-4a88-a24b-4ddd5c6484c2.png">

Compared to `httpie`:

<img width="1002" alt="Screenshot 2022-08-05 at 16 58 57" src="https://user-images.githubusercontent.com/16323814/183104778-306152e5-f392-4cd6-aec3-b7d8610e0f4a.png">

