### PR TITLE
Add curl logs

### DIFF
--- a/integration/test_hurl.py
+++ b/integration/test_hurl.py
@@ -141,6 +141,12 @@ def test(hurl_file: str):
     if os.path.exists(f):
         expected = open(f, encoding="utf-8").read()
         actual = decode_string(result.stderr)
+
+        # curl debug logs are too dependent on the context, so we filter
+        # them and not take them into account for testing differences.
+        expected = remove_curl_debug_lines(expected)
+        actual = remove_curl_debug_lines(actual)
+
         expected_lines = expected.split("\n")
         expected_pattern_lines = [parse_pattern(line) for line in expected_lines]
         actual_lines = re.split(r"\r?\n", actual)
@@ -196,6 +202,13 @@ def parse_pattern(s: str) -> str:
     s = re.sub("~+", ".*", s)
     s = "^" + s + "$"
     return s
+
+
+def remove_curl_debug_lines(text: str) -> str:
+    """Removes curl debug logs from text and returns the new text."""
+    lines = text.split("\n")
+    lines = [line for line in lines if not line.startswith("**")]
+    return "\n".join(lines)
 
 
 def main():

--- a/integration/tests_ok/option_verbose.err.pattern
+++ b/integration/tests_ok/option_verbose.err.pattern
@@ -40,6 +40,9 @@
 * Request can be run with the following curl command:
 * curl 'http://localhost:8000/hello'
 *
