### PR TITLE
Make compact help

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,6 +163,7 @@ dependencies = [
  "once_cell",
  "strsim",
  "termcolor",
+ "terminal_size",
 ]
 
 [[package]]
@@ -322,6 +323,27 @@ name = "encoding_index_tests"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
+
+[[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "fastrand"
@@ -508,6 +530,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ea37f355c05dde75b84bba2d767906ad522e97cd9e2eef2be7a4ab7fb442c06"
+
+[[package]]
 name = "itoa"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -576,6 +604,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.0.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
 name = "log"
@@ -818,6 +852,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
+name = "rustix"
+version = "0.35.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbb2fda4666def1433b1b05431ab402e42a1084285477222b72d6c564c417cef"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "rusty-fork"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -931,6 +979,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8440c860cf79def6164e4a0a983bcc2305d82419177a0e0c71930d049e3ac5a1"
+dependencies = [
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]

--- a/packages/hurl/Cargo.toml
+++ b/packages/hurl/Cargo.toml
@@ -21,7 +21,7 @@ atty = "0.2.14"
 base64 = "0.13.0"
 brotli = "3.3.4"
 chrono = { version = "0.4.22", default-features = false, features = ["clock"] }
-clap = { version = "4.0.7", features = ["cargo", "string"] }
+clap = { version = "4.0.7", features = ["cargo", "string", "wrap_help"] }
 colored = "2.0.0"
 curl = "0.4.44"
 encoding = "0.2.33"

--- a/packages/hurl/src/cli/options.rs
+++ b/packages/hurl/src/cli/options.rs
@@ -92,7 +92,7 @@ pub fn app(version: &str) -> Command {
         .arg(
             clap::Arg::new("color")
                 .long("color")
-                .help("Colorize Output")
+                .help("Colorize output")
                 .action(ArgAction::SetTrue)
                 .conflicts_with("no_color")
         )
@@ -135,7 +135,7 @@ pub fn app(version: &str) -> Command {
             clap::Arg::new("file_root")
                 .long("file-root")
                 .value_name("DIR")
-                .help("set root filesystem to import file in hurl (default is current directory)")
+                .help("Set root filesystem to import file (default is current directory)")
                 .num_args(1)
         )
         .arg(
@@ -149,7 +149,7 @@ pub fn app(version: &str) -> Command {
             clap::Arg::new("glob")
                 .long("glob")
                 .value_name("GLOB")
-                .help("Specify input files that match the given blob. Multiple glob flags may be used.")
+                .help("Specify input files that match the given blob. Multiple glob flags may be used")
                 .action(ArgAction::Append)
                 .number_of_values(1)
         )
@@ -163,7 +163,7 @@ pub fn app(version: &str) -> Command {
         .arg(
             clap::Arg::new("ignore_asserts")
                 .long("ignore-asserts")
-                .help("Ignore asserts defined in the Hurl file.")
+                .help("Ignore asserts defined in the Hurl file")
                 .action(ArgAction::SetTrue)
         )
         .arg(
@@ -183,7 +183,7 @@ pub fn app(version: &str) -> Command {
         .arg(
             clap::Arg::new("json")
                 .long("json")
-                .help("Output each hurl file result to JSON")
+                .help("Output each Hurl file result to JSON")
                 .conflicts_with("no_output")
                 .action(ArgAction::SetTrue)
         )
@@ -207,14 +207,14 @@ pub fn app(version: &str) -> Command {
         .arg(
             clap::Arg::new("no_color")
                 .long("no-color")
-                .help("Do not colorize Output")
+                .help("Do not colorize output")
                 .conflicts_with("color")
                 .action(ArgAction::SetTrue)
         )
         .arg(
             clap::Arg::new("no_output")
                 .long("no-output")
-                .help("Suppress output. By default, Hurl outputs the body of the last response.")
+                .help("Suppress output. By default, Hurl outputs the body of the last response")
                 .conflicts_with("json")
                 .action(ArgAction::SetTrue)
         )
@@ -252,20 +252,20 @@ pub fn app(version: &str) -> Command {
             clap::Arg::new("report_html")
                 .long("report-html")
                 .value_name("DIR")
-                .help("Generate html report to dir")
+                .help("Generate HTML report to dir")
                 .num_args(1)
         )
         .arg(
             clap::Arg::new("test")
                 .long("test")
-                .help("Activate test mode.")
+                .help("Activate test mode")
                 .action(ArgAction::SetTrue)
         )
         .arg(
             clap::Arg::new("to_entry")
                 .long("to-entry")
                 .value_name("ENTRY_NUMBER")
-                .help("Execute hurl file to ENTRY_NUMBER (starting at 1)")
+                .help("Execute Hurl file to ENTRY_NUMBER (starting at 1)")
                 .conflicts_with("interactive")
                 .num_args(1)
         )
@@ -274,7 +274,7 @@ pub fn app(version: &str) -> Command {
                 .short('u')
                 .long("user")
                 .value_name("user:password")
-                .help("Add basic Authentication header to each request.")
+                .help("Add basic Authentication header to each request")
                 .num_args(1)
         )
         .arg(
@@ -282,7 +282,7 @@ pub fn app(version: &str) -> Command {
                 .short('A')
                 .long("user-agent")
                 .value_name("name")
-                .help("Specify the User-Agent string to send to the HTTP server.")
+                .help("Specify the User-Agent string to send to the HTTP server")
                 .num_args(1)
         )
         .arg(
@@ -311,7 +311,7 @@ pub fn app(version: &str) -> Command {
         .arg(
             clap::Arg::new("very_verbose")
                 .long("very-verbose")
-                .help("Turn on verbose output, uncluding HTTP response")
+                .help("Turn on verbose output, including HTTP response")
                 .action(ArgAction::SetTrue)
         )
 }

--- a/packages/hurlfmt/Cargo.toml
+++ b/packages/hurlfmt/Cargo.toml
@@ -16,7 +16,7 @@ strict = []
 [dependencies]
 atty = "0.2.14"
 base64 = "0.13.0"
-clap = { version = "4.0.7", features = ["cargo"] }
+clap = { version = "4.0.7", features = ["cargo", "wrap_help"] }
 colored = "2.0.0"
 hurl_core = { version = "1.8.0-SNAPSHOT", path = "../hurl_core" }
 regex = "1.6.0"


### PR DESCRIPTION
Before:


```
hurl 1.7.0 libcurl/7.77.0 (SecureTransport) LibreSSL/2.8.3 zlib/1.2.11 nghttp2/1.42.0
Run hurl FILE(s) or standard input

USAGE:
    hurl [OPTIONS] [--] [INPUT]...

ARGS:
    <INPUT>...    Sets the input file to use

OPTIONS:
        --cacert <FILE>
            CA certificate to verify peer against (PEM format)

        --color
            Colorize Output

        --compressed
            Request compressed response (using deflate or gzip)

        --connect-timeout <SECONDS>
            Maximum time allowed for connection

    -b, --cookie <FILE>
            Read cookies from FILE

    -c, --cookie-jar <FILE>
            Write cookies to FILE after running the session (only for one session)

        --fail-at-end
            Fail at end

        --file-root <DIR>
            set root filesystem to import file in hurl (default is current directory)

    -L, --location
            Follow redirects

        --glob <GLOB>
            Specify input files that match the given blob. Multiple glob flags may be used.

    -i, --include
            Include the HTTP headers in the output

        --ignore-asserts
            Ignore asserts defined in the Hurl file.

    -k, --insecure
            Allow insecure SSL connections

        --interactive
            Turn on interactive mode

        --json
            Output each hurl file result to JSON

        --max-redirs <NUM>
            Maximum number of redirects allowed

    -m, --max-time <NUM>
            Maximum time allowed for the transfer

        --no-color
            Do not colorize Output

        --no-output
            Suppress output. By default, Hurl outputs the body of the last response.

        --noproxy <HOST(S)>
            List of hosts which do not use proxy

    -o, --output <FILE>
            Write to FILE instead of stdout

        --progress
            Print filename and status for each test (stderr) - deprecated use --test

    -x, --proxy <[PROTOCOL://]HOST[:PORT]>
            Use proxy on given protocol/host/port

        --report-junit <FILE>
            Write a Junit XML report to the given file

        --report-html <DIR>
            Generate html report to dir

        --summary
            Print test metrics at the end of the run (stderr) - deprecated use --test

        --test
            Activate test mode.

        --to-entry <ENTRY_NUMBER>
            Execute hurl file to ENTRY_NUMBER (starting at 1)

    -u, --user <user:password>
            Add basic Authentication header to each request.

    -A, --user-agent <name>
            Specify the User-Agent string to send to the HTTP server.

        --variable <NAME=VALUE>
            Define a variable

        --variables-file <FILE>
            Define a properties file in which you define your variables

    -v, --verbose
            Turn on verbose output

        --very-verbose
            Turn on verbose output, uncluding HTTP response

    -h, --help
            Print help information

    -V, --version
            Print version information
```

After:

```
Run hurl FILE(s) or standard input

Usage: hurl [OPTIONS] [INPUT]...

Arguments:
  [INPUT]...  Sets the input file to use

Options:
      --cacert <FILE>                     CA certificate to verify peer against (PEM format)
      --color                             Colorize output
      --compressed                        Request compressed response (using deflate or gzip)
      --connect-timeout <SECONDS>         Maximum time allowed for connection
  -b, --cookie <FILE>                     Read cookies from FILE
  -c, --cookie-jar <FILE>                 Write cookies to FILE after running the session (only for one session)
      --fail-at-end                       Fail at end
      --file-root <DIR>                   Set root filesystem to import file (default is current directory)
  -L, --location                          Follow redirects
      --glob <GLOB>                       Specify input files that match the given blob. Multiple glob flags may be used
  -i, --include                           Include the HTTP headers in the output
      --ignore-asserts                    Ignore asserts defined in the Hurl file
  -k, --insecure                          Allow insecure SSL connections
      --interactive                       Turn on interactive mode
      --json                              Output each Hurl file result to JSON
      --max-redirs <NUM>                  Maximum number of redirects allowed
  -m, --max-time <NUM>                    Maximum time allowed for the transfer
      --no-color                          Do not colorize output
      --no-output                         Suppress output. By default, Hurl outputs the body of the last response
      --noproxy <HOST(S)>                 List of hosts which do not use proxy
  -o, --output <FILE>                     Write to FILE instead of stdout
  -x, --proxy <[PROTOCOL://]HOST[:PORT]>  Use proxy on given protocol/host/port
      --report-junit <FILE>               Write a Junit XML report to the given file
      --report-html <DIR>                 Generate HTML report to dir
      --test                              Activate test mode
      --to-entry <ENTRY_NUMBER>           Execute Hurl file to ENTRY_NUMBER (starting at 1)
  -u, --user <user:password>              Add basic Authentication header to each request
  -A, --user-agent <name>                 Specify the User-Agent string to send to the HTTP server
      --variable <NAME=VALUE>             Define a variable
      --variables-file <FILE>             Define a properties file in which you define your variables
  -v, --verbose                           Turn on verbose output
      --very-verbose                      Turn on verbose output, including HTTP response
  -h, --help                              Print help information
  -V, --version                           Print version information
```



Fixes #861.