### PR TITLE
Hurl is now available on FreeBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Table of Contents
          * [macOS](#macos)
             * [Homebrew](#homebrew)
             * [MacPorts](#macports)
+         * [FreeBSD](#freebsd)
          * [Windows](#windows)
             * [Zip File](#zip-file)
             * [Installer](#installer)
@@ -882,7 +883,11 @@ $ brew install hurl
 ```shell
 $ sudo port install hurl
 ```
+#### FreeBSD
 
+```shell
+$ sudo pkg install hurl
+```
 
 ### Windows
 


### PR DESCRIPTION
Update project description to indicate how to install Hurd on FreeBSD