+** Hostname localhost was found in DNS cache
+**   Trying 127.0.0.1:8000...
+** Connected to localhost (127.0.0.1) port 8000 (#3)
 > GET /hello HTTP/1.1
 > Host: localhost:8000
 > Accept: */*
@@ -47,6 +50,9 @@
 >
 * Request body:
 *
+** Mark bundle as not supporting multiuse
+** HTTP 1.0, assume close after body
+** Closing connection 3
 * Response: (received 12 bytes in ~~~ ms)
 *
 < HTTP/1.0 200 OK

--- a/integration/tests_ok/very_verbose.err.pattern
+++ b/integration/tests_ok/very_verbose.err.pattern
@@ -16,6 +16,8 @@
 * Request can be run with the following curl command:
 * curl 'http://localhost:8000/very-verbose/redirect' -L
 *
+**   Trying 127.0.0.1:8000...
+** Connected to localhost (127.0.0.1) port 8000 (#0)
 > GET /very-verbose/redirect HTTP/1.1
 > Host: localhost:8000
 > Accept: */*
@@ -23,6 +25,9 @@
 >
 * Request body:
 *
+** Mark bundle as not supporting multiuse
+** HTTP 1.0, assume close after body
+** Closing connection 0
 * Response: (received 205 bytes in ~~~ ms)
 *
 < HTTP/1.0 301 MOVED PERMANENTLY
@@ -47,6 +52,9 @@
 *
 * => Redirect to http://localhost:8000/very-verbose/redirected
 *
+** Hostname localhost was found in DNS cache
+**   Trying 127.0.0.1:8000...
+** Connected to localhost (127.0.0.1) port 8000 (#1)
 > GET /very-verbose/redirected HTTP/1.1
 > Host: localhost:8000
 > Accept: */*
@@ -54,6 +62,9 @@
 >
 * Request body:
 *
+** Mark bundle as not supporting multiuse
+** HTTP 1.0, assume close after body
+** Closing connection 1
 * Response: (received 11 bytes in ~~~ ms)
 *
 < HTTP/1.0 200 OK
@@ -76,6 +87,9 @@
 * Request can be run with the following curl command:
 * curl 'http://localhost:8000/very-verbose/encoding/latin1' -L
 *
+** Hostname localhost was found in DNS cache
+**   Trying 127.0.0.1:8000...
+** Connected to localhost (127.0.0.1) port 8000 (#2)
 > GET /very-verbose/encoding/latin1 HTTP/1.1
 > Host: localhost:8000
 > Accept: */*
@@ -83,6 +97,9 @@
 >
 * Request body:
 *
+** Mark bundle as not supporting multiuse
+** HTTP 1.0, assume close after body
+** Closing connection 2
 * Response: (received 4 bytes in ~~~ ms)
 *
 < HTTP/1.0 200 OK
@@ -108,6 +125,9 @@
 * Request can be run with the following curl command:
 * curl 'http://localhost:8000/very-verbose/compressed/brotli' -H 'Accept-Encoding: brotli' -H 'Content-Type: application/json' --data $'{\n    "foo": "bar",\n    "baz": true\n}' -L
 *
+** Hostname localhost was found in DNS cache
+**   Trying 127.0.0.1:8000...
+** Connected to localhost (127.0.0.1) port 8000 (#3)
 > POST /very-verbose/compressed/brotli HTTP/1.1
 > Host: localhost:8000
 > Accept: */*
@@ -121,6 +141,10 @@
 *     "foo": "bar",
 *     "baz": true
 * }
+** We are completely uploaded and fine
+** Mark bundle as not supporting multiuse
+** HTTP 1.0, assume close after body
+** Closing connection 3
 * Response: (received 17 bytes in ~~~ ms)
 *
 < HTTP/1.0 200 OK
@@ -144,6 +168,9 @@
 * Request can be run with the following curl command:
 * curl 'http://localhost:8000/very-verbose/cat' -L
 *
+** Hostname localhost was found in DNS cache
+**   Trying 127.0.0.1:8000...
+** Connected to localhost (127.0.0.1) port 8000 (#4)
 > GET /very-verbose/cat HTTP/1.1
 > Host: localhost:8000
 > Accept: */*
@@ -151,6 +178,9 @@
 >
 * Request body:
 *
+** Mark bundle as not supporting multiuse
+** HTTP 1.0, assume close after body
+** Closing connection 4
 * Response: (received 25992 bytes in ~~~ ms)
 *
 < HTTP/1.0 200 OK
@@ -177,6 +207,9 @@
 * Request can be run with the following curl command:
 * curl 'http://localhost:8000/very-verbose/update-cat' -F 'cat=@tests_ok~cat.jpg;type=image/jpeg' -L
 *
+** Hostname localhost was found in DNS cache
+**   Trying 127.0.0.1:8000...
+** Connected to localhost (127.0.0.1) port 8000 (#5)
 > POST /very-verbose/update-cat HTTP/1.1
 > Host: localhost:8000
 > Accept: */*
@@ -186,6 +219,10 @@
 >
 * Request body:
 * Bytes <~~~~~...>
+** We are completely uploaded and fine
+** Mark bundle as not supporting multiuse
+** HTTP 1.0, assume close after body
+** Closing connection 5
 * Response: (received 0 bytes in ~~~ ms)
 *
 < HTTP/1.0 200 OK
@@ -209,6 +246,9 @@
 * Request can be run with the following curl command:
 * curl 'http://localhost:8000/very-verbose/done' -H 'x-foo: bar' -L
 *
+** Hostname localhost was found in DNS cache
+**   Trying 127.0.0.1:8000...
+** Connected to localhost (127.0.0.1) port 8000 (#6)
 > GET /very-verbose/done HTTP/1.1
 > Host: localhost:8000
 > Accept: */*
@@ -217,6 +257,9 @@
 >
 * Request body:
 *
+** Mark bundle as not supporting multiuse
+** HTTP 1.0, assume close after body
+** Closing connection 6
 * Response: (received 4 bytes in ~~~ ms)
 *
 < HTTP/1.0 200 OK

--- a/packages/hurl/src/http/client.rs
+++ b/packages/hurl/src/http/client.rs
@@ -254,6 +254,16 @@ impl Client {
                             }
                         }
                     }
+                    // Curl debug logs
+                    easy::InfoType::Text => {
+                        let len = data.len();
+                        if very_verbose && len > 0 {
+                            let text = str::from_utf8(&data[..len - 1]);
+                            if let Ok(text) = text {
+                                logger.debug_curl(text);
+                            }
+                        }
+                    }
                     _ => {}
                 })
                 .unwrap();

--- a/packages/hurl/src/runner/entry.rs
+++ b/packages/hurl/src/runner/entry.rs
@@ -80,12 +80,11 @@ pub fn run(
     }
     logger.debug("");
     log_request_spec(&http_request, logger);
