### PR TITLE
Pass client_options in execute and executes_with_redirect HTTP client methods

### DIFF
--- a/packages/hurl/src/main.rs
+++ b/packages/hurl/src/main.rs
@@ -168,7 +168,7 @@ fn execute(
             };
             let context_dir = ContextDir::new(current_dir, file_root);
 
-            let options = http::ClientOptions {
+            let client_options = http::ClientOptions {
                 cacert_file,
                 follow_location,
                 max_redirect,
@@ -185,7 +185,7 @@ fn execute(
                 context_dir: context_dir.clone(),
             };
 
-            let mut client = http::Client::init(options);
+            let mut client = http::Client::new(&client_options);
 
             let pre_entry = if cli_options.interactive {
                 cli::interactive::pre_entry
@@ -202,7 +202,7 @@ fn execute(
             let to_entry = cli_options.to_entry;
             let ignore_asserts = cli_options.ignore_asserts;
             let very_verbose = cli_options.very_verbose;
-            let options = RunnerOptions {
+            let runner_options = RunnerOptions {
                 fail_fast,
                 variables,
                 to_entry,
@@ -212,7 +212,14 @@ fn execute(
                 pre_entry,
                 post_entry,
             };
-            let result = runner::run(&hurl_file, filename, &mut client, &options, logger);
+            let result = runner::run(
+                &hurl_file,
+                filename,
+                &mut client,
+                &runner_options,
+                &client_options,
+                logger,
+            );
             if cli_options.progress {
                 logger.test_completed(result.success);
             }

--- a/packages/hurl/tests/runner.rs
+++ b/packages/hurl/tests/runner.rs
@@ -33,11 +33,11 @@ fn test_hurl_file() {
     let content = cli::read_to_string(filename).expect("Something went wrong reading the file");
     let hurl_file = parser::parse_hurl_file(content.as_str()).unwrap();
     let variables = HashMap::new();
-    let options = http::ClientOptions::default();
-    let mut client = http::Client::init(options);
+    let client_options = http::ClientOptions::default();
+    let mut client = http::Client::new(&client_options);
     let logger = Logger::new(false, false, filename, &content);
 
-    let options = RunnerOptions {
+    let runner_options = RunnerOptions {
         fail_fast: false,
         variables,
         to_entry: None,
@@ -48,7 +48,14 @@ fn test_hurl_file() {
         post_entry: || true,
     };
 
-    let _hurl_log = runner::run(&hurl_file, filename, &mut client, &options, &logger);
+    let _hurl_log = runner::run(
+        &hurl_file,
+        filename,
+        &mut client,
+        &runner_options,
+        &client_options,
+        &logger,
+    );
 }
 
 #[cfg(test)]
@@ -114,8 +121,8 @@ fn hello_request() -> Request {
 
 #[test]
 fn test_hello() {
-    let options = http::ClientOptions::default();
-    let mut client = http::Client::init(options);
+    let client_options = http::ClientOptions::default();
+    let mut client = http::Client::new(&client_options);
 
     // We construct a Hurl file ast "by hand", with fake source info.
     // In this particular case, the raw content is empty as the Hurl file hasn't
@@ -162,7 +169,7 @@ fn test_hello() {
         line_terminators: vec![],
     };
     let variables = HashMap::new();
-    let options = RunnerOptions {
+    let runner_options = RunnerOptions {
         fail_fast: true,
         variables,
         to_entry: None,
@@ -173,5 +180,12 @@ fn test_hello() {
         post_entry: || true,
     };
 
-    runner::run(&hurl_file, "filename", &mut client, &options, &logger);
+    runner::run(
+        &hurl_file,
+        "filename",
+        &mut client,
+        &runner_options,
+        &client_options,
+        &logger,
+    );
 }


### PR DESCRIPTION
This is a preliminary PR for #624 .

`ClientOptions` is not saved  anymore in `Client` struct. We pass now an `option: &ClientOptions` parameter in each method of the HTTP client. This will make easier to override a `ClientOption` for each executed request.