### PR TITLE
Use only the RunnerOptions struct when running a Hurl File/Entry

### DIFF
--- a/packages/hurl/src/http/client.rs
+++ b/packages/hurl/src/http/client.rs
@@ -45,7 +45,7 @@ pub struct Client {
 
 impl Client {
     /// Creates HTTP Hurl client.
-    pub fn new(options: &ClientOptions) -> Client {
+    pub fn new(cookie_input_file: Option<String>) -> Client {
         let mut h = easy::Easy::new();
 
         // Set handle attributes
@@ -53,14 +53,8 @@ impl Client {
 
         // Activate cookie storage
         // with or without persistence (empty string)
-        h.cookie_file(
-            options
-                .cookie_input_file
-                .clone()
-                .unwrap_or_else(|| "".to_string())
-                .as_str(),
-        )
-        .unwrap();
+        h.cookie_file(cookie_input_file.unwrap_or_else(|| "".to_string()).as_str())
+            .unwrap();
 
         Client {
             handle: Box::new(h),

--- a/packages/hurl/src/main.rs
+++ b/packages/hurl/src/main.rs
@@ -201,25 +201,7 @@ fn execute(
                 user_agent,
                 verbosity,
             };
-            let client_options = http::ClientOptions {
-                cacert_file: runner_options.cacert_file.clone(),
-                follow_location: runner_options.follow_location,
-                max_redirect: runner_options.max_redirect,
-                cookie_input_file: runner_options.cookie_input_file.clone(),
-                proxy: runner_options.proxy.clone(),
-                no_proxy: runner_options.no_proxy.clone(),
-                verbosity: runner_options.verbosity.as_ref().map(|v| match v {
-                    Verbosity::Verbose => http::Verbosity::Verbose,
-                    Verbosity::VeryVerbose => http::Verbosity::VeryVerbose,
-                }),
-                insecure: runner_options.insecure,
-                timeout: runner_options.timeout,
-                connect_timeout: runner_options.connect_timeout,
-                user: runner_options.user.clone(),
-                user_agent: runner_options.user_agent.clone(),
-                compressed: runner_options.compressed,
-            };
-            let mut client = http::Client::new(&client_options);
+            let mut client = http::Client::new(runner_options.cookie_input_file.clone());
 
             let result = runner::run(&hurl_file, filename, &mut client, &runner_options, logger);
             if cli_options.progress {

--- a/packages/hurl/src/main.rs
+++ b/packages/hurl/src/main.rs
@@ -182,7 +182,6 @@ fn execute(
                 cacert_file,
                 compressed,
                 fail_fast,
-                variables,
                 to_entry,
                 user,
                 context_dir,
@@ -202,8 +201,14 @@ fn execute(
                 verbosity,
             };
             let mut client = http::Client::new(runner_options.cookie_input_file.clone());
-
-            let result = runner::run(&hurl_file, filename, &mut client, &runner_options, logger);
+            let result = runner::run(
+                &hurl_file,
+                filename,
+                &mut client,
+                &runner_options,
+                &variables,
+                logger,
+            );
             if cli_options.progress {
                 logger.test_completed(&result);
             }

--- a/packages/hurl/src/runner/core.rs
+++ b/packages/hurl/src/runner/core.rs
@@ -17,6 +17,7 @@
  */
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::time::Duration;
 
 use crate::http;
 use crate::http::ContextDir;
@@ -26,14 +27,61 @@ use super::value::Value;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RunnerOptions {
-    pub fail_fast: bool,
-    pub variables: HashMap<String, Value>,
-    pub to_entry: Option<usize>,
+    pub cacert_file: Option<String>,
+    pub compressed: bool,
+    pub connect_timeout: Duration,
     pub context_dir: ContextDir,
+    pub cookie_input_file: Option<String>,
+    pub fail_fast: bool,
+    pub follow_location: bool,
     pub ignore_asserts: bool,
-    pub very_verbose: bool, // If true, log body response in verbose mode.
-    pub pre_entry: Option<fn(Entry) -> bool>,
+    pub insecure: bool,
+    pub max_redirect: Option<usize>,
+    pub no_proxy: Option<String>,
     pub post_entry: Option<fn() -> bool>,
+    pub pre_entry: Option<fn(Entry) -> bool>,
+    pub proxy: Option<String>,
+    pub timeout: Duration,
+    pub to_entry: Option<usize>,
+    pub user: Option<String>,
+    pub user_agent: Option<String>,
+    pub variables: HashMap<String, Value>,
+    pub verbosity: Option<Verbosity>,
+    pub very_verbose: bool, // If true, log body response in verbose mode.
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Verbosity {
+    Verbose,
+    VeryVerbose,
+}
+
+impl Default for RunnerOptions {
+    fn default() -> Self {
+        RunnerOptions {
+            cacert_file: None,
+            compressed: false,
+            connect_timeout: Duration::from_secs(300),
+            context_dir: Default::default(),
+            cookie_input_file: None,
+            fail_fast: false,
+            follow_location: false,
+            ignore_asserts: false,
+            insecure: false,
+            max_redirect: Some(50),
+            no_proxy: None,
+            post_entry: None,
+            pre_entry: None,
+            proxy: None,
+            timeout: Duration::from_secs(300),
+            to_entry: None,
+            user: None,
+            user_agent: None,
+            variables: Default::default(),
+            verbosity: None,
+            very_verbose: false,
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/packages/hurl/src/runner/core.rs
+++ b/packages/hurl/src/runner/core.rs
@@ -15,7 +15,6 @@
  * limitations under the License.
  *
  */
-use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -45,7 +44,6 @@ pub struct RunnerOptions {
     pub to_entry: Option<usize>,
     pub user: Option<String>,
     pub user_agent: Option<String>,
-    pub variables: HashMap<String, Value>,
     pub verbosity: Option<Verbosity>,
     pub very_verbose: bool, // If true, log body response in verbose mode.
 }
@@ -77,7 +75,6 @@ impl Default for RunnerOptions {
             to_entry: None,
             user: None,
             user_agent: None,
-            variables: Default::default(),
             verbosity: None,
             very_verbose: false,
         }

--- a/packages/hurl/src/runner/entry.rs
+++ b/packages/hurl/src/runner/entry.rs
@@ -19,6 +19,7 @@ use std::collections::HashMap;
 
 use crate::cli::Logger;
 use crate::http;
+use crate::http::ClientOptions;
 use hurl_core::ast::*;
 
 use super::core::*;
@@ -54,25 +55,7 @@ pub fn run(
             }];
         }
     };
-
-    let client_options = http::ClientOptions {
-        cacert_file: runner_options.cacert_file.clone(),
-        follow_location: runner_options.follow_location,
-        max_redirect: runner_options.max_redirect,
-        cookie_input_file: runner_options.cookie_input_file.clone(),
-        proxy: runner_options.proxy.clone(),
-        no_proxy: runner_options.no_proxy.clone(),
-        verbosity: runner_options.verbosity.as_ref().map(|v| match v {
-            Verbosity::Verbose => http::Verbosity::Verbose,
-            Verbosity::VeryVerbose => http::Verbosity::VeryVerbose,
-        }),
-        insecure: runner_options.insecure,
-        timeout: runner_options.timeout,
-        connect_timeout: runner_options.connect_timeout,
-        user: runner_options.user.clone(),
-        user_agent: runner_options.user_agent.clone(),
-        compressed: runner_options.compressed,
-    };
+    let client_options = http::ClientOptions::from(runner_options);
 
     // Experimental features
     // with cookie storage
@@ -205,6 +188,29 @@ pub fn run(
     }
 
     entry_results
+}
+
+impl From<&RunnerOptions> for ClientOptions {
+    fn from(runner_options: &RunnerOptions) -> Self {
+        ClientOptions {
+            cacert_file: runner_options.cacert_file.clone(),
+            follow_location: runner_options.follow_location,
+            max_redirect: runner_options.max_redirect,
+            cookie_input_file: runner_options.cookie_input_file.clone(),
+            proxy: runner_options.proxy.clone(),
+            no_proxy: runner_options.no_proxy.clone(),
+            verbosity: runner_options.verbosity.as_ref().map(|v| match v {
+                Verbosity::Verbose => http::Verbosity::Verbose,
+                Verbosity::VeryVerbose => http::Verbosity::VeryVerbose,
+            }),
+            insecure: runner_options.insecure,
+            timeout: runner_options.timeout,
+            connect_timeout: runner_options.connect_timeout,
+            user: runner_options.user.clone(),
+            user_agent: runner_options.user_agent.clone(),
+            compressed: runner_options.compressed,
+        }
+    }
 }
 
 /// Logs this HTTP `request` spec.

--- a/packages/hurl/src/runner/hurl_file.rs
+++ b/packages/hurl/src/runner/hurl_file.rs
@@ -51,8 +51,7 @@ use super::entry;
 /// let hurl_file = parser::parse_hurl_file(s).unwrap();
 ///
 /// // Create an HTTP client
-/// let client_options = http::ClientOptions::default();
-/// let mut client = http::Client::new(&client_options);
+/// let mut client = http::Client::new(None);
 /// let logger = Logger::new(false, false, filename, s);
 ///
 /// // Define runner options

--- a/packages/hurl/src/runner/hurl_file.rs
+++ b/packages/hurl/src/runner/hurl_file.rs
@@ -21,6 +21,7 @@ use std::time::Instant;
 use crate::cli::Logger;
 use crate::http;
 use crate::runner::entry::get_entry_verbosity;
+use crate::runner::Value;
 use hurl_core::ast::*;
 
 use super::core::*;
@@ -35,12 +36,14 @@ use super::entry;
 /// # Example
 ///
 /// ```
+/// use std::collections::HashMap;
 /// use std::path::PathBuf;
 /// use hurl::cli::Logger;
 /// use hurl_core::parser;
 /// use hurl::http;
 /// use hurl::http::ContextDir;
 /// use hurl::runner;
+/// use hurl::runner::Value;
 ///
 /// // Parse Hurl file
 /// let filename = "sample.hurl";
@@ -60,12 +63,17 @@ use super::entry;
 ///   ..runner::RunnerOptions::default()
 /// };
 ///
+/// // set variables
+/// let mut variables = HashMap::default();
+/// variables.insert("name".to_string(), Value::String("toto".to_string()));
+///
 /// // Run the hurl file
 /// let hurl_results = runner::run(
 ///     &hurl_file,
 ///     filename,
 ///     &mut client,
 ///     &runner_options,
+///     &variables,
 ///     &logger
 /// );
 /// assert!(hurl_results.success);
@@ -75,14 +83,11 @@ pub fn run(
     filename: &str,
     http_client: &mut http::Client,
     runner_options: &RunnerOptions,
+    variables: &HashMap<String, Value>,
     logger: &Logger,
 ) -> HurlResult {
     let mut entries = vec![];
-    let mut variables = HashMap::default();
-
-    for (key, value) in &runner_options.variables {
-        variables.insert(key.to_string(), value.clone());
-    }
+    let mut variables = variables.clone();
 
     let n = if let Some(to_entry) = runner_options.to_entry {
         to_entry

--- a/packages/hurl/src/runner/mod.rs
+++ b/packages/hurl/src/runner/mod.rs
@@ -25,6 +25,7 @@
 
 pub use self::core::{
     AssertResult, CaptureResult, EntryResult, Error, HurlResult, RunnerError, RunnerOptions,
+    Verbosity,
 };
 pub use self::hurl_file::run;
 pub use self::value::Value;

--- a/packages/hurl/tests/libcurl.rs
+++ b/packages/hurl/tests/libcurl.rs
@@ -49,7 +49,7 @@ fn default_get_request(url: &str) -> RequestSpec {
 fn test_hello() {
     let options = ClientOptions::default();
     let context_dir = ContextDir::default();
-    let mut client = Client::new(&options);
+    let mut client = Client::new(None);
     let logger = Logger::new(false, false, "", "");
     let request_spec = default_get_request("http://localhost:8000/hello");
     assert_eq!(
@@ -94,7 +94,7 @@ fn test_hello() {
 fn test_put() {
     let options = ClientOptions::default();
     let context_dir = ContextDir::default();
-    let mut client = Client::new(&options);
+    let mut client = Client::new(None);
     let logger = Logger::new(false, false, "", "");
     let request_spec = RequestSpec {
         method: Method::Put,
@@ -132,7 +132,7 @@ fn test_put() {
 fn test_patch() {
     let options = ClientOptions::default();
     let context_dir = ContextDir::default();
-    let mut client = Client::new(&options);
+    let mut client = Client::new(None);
     let logger = Logger::new(false, false, "", "");
     let request_spec = RequestSpec {
         method: Method::Patch,
@@ -190,7 +190,7 @@ fn test_patch() {
 fn test_custom_headers() {
     let options = ClientOptions::default();
     let context_dir = ContextDir::default();
-    let mut client = Client::new(&options);
+    let mut client = Client::new(None);
     let logger = Logger::new(false, false, "", "");
     let request_spec = RequestSpec {
         method: Method::Get,
@@ -237,7 +237,7 @@ fn test_custom_headers() {
 fn test_querystring_params() {
     let options = ClientOptions::default();
     let context_dir = ContextDir::default();
-    let mut client = Client::new(&options);
+    let mut client = Client::new(None);
     let logger = Logger::new(false, false, "", "");
     let request_spec = RequestSpec {
         method: Method::Get,
@@ -288,7 +288,7 @@ fn test_querystring_params() {
 fn test_form_params() {
     let options = ClientOptions::default();
     let context_dir = ContextDir::default();
-    let mut client = Client::new(&options);
+    let mut client = Client::new(None);
     let logger = Logger::new(false, false, "", "");
     let request_spec = RequestSpec {
         method: Method::Post,
@@ -361,7 +361,7 @@ fn test_redirect() {
     let request_spec = default_get_request("http://localhost:8000/redirect");
     let logger = Logger::new(false, false, "", "");
     let options = ClientOptions::default();
-    let mut client = Client::new(&options);
+    let mut client = Client::new(None);
     let (request, response) = client.execute(&request_spec, &options, &logger).unwrap();
     assert_eq!(request.method, "GET".to_string());
     assert_eq!(request.url, "http://localhost:8000/redirect".to_string());
@@ -384,7 +384,7 @@ fn test_follow_location() {
         ..Default::default()
     };
     let context_dir = ContextDir::default();
-    let mut client = Client::new(&options);
+    let mut client = Client::new(None);
     assert_eq!(options.curl_args(), vec!["-L".to_string()]);
     assert_eq!(
         client.curl_command_line(&request_spec, &context_dir, &options),
@@ -433,7 +433,7 @@ fn test_max_redirect() {
         ..Default::default()
     };
     let context_dir = ContextDir::default();
-    let mut client = Client::new(&options);
+    let mut client = Client::new(None);
     let logger = Logger::new(false, false, "", "");
 
     let request_spec = default_get_request("http://localhost:8000/redirect/15");
@@ -469,7 +469,7 @@ fn test_max_redirect() {
 fn test_multipart_form_data() {
     let options = ClientOptions::default();
     let context_dir = ContextDir::default();
-    let mut client = Client::new(&options);
+    let mut client = Client::new(None);
     let logger = Logger::new(false, false, "", "");
     let request_spec = RequestSpec {
         method: Method::Post,
@@ -534,7 +534,7 @@ fn test_multipart_form_data() {
 fn test_post_bytes() {
     let options = ClientOptions::default();
     let context_dir = ContextDir::default();
-    let mut client = Client::new(&options);
+    let mut client = Client::new(None);
     let logger = Logger::new(false, false, "", "");
     let request_spec = RequestSpec {
         method: Method::Post,
@@ -567,7 +567,7 @@ fn test_post_bytes() {
 fn test_expect() {
     let options = ClientOptions::default();
     let context_dir = ContextDir::default();
-    let mut client = Client::new(&options);
+    let mut client = Client::new(None);
     let logger = Logger::new(false, false, "", "");
     let request_spec = RequestSpec {
         method: Method::Post,
@@ -605,7 +605,7 @@ fn test_basic_authentication() {
         ..Default::default()
     };
     let context_dir = ContextDir::default();
-    let mut client = Client::new(&options);
+    let mut client = Client::new(None);
     let logger = Logger::new(false, false, "", "");
     let request_spec = RequestSpec {
         method: Method::Get,
@@ -633,7 +633,7 @@ fn test_basic_authentication() {
     assert_eq!(response.body, b"You are authenticated".to_vec());
 
     let options = ClientOptions::default();
-    let mut client = Client::new(&options);
+    let mut client = Client::new(None);
     let request_spec = RequestSpec {
         method: Method::Get,
         url: "http://bob%40email.com:secret@localhost:8000/basic-authentication".to_string(),
@@ -665,7 +665,7 @@ fn test_cacert() {
         cacert_file: Some("tests/cert.pem".to_string()),
         ..Default::default()
     };
-    let mut client = Client::new(&options);
+    let mut client = Client::new(None);
     let logger = Logger::new(false, false, "", "");
     let request_spec = default_get_request("https://localhost:8001/hello");
     let (_, response) = client.execute(&request_spec, &options, &logger).unwrap();
@@ -677,7 +677,7 @@ fn test_cacert() {
 #[test]
 fn test_error_could_not_resolve_host() {
     let options = ClientOptions::default();
-    let mut client = Client::new(&options);
+    let mut client = Client::new(None);
     let logger = Logger::new(false, false, "", "");
     let request_spec = default_get_request("http://unknown");
     let error = client
@@ -700,7 +700,7 @@ fn test_error_could_not_resolve_host() {
 #[test]
 fn test_error_fail_to_connect() {
     let options = ClientOptions::default();
-    let mut client = Client::new(&options);
+    let mut client = Client::new(None);
     let logger = Logger::new(false, false, "", "");
     let request_spec = default_get_request("http://localhost:9999");
     let error = client
@@ -723,7 +723,7 @@ fn test_error_fail_to_connect() {
         proxy: Some("localhost:9999".to_string()),
         ..Default::default()
     };
-    let mut client = Client::new(&options);
+    let mut client = Client::new(None);
     let request = default_get_request("http://localhost:8000/hello");
     let error = client.execute(&request, &options, &logger).err().unwrap();
     assert!(matches!(error, HttpError::Libcurl { .. }));
@@ -746,7 +746,7 @@ fn test_error_could_not_resolve_proxy_name() {
         proxy: Some("unknown".to_string()),
         ..Default::default()
     };
-    let mut client = Client::new(&options);
+    let mut client = Client::new(None);
     let logger = Logger::new(false, false, "", "");
     let request_spec = default_get_request("http://localhost:8000/hello");
     let error = client
@@ -769,7 +769,7 @@ fn test_error_could_not_resolve_proxy_name() {
 #[test]
 fn test_error_ssl() {
     let options = ClientOptions::default();
-    let mut client = Client::new(&options);
+    let mut client = Client::new(None);
     let logger = Logger::new(false, false, "", "");
     let request_spec = default_get_request("https://localhost:8001/hello");
     let error = client
@@ -802,7 +802,7 @@ fn test_timeout() {
         timeout: Duration::from_millis(100),
         ..Default::default()
     };
-    let mut client = Client::new(&options);
+    let mut client = Client::new(None);
     let logger = Logger::new(false, false, "", "");
     let request_spec = default_get_request("http://localhost:8000/timeout");
     let error = client
@@ -828,7 +828,7 @@ fn test_accept_encoding() {
         compressed: true,
         ..Default::default()
     };
-    let mut client = Client::new(&options);
+    let mut client = Client::new(None);
     let logger = Logger::new(false, false, "", "");
 
     let request_spec = RequestSpec {
@@ -861,7 +861,7 @@ fn test_connect_timeout() {
         ..Default::default()
     };
     let context_dir = ContextDir::default();
-    let mut client = Client::new(&options);
+    let mut client = Client::new(None);
     let logger = Logger::new(false, false, "", "");
     let request_spec = default_get_request("http://10.0.0.0");
     assert_eq!(
@@ -903,7 +903,7 @@ fn test_connect_timeout() {
 fn test_cookie() {
     let options = ClientOptions::default();
     let context_dir = ContextDir::default();
-    let mut client = Client::new(&options);
+    let mut client = Client::new(None);
     let logger = Logger::new(false, false, "", "");
     let request_spec = RequestSpec {
         method: Method::Get,
@@ -954,7 +954,7 @@ fn test_cookie() {
 fn test_multiple_request_cookies() {
     let options = ClientOptions::default();
     let context_dir = ContextDir::default();
-    let mut client = Client::new(&options);
+    let mut client = Client::new(None);
     let logger = Logger::new(false, false, "", "");
     let request_spec = RequestSpec {
         method: Method::Get,
@@ -997,7 +997,7 @@ fn test_multiple_request_cookies() {
 #[test]
 fn test_cookie_storage() {
     let options = ClientOptions::default();
-    let mut client = Client::new(&options);
+    let mut client = Client::new(None);
     let logger = Logger::new(false, false, "", "");
     let request_spec =
         default_get_request("http://localhost:8000/cookies/set-session-cookie2-valueA");
@@ -1042,7 +1042,7 @@ fn test_cookie_file() {
         ..Default::default()
     };
     let context_dir = ContextDir::default();
-    let mut client = Client::new(&options);
+    let mut client = Client::new(Some("tests/cookies.txt".to_string()));
     let logger = Logger::new(false, false, "", "");
     let request_spec =
         default_get_request("http://localhost:8000/cookies/assert-that-cookie2-is-valueA");
@@ -1077,7 +1077,7 @@ fn test_proxy() {
         ..Default::default()
     };
     let context_dir = ContextDir::default();
-    let mut client = Client::new(&options);
+    let mut client = Client::new(None);
     let logger = Logger::new(false, false, "", "");
     let request_spec = default_get_request("http://localhost:8000/proxy");
     assert_eq!(
@@ -1098,7 +1098,7 @@ fn test_insecure() {
         ..Default::default()
     };
     let context_dir = ContextDir::default();
-    let mut client = Client::new(&options);
+    let mut client = Client::new(None);
     let logger = Logger::new(false, false, "", "");
     assert_eq!(options.curl_args(), vec!["--insecure".to_string()]);
     let request_spec = default_get_request("https://localhost:8001/hello");

--- a/packages/hurl/tests/runner.rs
+++ b/packages/hurl/tests/runner.rs
@@ -33,10 +33,8 @@ fn test_hurl_file() {
     let content = cli::read_to_string(filename).expect("Something went wrong reading the file");
     let hurl_file = parser::parse_hurl_file(content.as_str()).unwrap();
     let variables = HashMap::new();
-    let client_options = http::ClientOptions::default();
-    let mut client = http::Client::new(&client_options);
+    let mut client = http::Client::new(None);
     let logger = Logger::new(false, false, filename, &content);
-
     let runner_options = RunnerOptions {
         variables,
 
@@ -109,8 +107,7 @@ fn hello_request() -> Request {
 
 #[test]
 fn test_hello() {
-    let client_options = http::ClientOptions::default();
-    let mut client = http::Client::new(&client_options);
+    let mut client = http::Client::new(None);
 
     // We construct a Hurl file ast "by hand", with fake source info.
     // In this particular case, the raw content is empty as the Hurl file hasn't

--- a/packages/hurl/tests/runner.rs
+++ b/packages/hurl/tests/runner.rs
@@ -35,13 +35,15 @@ fn test_hurl_file() {
     let variables = HashMap::new();
     let mut client = http::Client::new(None);
     let logger = Logger::new(false, false, filename, &content);
-    let runner_options = RunnerOptions {
-        variables,
-
-        ..RunnerOptions::default()
-    };
-
-    let _hurl_log = runner::run(&hurl_file, filename, &mut client, &runner_options, &logger);
+    let runner_options = RunnerOptions::default();
+    let _hurl_log = runner::run(
+        &hurl_file,
+        filename,
+        &mut client,
+        &runner_options,
+        &variables,
+        &logger,
+    );
 }
 
 #[cfg(test)]
@@ -153,12 +155,14 @@ fn test_hello() {
         }],
         line_terminators: vec![],
     };
+    let variables = HashMap::new();
     let runner_options = RunnerOptions::default();
     runner::run(
         &hurl_file,
         "filename",
         &mut client,
         &runner_options,
+        &variables,
         &logger,
     );
 }

--- a/packages/hurl/tests/runner.rs
+++ b/packages/hurl/tests/runner.rs
@@ -16,15 +16,15 @@
  *
  */
 
+use std::collections::HashMap;
+
 use hurl::cli;
 use hurl::cli::Logger;
 use hurl::http;
-use hurl::http::ContextDir;
 use hurl::runner;
 use hurl::runner::RunnerOptions;
 use hurl_core::ast::*;
 use hurl_core::parser;
-use std::collections::HashMap;
 
 // Can be used for debugging
 #[test]
@@ -38,24 +38,12 @@ fn test_hurl_file() {
     let logger = Logger::new(false, false, filename, &content);
 
     let runner_options = RunnerOptions {
-        fail_fast: false,
         variables,
-        to_entry: None,
-        context_dir: ContextDir::default(),
-        ignore_asserts: false,
-        very_verbose: false,
-        pre_entry: None,
-        post_entry: None,
+
+        ..RunnerOptions::default()
     };
 
-    let _hurl_log = runner::run(
-        &hurl_file,
-        filename,
-        &mut client,
-        &runner_options,
-        &client_options,
-        &logger,
-    );
+    let _hurl_log = runner::run(&hurl_file, filename, &mut client, &runner_options, &logger);
 }
 
 #[cfg(test)]
@@ -168,24 +156,12 @@ fn test_hello() {
         }],
         line_terminators: vec![],
     };
-    let variables = HashMap::new();
-    let runner_options = RunnerOptions {
-        fail_fast: true,
-        variables,
-        to_entry: None,
-        context_dir: ContextDir::default(),
-        ignore_asserts: false,
-        very_verbose: false,
-        pre_entry: None,
-        post_entry: None,
-    };
-
+    let runner_options = RunnerOptions::default();
     runner::run(
         &hurl_file,
         "filename",
         &mut client,
         &runner_options,
-        &client_options,
         &logger,
     );
 }


### PR DESCRIPTION
Currently, the entry is run with 2  options structs:  `RunnerOptions` and `ClientOptions`.

The `ClientOptions` can be overriden in the `[Options]` section.

This PR is about using only the `RunnerOptions` struct when running a hurl_file or an entry.
It contains all the options (including all the HTTP options) and can be overriden by the [Options] section in the Hurl file.
(the `ClientOptions` will only be used when making the HTTP call)

Remarks:
The `[Options]` section currently only belongs to an entry, but in the future, we could have such a section globally for the full Hurl file.
We should be able to use the same `RunnerOptions` struct.

Variables have also been removed from The `RunnerOptions` struct.client constructor.