+
     logger.debug("Request can be run with the following curl command:");
-    logger.debug(
-        http_client
-            .curl_command_line(&http_request, &runner_options.context_dir, &client_options)
-            .as_str(),
-    );
+    let curl_command =
+        http_client.curl_command_line(&http_request, &runner_options.context_dir, &client_options);
+    logger.debug(curl_command.as_str());
     logger.debug("");
 
     // Run the HTTP requests (optionally follow redirection)

--- a/packages/hurl/src/util/logger.rs
+++ b/packages/hurl/src/util/logger.rs
@@ -83,8 +83,9 @@ impl BaseLogger {
 pub struct Logger<'a> {
     pub info: fn(&str),
     pub debug: fn(&str),
-    pub debug_important: fn(&str),
+    pub debug_curl: fn(&str),
     pub debug_error: fn(&str, &str, &dyn Error),
+    pub debug_important: fn(&str),
     pub warning: fn(&str),
     pub error: fn(&str),
     pub error_rich: fn(&str, &str, &dyn Error),
@@ -108,8 +109,9 @@ impl<'a> Logger<'a> {
             (true, true) => Logger {
                 info: log_info,
                 debug: log_debug,
-                debug_important: log_debug_important,
+                debug_curl: log_debug_curl,
                 debug_error: log_debug_error,
+                debug_important: log_debug_important,
                 warning: log_warning,
                 error: log_error,
                 error_rich: log_error_rich,
@@ -128,8 +130,9 @@ impl<'a> Logger<'a> {
             (false, true) => Logger {
                 info: log_info,
                 debug: log_debug_no_color,
-                debug_important: log_debug_no_color,
+                debug_curl: log_debug_curl_no_color,
                 debug_error: log_debug_error_no_color,
+                debug_important: log_debug_no_color,
                 warning: log_warning_no_color,
                 error: log_error_no_color,
                 error_rich: log_error_rich_no_color,
@@ -148,8 +151,9 @@ impl<'a> Logger<'a> {
             (true, false) => Logger {
                 info: log_info,
                 debug: |_| {},
-                debug_important: |_| {},
+                debug_curl: |_| {},
                 debug_error: |_, _, _| {},
+                debug_important: |_| {},
                 warning: log_warning,
                 error: log_error,
                 error_rich: log_error_rich,
@@ -168,8 +172,9 @@ impl<'a> Logger<'a> {
             (false, false) => Logger {
                 info: log_info,
                 debug: |_| {},
-                debug_important: |_| {},
+                debug_curl: |_| {},
                 debug_error: |_, _, _| {},
+                debug_important: |_| {},
                 warning: log_warning_no_color,
                 error: log_error_no_color,
                 error_rich: log_error_rich_no_color,
@@ -194,6 +199,10 @@ impl<'a> Logger<'a> {
 
     pub fn debug(&self, message: &str) {
         (self.debug)(message)
+    }
+
+    pub fn debug_curl(&self, message: &str) {
+        (self.debug_curl)(message)
     }
 
     pub fn debug_important(&self, message: &str) {
@@ -262,6 +271,22 @@ fn log_debug_no_color(message: &str) {
         eprintln!("*");
     } else {
         eprintln!("* {}", message);
+    }
+}
+
+fn log_debug_curl(message: &str) {
+    if message.is_empty() {
+        eprintln!("{}", "**".blue().bold());
+    } else {
+        eprintln!("{} {}", "**".blue().bold(), message.green());
+    }
+}
+
+fn log_debug_curl_no_color(message: &str) {
+    if message.is_empty() {
+        eprintln!("**");
+    } else {
+        eprintln!("** {}", message);
     }
 }
 


### PR DESCRIPTION
We ouput curl logs with `--very-verbose` option.

Fo instance:

`$ echo 'GET https://hurl.dev' | hurl --very-verbose --no-output`

Output:

![curl-logs](https://user-images.githubusercontent.com/16323814/196785647-c7e86029-09cf-43cb-86ef-a48e798fe97f.png)

We ignore curl logs (lines thats start with **) in integration tests.

Closes #899.
