### PR TITLE
Reduces Hurl release binary size.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,11 @@ members =[
     "packages/hurlfmt",
     "packages/hurl_core",
 ]
+
+
+[profile.release]
+lto = true          # Enable Link Time Optimization
+codegen-units = 1   # Reduce number of codegen units to increase optimizations.
+panic = "abort"     # Abort on panic
+strip = true        # Automatically strip symbols from the binary.
+

--- a/bin/release/release.sh
+++ b/bin/release/release.sh
@@ -4,8 +4,6 @@ set -e
 PATH="$HOME"/.cargo/bin:$PATH
 export PATH
 cargo build --release --verbose --locked
-strip target/release/hurl
-strip target/release/hurlfmt
 
 target/release/hurl --version
 


### PR DESCRIPTION
Set `[profile.release]` flag to reduce Hurl binary size.
Options that affect size have been chosen (and not performance).
On a Mac, the binary size goes from 5.7M to 3.2M.

Source:

- [Make your Rust Binaries TINY!](https://www.youtube.com/watch?v=b2qe3L4BX-Y)
- https://github.com/johnthagen/min-sized-rust/blob/master/Cargo.toml

To note: the build time in release can be slightly bigger( we can see with this PR how the build time is affected).
