### PR TITLE
Log number bytes received and duration.

### DIFF
--- a/integration/tests_ok/option_verbose.err.pattern
+++ b/integration/tests_ok/option_verbose.err.pattern
@@ -17,7 +17,7 @@
 > Accept: */*
 > User-Agent: hurl/~~~
 >
-* Response:
+* Response: (received 12 bytes in ~~~ ms)
 *
 < HTTP/1.0 200 OK
 < Content-Type: text/html; charset=utf-8
@@ -47,7 +47,7 @@
 >
 * Request body:
 *
-* Response:
+* Response: (received 12 bytes in ~~~ ms)
 *
 < HTTP/1.0 200 OK
 < Content-Type: text/html; charset=utf-8

--- a/integration/tests_ok/verbose.err.pattern
+++ b/integration/tests_ok/verbose.err.pattern
@@ -19,7 +19,7 @@
 > Accept: */*
 > User-Agent: hurl/~~~
 >
-* Response:
+* Response: (received 12 bytes in ~~~ ms)
 *
 < HTTP/1.0 200 OK
 < Content-Type: text/html; charset=utf-8

--- a/integration/tests_ok/very_verbose.err.pattern
+++ b/integration/tests_ok/very_verbose.err.pattern
@@ -21,7 +21,7 @@
 >
 * Request body:
 *
-* Response:
+* Response: (received 205 bytes in ~~~ ms)
 *
 < HTTP/1.0 301 MOVED PERMANENTLY
 < Content-Type: text/html; charset=utf-8
@@ -52,7 +52,7 @@
 >
 * Request body:
 *
-* Response:
+* Response: (received 11 bytes in ~~~ ms)
 *
 < HTTP/1.0 200 OK
 < Content-Type: text/html; charset=utf-8
@@ -81,7 +81,7 @@
 >
 * Request body:
 *
-* Response:
+* Response: (received 4 bytes in ~~~ ms)
 *
 < HTTP/1.0 200 OK
 < Content-Type: text/html; charset=ISO-8859-1
@@ -119,7 +119,7 @@
 *     "foo": "bar",
 *     "baz": true
 * }
-* Response:
+* Response: (received 17 bytes in ~~~ ms)
 *
 < HTTP/1.0 200 OK
 < Content-Type: text/html; charset=utf-8
@@ -149,7 +149,7 @@
 >
 * Request body:
 *
-* Response:
+* Response: (received 25992 bytes in ~~~ ms)
 *
 < HTTP/1.0 200 OK
 < Content-Type: image/jpeg
@@ -184,7 +184,7 @@
 >
 * Request body:
 * Bytes <~~~~~...>
-* Response:
+* Response: (received 0 bytes in ~~~ ms)
 *
 < HTTP/1.0 200 OK
 < Content-Type: text/html; charset=utf-8
@@ -215,7 +215,7 @@
 >
 * Request body:
 *
-* Response:
+* Response: (received 4 bytes in ~~~ ms)
 *
 < HTTP/1.0 200 OK
 < Content-Type: text/html; charset=utf-8

--- a/packages/hurl/src/http/client.rs
+++ b/packages/hurl/src/http/client.rs
@@ -261,11 +261,6 @@ impl Client {
                 .header_function(|h| {
                     if let Some(s) = decode_header(h) {
                         if s.starts_with("HTTP/") {
-                            if verbose {
-                                logger.debug_important("Response:");
-                                logger.debug("");
-                                logger.status_version_in(s.trim());
-                            }
                             status_lines.push(s);
                         } else {
                             response_headers.push(s)
@@ -304,6 +299,7 @@ impl Client {
         };
         let headers = self.parse_response_headers(&response_headers);
         let duration = start.elapsed();
+        let lenght = response_body.len();
         self.handle.reset();
 
         let request = Request {
@@ -321,6 +317,22 @@ impl Client {
         };
 
         if verbose {
+            logger.debug_important(
+                format!(
+                    "Response: (received {} bytes in {} ms)",
+                    lenght,
+                    duration.as_millis()
+                )
+                .as_str(),
+            );
+            logger.debug("");
+
+            // FIXME: Explain why there may be multiple status line
+            status_lines
+                .iter()
+                .filter(|s| s.starts_with("HTTP/"))
+                .for_each(|s| logger.status_version_in(s.trim()));
+
             for header in &response.headers {
                 logger.header_in(&header.name, &header.value);
             }


### PR DESCRIPTION
In verbose mode, log the number of bytes received and duration (the HTTP response header Content-Length is not mandatory) so it's always useful to have the number of bytes received.

The logs looks like:

```
* Executing entry 1
*
* Cookie store:
*
* Request:
* GET http://localhost:8000/verbose
*
* Request can be run with the following curl command:
* curl 'http://localhost:8000/verbose'
*
> GET /verbose HTTP/1.1
> Host: localhost:8000
> Accept: */*
> User-Agent: hurl/~~~
>
* Response: (received 12 bytes in 10 ms)
*
< HTTP/1.0 200 OK
< Content-Type: text/html; charset=utf-8
< Content-Length: 12
< Server: Flask Server
< Date: ~~~
<
*
 ```