### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -357,7 +357,7 @@ Changes:
 
 * Add Hurl File JSON export  [#65](https://github.com/Orange-OpenSource/hurl/issues/65)
 
-* Support wildcard value in implicit status code reponse [#55](https://github.com/Orange-OpenSource/hurl/issues/55)
+* Support wildcard value in implicit status code response [#55](https://github.com/Orange-OpenSource/hurl/issues/55)
 
 
 Bugs Fixes:

--- a/bin/windows/hurl.nsi
+++ b/bin/windows/hurl.nsi
@@ -63,7 +63,7 @@ SectionGroup "executables"
     SendMessage ${HWND_BROADCAST} ${WM_WININICHANGE} 0 "STR:Environment" /TIMEOUT=5000
     ; Write the uninstall
     WriteUninstaller "$INSTDIR\uninstall.exe"
-    ; Write windows uninstall panel informations
+    ; Write windows uninstall panel information
     ${GetSize} "$INSTDIR" "/S=0K" $0 $1 $2
     IntFmt $0 "0x%08X" $0
     WriteRegStr HKLM "${UNINSTALLPANELKEY}" "DisplayName" "Hurl"

--- a/contrib/windows/windows_package_managers/scoop/README.md
+++ b/contrib/windows/windows_package_managers/scoop/README.md
@@ -2,4 +2,4 @@ Official hurl bucket url [#289](https://github.com/Orange-OpenSource/hurl/issues
 - https://github.com/ScoopInstaller/Main/blob/master/bucket/hurl.json
 
 Update manifest command:
-- The update is automatically commited by scoop scheduled github actions
+- The update is automatically committed by scoop scheduled GitHub Actions.

--- a/docs/asserting-response.md
+++ b/docs/asserting-response.md
@@ -267,7 +267,7 @@ GET http://localhost:8000/cookies/set
 HTTP/1.0 200
 
 # Explicit check of Set-Cookie header value. If the attributes are
-# not in this excat order, this assert will fail. 
+# not in this exact order, this assert will fail. 
 Set-Cookie: LSID=DQAAAKEaem_vYg; Expires=Wed, 13 Jan 2021 22:23:01 GMT; Secure; HttpOnly; Path=/accounts; SameSite=Lax;
 Set-Cookie: HSID=AYQEVnDKrdst; Domain=.localhost; Expires=Wed, 13 Jan 2021 22:23:01 GMT; HttpOnly; Path=/
 Set-Cookie: SSID=Ap4PGTEq; Domain=.localhost; Expires=Wed, 13 Jan 2021 22:23:01 GMT; Secure; HttpOnly; Path=/

--- a/docs/tutorial/adding-asserts.md
+++ b/docs/tutorial/adding-asserts.md
@@ -198,7 +198,7 @@ while the explicit one allows you to use other [predicates] (like `contains`, `s
 GET http://localhost:8080
 
 HTTP/1.1 200
-# Implicitely testing response headers:
+# Implicitly testing response headers:
 Content-Type: text/html;charset=UTF-8
 [Asserts]
 xpath "string(//head/title)" == "Welcome to Quiz!"

--- a/docs/tutorial/your-first-hurl-file.md
+++ b/docs/tutorial/your-first-hurl-file.md
@@ -59,7 +59,7 @@ the jar application from <https://github.com/jcamiel/quiz/releases/latest> and r
 $ java -jar quiz-0.0.2.jar 
 ```
 
-Either you're using the Docker images ot the jar app, you can open a browser and test the quiz application by
+Either you're using the Docker images or the jar app, you can open a browser and test the quiz application by
 typing the url <http://localhost:8080>:
 
 <div>

--- a/integration/report.py
+++ b/integration/report.py
@@ -13,7 +13,7 @@ from typing import List, Dict
 
 
 def get_files(glob_expr: str) -> List[str]:
-    """return sorted list of files matching a glob expresion
+    """return sorted list of files matching a glob expression
 
     Arguments:
       glob_expr -- the input file glob expression

--- a/integration/test_hurl.py
+++ b/integration/test_hurl.py
@@ -12,7 +12,7 @@ import argparse
 
 
 def decode_string(encoded: bytes) -> str:
-    """Decodes bytes to string from infering encoding."""
+    """Decodes bytes to string from inferring encoding."""
     if encoded.startswith(codecs.BOM_UTF8):
         return encoded.decode("utf-8-sig")
     elif encoded.startswith(codecs.BOM_UTF16):

--- a/packages/hurl/src/http/client.rs
+++ b/packages/hurl/src/http/client.rs
@@ -293,7 +293,7 @@ impl Client {
         };
         let headers = self.parse_response_headers(&response_headers);
         let duration = start.elapsed();
-        let lenght = response_body.len();
+        let length = response_body.len();
         self.handle.reset();
 
         let request = Request {
@@ -314,7 +314,7 @@ impl Client {
             logger.debug_important(
                 format!(
                     "Response: (received {} bytes in {} ms)",
-                    lenght,
+                    length,
                     duration.as_millis()
                 )
                 .as_str(),
@@ -437,7 +437,7 @@ impl Client {
         }
     }
 
-    /// Sets multipart form datas.
+    /// Sets multipart form data.
     fn set_multipart(&mut self, params: &[MultipartParam]) {
         if !params.is_empty() {
             let mut form = easy::Form::new();

--- a/packages/hurl/src/jsonpath/parser/combinators.rs
+++ b/packages/hurl/src/jsonpath/parser/combinators.rs
@@ -47,7 +47,7 @@ pub fn zero_or_more<'a, T>(f: ParseFunc<'a, T>, p: &mut Reader) -> ParseResult<'
 }
 
 // return the last error when no default error is specified
-// tipically this should be recoverable
+// typically this should be recoverable
 pub fn choice<'a, T>(fs: Vec<ParseFunc<'a, T>>, p: &mut Reader) -> ParseResult<'a, T> {
     match fs.get(0) {
         None => panic!("You can call choice with an empty vector of choice"),

--- a/packages/hurl/src/report/junit/mod.rs
+++ b/packages/hurl/src/report/junit/mod.rs
@@ -20,7 +20,7 @@
 // XML JUnit report
 //
 // It does not really seem to be used nowadays
-// The link bellow seems the most "official" spec
+// The link below seems the most "official" spec
 // https://www.ibm.com/docs/fr/developer-for-zos/9.1.1?topic=formats-junit-xml-format
 //
 // One Hurl file will result into one junit <testcase>.

--- a/packages/hurl_core/src/parser/combinators.rs
+++ b/packages/hurl_core/src/parser/combinators.rs
@@ -110,7 +110,7 @@ pub fn one_or_more<'a, T>(f: ParseFunc<'a, T>, reader: &mut Reader) -> ParseResu
             }
         }
         Err(Error { pos, inner, .. }) => {
-            // if zero occurence => should fail?
+            // if zero occurrence => should fail?
             Err(Error {
                 pos,
                 recoverable: false,
@@ -122,7 +122,7 @@ pub fn one_or_more<'a, T>(f: ParseFunc<'a, T>, reader: &mut Reader) -> ParseResu
 
 pub fn choice<'a, T>(fs: Vec<ParseFunc<'a, T>>, reader: &mut Reader) -> ParseResult<'a, T> {
     // return the last error when no default error is specified
-    // tipically this should be recoverable
+    // typically this should be recoverable
     match fs.get(0) {
         None => panic!("You can call choice with an empty vector of choice"),
         Some(f) => {

--- a/packages/hurlfmt/src/linter/core.rs
+++ b/packages/hurlfmt/src/linter/core.rs
@@ -25,8 +25,8 @@ pub struct Error {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum LinterError {
-    UnneccessarySpace {},
-    UnneccessaryJsonEncoding {},
+    UnnecessarySpace {},
+    UnnecessaryJsonEncoding {},
     OneSpace {},
 }
 

--- a/packages/hurlfmt/src/linter/error.rs
+++ b/packages/hurlfmt/src/linter/error.rs
@@ -33,16 +33,16 @@ impl Error for linter::Error {
 
     fn description(&self) -> String {
         match self.inner {
-            LinterError::UnneccessarySpace { .. } => "Unnecessary space".to_string(),
-            LinterError::UnneccessaryJsonEncoding {} => "Unnecessary json encoding".to_string(),
+            LinterError::UnnecessarySpace { .. } => "Unnecessary space".to_string(),
+            LinterError::UnnecessaryJsonEncoding {} => "Unnecessary json encoding".to_string(),
             LinterError::OneSpace {} => "One space ".to_string(),
         }
     }
 
     fn fixme(&self) -> String {
         match self.inner {
-            LinterError::UnneccessarySpace { .. } => "Remove space".to_string(),
-            LinterError::UnneccessaryJsonEncoding {} => "Use Simple String".to_string(),
+            LinterError::UnnecessarySpace { .. } => "Remove space".to_string(),
+            LinterError::UnnecessaryJsonEncoding {} => "Use Simple String".to_string(),
             LinterError::OneSpace {} => "Use only one space".to_string(),
         }
     }

--- a/packages/hurlfmt/src/linter/rules.rs
+++ b/packages/hurlfmt/src/linter/rules.rs
@@ -57,7 +57,7 @@ impl Lintable<Request> for Request {
         if !self.space0.value.is_empty() {
             errors.push(Error {
                 source_info: self.clone().space0.source_info,
-                inner: LinterError::UnneccessarySpace {},
+                inner: LinterError::UnnecessarySpace {},
             });
         }
         if self.space1.value != " " {
@@ -107,7 +107,7 @@ impl Lintable<Response> for Response {
         if !self.space0.value.is_empty() {
             errors.push(Error {
                 source_info: self.clone().space0.source_info,
-                inner: LinterError::UnneccessarySpace {},
+                inner: LinterError::UnnecessarySpace {},
             });
         }
         errors
@@ -746,7 +746,7 @@ impl Lintable<LineTerminator> for LineTerminator {
                 if !self.space0.value.is_empty() {
                     errors.push(Error {
                         source_info: self.clone().space0.source_info,
-                        inner: LinterError::UnneccessarySpace {},
+                        inner: LinterError::UnnecessarySpace {},
                     });
                 }
             }


### PR DESCRIPTION
Found via `codespell -S contrib,target -L crate,asser,te`