### PR TITLE
Change Template struct using delimiter: Option char field instead of quotes: bool.

### DIFF
--- a/packages/hurl/src/runner/capture.rs
+++ b/packages/hurl/src/runner/capture.rs
@@ -181,7 +181,7 @@ pub mod tests {
                 value: QueryValue::Xpath {
                     space0: whitespace.clone(),
                     expr: Template {
-                        quotes: true,
+                        delimiter: Some('"'),
                         elements: vec![TemplateElement::String {
                             value: "//user".to_string(),
                             encoded: "//user".to_string(),

--- a/packages/hurl/src/runner/filter.rs
+++ b/packages/hurl/src/runner/filter.rs
@@ -245,7 +245,7 @@ pub mod tests {
             value: FilterValue::Regex {
                 space0: whitespace,
                 value: RegexValue::Template(Template {
-                    quotes: false,
+                    delimiter: None,
                     elements: vec![TemplateElement::String {
                         value: "Hello (.*)!".to_string(),
                         encoded: "Hello (.*)!".to_string(),
@@ -286,7 +286,7 @@ pub mod tests {
             value: FilterValue::Regex {
                 space0: whitespace,
                 value: RegexValue::Template(Template {
-                    quotes: false,
+                    delimiter: None,
                     elements: vec![TemplateElement::String {
                         value: "???".to_string(),
                         encoded: "???".to_string(),

--- a/packages/hurl/src/runner/json.rs
+++ b/packages/hurl/src/runner/json.rs
@@ -165,7 +165,7 @@ mod tests {
     pub fn json_hello_world_value() -> JsonValue {
         // "hello\u0020{{name}}!"
         JsonValue::String(Template {
-            quotes: true,
+            delimiter: Some('"'),
             elements: vec![
                 TemplateElement::String {
                     value: "Hello ".to_string(),
@@ -200,7 +200,7 @@ mod tests {
             elements: vec![JsonObjectElement {
                 space0: "".to_string(),
                 name: Template {
-                    quotes: false,
+                    delimiter: None,
                     elements: vec![TemplateElement::String {
                         value: "firstName".to_string(),
                         encoded: "firstName".to_string(),
@@ -210,7 +210,7 @@ mod tests {
                 space1: "".to_string(),
                 space2: " ".to_string(),
                 value: JsonValue::String(Template {
-                    quotes: false,
+                    delimiter: None,
                     elements: vec![TemplateElement::String {
                         value: "John".to_string(),
                         encoded: "John".to_string(),
@@ -304,7 +304,7 @@ mod tests {
         );
 
         let template = Template {
-            quotes: true,
+            delimiter: Some('"'),
             elements: vec![TemplateElement::String {
                 encoded: "Hi".to_string(),
                 value: "Hi".to_string(),
@@ -364,7 +364,7 @@ mod tests {
         assert_eq!(
             eval_json_value(
                 &JsonValue::String(Template {
-                    quotes: false,
+                    delimiter: None,
                     elements: vec![TemplateElement::String {
                         value: "\n".to_string(),
                         encoded: "\\n".to_string(),
@@ -384,7 +384,7 @@ mod tests {
         assert_eq!(
             eval_json_template(
                 &Template {
-                    quotes: false,
+                    delimiter: None,
                     elements: vec![TemplateElement::String {
                         value: "\n".to_string(),
                         encoded: "\\n".to_string(),
@@ -402,7 +402,7 @@ mod tests {
         assert_eq!(
             eval_json_template(
                 &Template {
-                    quotes: true,
+                    delimiter: Some('"'),
                     elements: vec![
                         TemplateElement::String {
                             value: "Hello ".to_string(),

--- a/packages/hurl/src/runner/predicate.rs
+++ b/packages/hurl/src/runner/predicate.rs
@@ -1171,7 +1171,7 @@ mod tests {
         };
 
         let template = Template {
-            quotes: true,
+            delimiter: Some('"'),
             elements: vec![TemplateElement::Expression(Expr {
                 space0: Whitespace {
                     value: "".to_string(),
@@ -1567,7 +1567,7 @@ mod tests {
                 value: PredicateFuncValue::StartWith {
                     space0: whitespace(),
                     value: PredicateValue::String(Template {
-                        quotes: false,
+                        delimiter: None,
                         elements: vec![TemplateElement::String {
                             value: "toto".to_string(),
                             encoded: "toto".to_string(),

--- a/packages/hurl/src/runner/query.rs
+++ b/packages/hurl/src/runner/query.rs
@@ -326,7 +326,7 @@ pub mod tests {
             value: QueryValue::Xpath {
                 space0: whitespace,
                 expr: Template {
-                    quotes: true,
+                    delimiter: Some('"'),
                     elements: vec![TemplateElement::String {
                         value: "???".to_string(),
                         encoded: "???".to_string(),
@@ -347,7 +347,7 @@ pub mod tests {
             value: QueryValue::Xpath {
                 space0: whitespace,
                 expr: Template {
-                    quotes: true,
+                    delimiter: Some('"'),
                     elements: vec![TemplateElement::String {
                         value: "count(//user)".to_string(),
                         encoded: "count(//user)".to_string(),
@@ -368,7 +368,7 @@ pub mod tests {
             value: QueryValue::Xpath {
                 space0: whitespace,
                 expr: Template {
-                    quotes: true,
+                    delimiter: Some('"'),
                     elements: vec![TemplateElement::String {
                         value: "//user".to_string(),
                         encoded: "/user".to_string(),
@@ -415,8 +415,7 @@ pub mod tests {
                         value: String::from("$.success"),
                         encoded: String::from("$.success"),
                     }],
-                    quotes: true,
-                    //delimiter: "".to_string(),
+                    delimiter: Some('"'),
                     source_info: SourceInfo::new(1, 10, 1, 19),
                 },
             },
@@ -437,8 +436,7 @@ pub mod tests {
                         value: String::from("$.errors"),
                         encoded: String::from("$.errors"),
                     }],
-                    quotes: true,
-                    //   delimiter: "".to_string(),
+                    delimiter: Some('"'),
                     source_info: SourceInfo::new(1, 10, 1, 18),
                 },
             },
@@ -459,8 +457,7 @@ pub mod tests {
                         value: String::from("$.duration"),
                         encoded: String::from("$.duration"),
                     }],
-                    quotes: true,
-                    //   delimiter: "".to_string(),
+                    delimiter: Some('"'),
                     source_info: SourceInfo::new(1, 10, 1, 18),
                 },
             },
@@ -477,7 +474,7 @@ pub mod tests {
                     source_info: SourceInfo::new(1, 6, 1, 7),
                 },
                 value: RegexValue::Template(Template {
-                    quotes: true,
+                    delimiter: Some('"'),
                     elements: vec![TemplateElement::String {
                         value: "Hello ([a-zA-Z]+)!".to_string(),
                         encoded: "Hello ([a-zA-Z]+)!".to_string(),
@@ -498,7 +495,7 @@ pub mod tests {
                     source_info: SourceInfo::new(1, 6, 1, 7),
                 },
                 value: RegexValue::Template(Template {
-                    quotes: true,
+                    delimiter: Some('"'),
                     elements: vec![TemplateElement::String {
                         value: "???".to_string(),
                         encoded: "???".to_string(),
@@ -539,7 +536,7 @@ pub mod tests {
                     source_info: SourceInfo::new(1, 7, 1, 8),
                 },
                 name: Template {
-                    quotes: true,
+                    delimiter: Some('"'),
                     elements: vec![TemplateElement::String {
                         value: "Custom".to_string(),
                         encoded: "Custom".to_string(),
@@ -569,7 +566,7 @@ pub mod tests {
                     source_info: SourceInfo::new(1, 7, 1, 8),
                 },
                 name: Template {
-                    quotes: true,
+                    delimiter: Some('"'),
                     elements: vec![TemplateElement::String {
                         value: "Content-Type".to_string(),
                         encoded: "Content-Type".to_string(),
@@ -614,7 +611,7 @@ pub mod tests {
                 space0: space.clone(),
                 expr: CookiePath {
                     name: Template {
-                        quotes: true,
+                        delimiter: Some('"'),
                         elements: vec![TemplateElement::String {
                             value: "LSID".to_string(),
                             encoded: "LSID".to_string(),
@@ -639,7 +636,7 @@ pub mod tests {
                 space0: space.clone(),
                 expr: CookiePath {
                     name: Template {
-                        quotes: true,
+                        delimiter: Some('"'),
                         elements: vec![TemplateElement::String {
                             value: "LSID".to_string(),
                             encoded: "LSID".to_string(),
@@ -668,7 +665,7 @@ pub mod tests {
                 space0: space.clone(),
                 expr: CookiePath {
                     name: Template {
-                        quotes: true,
+                        delimiter: Some('"'),
                         elements: vec![TemplateElement::String {
                             value: "LSID".to_string(),
                             encoded: "LSID".to_string(),
@@ -697,7 +694,7 @@ pub mod tests {
                 space0: space.clone(),
                 expr: CookiePath {
                     name: Template {
-                        quotes: true,
+                        delimiter: Some('"'),
                         elements: vec![TemplateElement::String {
                             value: "LSID".to_string(),
                             encoded: "LSID".to_string(),
@@ -863,7 +860,7 @@ pub mod tests {
                     source_info: SourceInfo::new(1, 6, 1, 7),
                 },
                 expr: Template {
-                    quotes: true,
+                    delimiter: Some('"'),
                     elements: vec![TemplateElement::String {
                         value: "^^^".to_string(),
                         encoded: "^^^".to_string(),
@@ -917,7 +914,7 @@ pub mod tests {
             value: QueryValue::Xpath {
                 space0: whitespace,
                 expr: Template {
-                    quotes: true,
+                    delimiter: Some('"'),
                     elements: vec![TemplateElement::String {
                         value: "normalize-space(/html/head/meta/@charset)".to_string(),
                         encoded: "normalize-space(/html/head/meta/@charset)".to_string(),
@@ -960,8 +957,7 @@ pub mod tests {
                         value: String::from("xxx"),
                         encoded: String::from("xxx"),
                     }],
-                    quotes: true,
-                    // delimiter: "".to_string(),
+                    delimiter: Some('"'),
                     source_info: SourceInfo::new(1, 10, 1, 13),
                 },
             },

--- a/packages/hurl/src/runner/request.rs
+++ b/packages/hurl/src/runner/request.rs
@@ -223,7 +223,7 @@ mod tests {
                         encoded: String::from("/hello"),
                     },
                 ],
-                quotes: false,
+                delimiter: None,
                 source_info: SourceInfo::new(0, 0, 0, 0),
             },
             line_terminator0: line_terminator,
@@ -267,7 +267,7 @@ mod tests {
                     value: String::from("http://localhost:8000/querystring-params"),
                     encoded: String::from("http://localhost:8000/querystring-params"),
                 }],
-                quotes: false,
+                delimiter: None,
                 source_info: SourceInfo::new(0, 0, 0, 0),
             },
             line_terminator0: line_terminator.clone(),
@@ -285,7 +285,7 @@ mod tests {
                             source_info: SourceInfo::new(0, 0, 0, 0),
                         },
                         Template {
-                            quotes: false,
+                            delimiter: None,
                             elements: vec![TemplateElement::Expression(Expr {
                                 space0: whitespace(),
                                 variable: Variable {
@@ -305,7 +305,7 @@ mod tests {
                             source_info: SourceInfo::new(0, 0, 0, 0),
                         },
                         Template {
-                            quotes: false,
+                            delimiter: None,
                             elements: vec![TemplateElement::String {
                                 value: "a b".to_string(),
                                 encoded: "a b".to_string(),
@@ -385,7 +385,7 @@ mod tests {
                     value: String::from("http:///localhost"),
                     encoded: String::from("http://localhost"),
                 },],
-                quotes: false,
+                delimiter: None,
                 source_info: SourceInfo::new(0, 0, 0, 0),
             },
             line_terminator0: line_terminator,
@@ -425,7 +425,7 @@ mod tests {
                         value: String::from("http:///localhost"),
                         encoded: String::from("http://localhost"),
                     },],
-                    quotes: false,
+                    delimiter: None,
                     source_info: SourceInfo::new(0, 0, 0, 0),
                 },
                 line_terminator0: line_terminator,

--- a/packages/hurl/tests/runner.rs
+++ b/packages/hurl/tests/runner.rs
@@ -68,7 +68,7 @@ fn hello_request() -> Request {
         method: Method::Get,
         space1: whitespace.clone(),
         url: Template {
-            quotes: false,
+            delimiter: None,
             elements: vec![TemplateElement::String {
                 value: "http://localhost:8000/hello".to_string(),
                 encoded: "http://localhost:8000/hello".to_string(),
@@ -92,7 +92,7 @@ fn hello_request() -> Request {
             space1: whitespace.clone(),
             space2: whitespace,
             value: Template {
-                quotes: false,
+                delimiter: None,
                 elements: vec![TemplateElement::String {
                     value: "test".to_string(),
                     encoded: "test".to_string(),

--- a/packages/hurl_core/src/ast/core.rs
+++ b/packages/hurl_core/src/ast/core.rs
@@ -556,7 +556,7 @@ pub struct File {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Template {
-    pub quotes: bool,
+    pub delimiter: Option<char>,
     pub elements: Vec<TemplateElement>,
     pub source_info: SourceInfo,
 }

--- a/packages/hurl_core/src/ast/display.rs
+++ b/packages/hurl_core/src/ast/display.rs
@@ -260,7 +260,7 @@ mod tests {
 
     fn hello_template() -> Template {
         Template {
-            quotes: false,
+            delimiter: None,
             elements: vec![
                 TemplateElement::String {
                     value: "Hello ".to_string(),
@@ -322,7 +322,7 @@ mod tests {
         assert_eq!(
             CookiePath {
                 name: Template {
-                    quotes: false,
+                    delimiter: None,
                     elements: vec![TemplateElement::String {
                         value: "LSID".to_string(),
                         encoded: "unused".to_string(),

--- a/packages/hurl_core/src/ast/json.rs
+++ b/packages/hurl_core/src/ast/json.rs
@@ -191,13 +191,13 @@ impl ObjectElement {
 impl Template {
     fn encoded(&self) -> String {
         let mut s = "".to_string();
-        if self.quotes {
-            s.push('"')
+        if let Some(d) = self.delimiter {
+            s.push(d)
         }
         let elements: Vec<String> = self.elements.iter().map(|e| e.encoded()).collect();
         s.push_str(elements.join("").as_str());
-        if self.quotes {
-            s.push('"')
+        if let Some(d) = self.delimiter {
+            s.push(d)
         }
         s
     }
@@ -241,7 +241,7 @@ mod tests {
         assert_eq!(
             "\"hello\"".to_string(),
             Value::String(Template {
-                quotes: false,
+                delimiter: None,
                 elements: vec![TemplateElement::String {
                     value: "hello".to_string(),
                     encoded: "hello".to_string(),
@@ -298,7 +298,7 @@ mod tests {
                 elements: vec![ObjectElement {
                     space0: " ".to_string(),
                     name: Template {
-                        quotes: true,
+                        delimiter: Some('"'),
                         elements: vec![TemplateElement::String {
                             value: "id".to_string(),
                             encoded: "id".to_string(),
@@ -338,7 +338,7 @@ mod tests {
         );
         assert_eq!(
             Template {
-                quotes: false,
+                delimiter: None,
                 elements: vec![TemplateElement::Expression(Expr {
                     space0: Whitespace {
                         value: "".to_string(),

--- a/packages/hurl_core/src/format/html.rs
+++ b/packages/hurl_core/src/format/html.rs
@@ -1120,7 +1120,7 @@ mod tests {
     fn test_multiline_string() {
         // ``````
         let multiline_string = MultilineString::OneLineText(Template {
-            quotes: false,
+            delimiter: None,
             elements: vec![TemplateElement::String {
                 value: "".to_string(),
                 encoded: "unused".to_string(),
@@ -1134,7 +1134,7 @@ mod tests {
 
         // ```hello```
         let multiline_string = MultilineString::OneLineText(Template {
-            quotes: false,
+            delimiter: None,
             elements: vec![TemplateElement::String {
                 value: "hello".to_string(),
                 encoded: "unused".to_string(),
@@ -1166,7 +1166,7 @@ mod tests {
                 },
             },
             value: Template {
-                quotes: false,
+                delimiter: None,
                 elements: vec![TemplateElement::String {
                     value: "line1\nline2\n".to_string(),
                     encoded: "unused".to_string(),
@@ -1204,7 +1204,7 @@ mod tests {
             elements: vec![JsonObjectElement {
                 space0: "\n   ".to_string(),
                 name: Template {
-                    quotes: true,
+                    delimiter: Some('"'),
                     elements: vec![TemplateElement::String {
                         value: "id".to_string(),
                         encoded: "id".to_string(),
@@ -1226,7 +1226,7 @@ mod tests {
     #[test]
     fn test_json_encoded_newline() {
         let value = JsonValue::String(Template {
-            quotes: true,
+            delimiter: Some('"'),
             elements: vec![TemplateElement::String {
                 value: "\n".to_string(),
                 encoded: "\\n".to_string(),

--- a/packages/hurl_core/src/parser/bytes.rs
+++ b/packages/hurl_core/src/parser/bytes.rs
@@ -130,7 +130,7 @@ mod tests {
             bytes(&mut reader).unwrap(),
             Bytes::Json {
                 value: JsonValue::String(Template {
-                    quotes: true,
+                    delimiter: Some('"'),
                     elements: vec![],
                     source_info: SourceInfo::new(1, 2, 1, 2),
                 })

--- a/packages/hurl_core/src/parser/cookiepath.rs
+++ b/packages/hurl_core/src/parser/cookiepath.rs
@@ -93,7 +93,7 @@ mod tests {
             cookiepath(&mut reader).unwrap(),
             CookiePath {
                 name: Template {
-                    quotes: false,
+                    delimiter: None,
                     elements: vec![TemplateElement::String {
                         value: "cookie1".to_string(),
                         encoded: "cookie1".to_string(),
@@ -113,7 +113,7 @@ mod tests {
             cookiepath(&mut reader).unwrap(),
             CookiePath {
                 name: Template {
-                    quotes: false,
+                    delimiter: None,
                     elements: vec![TemplateElement::String {
                         value: "cookie1".to_string(),
                         encoded: "cookie1".to_string(),
@@ -143,7 +143,7 @@ mod tests {
             cookiepath(&mut reader).unwrap(),
             CookiePath {
                 name: Template {
-                    quotes: false,
+                    delimiter: None,
                     elements: vec![TemplateElement::Expression(Expr {
                         space0: Whitespace {
                             value: String::from(""),

--- a/packages/hurl_core/src/parser/json.rs
+++ b/packages/hurl_core/src/parser/json.rs
@@ -57,7 +57,7 @@ fn string_value(reader: &mut Reader) -> ParseResult<'static, JsonValue> {
 
 fn string_template(reader: &mut Reader) -> ParseResult<'static, Template> {
     try_literal("\"", reader)?;
-    let quotes = true;
+    let delimiter = Some('"');
     let mut chars = vec![];
     let start = reader.state.pos.clone();
     loop {
@@ -80,7 +80,7 @@ fn string_template(reader: &mut Reader) -> ParseResult<'static, Template> {
     let elements = templatize(encoded_string)?;
 
     let template = Template {
-        quotes,
+        delimiter,
         elements,
         source_info: SourceInfo { start, end },
     };
@@ -423,7 +423,7 @@ mod tests {
     pub fn json_hello_world_value() -> JsonValue {
         // "hello\u0020{{name}}!"
         JsonValue::String(Template {
-            quotes: true,
+            delimiter: Some('"'),
             elements: vec![
                 TemplateElement::String {
                     value: "Hello ".to_string(),
@@ -458,7 +458,7 @@ mod tests {
         assert_eq!(
             string_value(&mut reader).unwrap(),
             JsonValue::String(Template {
-                quotes: true,
+                delimiter: Some('"'),
                 elements: vec![],
                 source_info: SourceInfo::new(1, 2, 1, 2),
             })
@@ -473,7 +473,7 @@ mod tests {
         assert_eq!(
             string_value(&mut reader).unwrap(),
             JsonValue::String(Template {
-                quotes: true,
+                delimiter: Some('"'),
                 elements: vec![TemplateElement::String {
                     value: "{}".to_string(),
                     encoded: "{}".to_string(),
@@ -814,7 +814,7 @@ mod tests {
                 elements: vec![JsonObjectElement {
                     space0: "".to_string(),
                     name: Template {
-                        quotes: true,
+                        delimiter: Some('"'),
                         elements: vec![TemplateElement::String {
                             value: "a".to_string(),
                             encoded: "a".to_string()
@@ -859,7 +859,7 @@ mod tests {
             JsonObjectElement {
                 space0: "".to_string(),
                 name: Template {
-                    quotes: true,
+                    delimiter: Some('"'),
                     elements: vec![TemplateElement::String {
                         value: "a".to_string(),
                         encoded: "a".to_string()

--- a/packages/hurl_core/src/parser/multiline.rs
+++ b/packages/hurl_core/src/parser/multiline.rs
@@ -106,7 +106,7 @@ fn graphql(reader: &mut Reader) -> ParseResult<'static, MultilineString> {
 
                     let elements = template::templatize(encoded_string)?;
                     let template = Template {
-                        quotes: false,
+                        delimiter: None,
                         elements,
                         source_info: SourceInfo { start, end },
                     };
@@ -134,7 +134,7 @@ fn graphql(reader: &mut Reader) -> ParseResult<'static, MultilineString> {
 
     let elements = template::templatize(encoded_string)?;
     let template = Template {
-        quotes: false,
+        delimiter: None,
         elements,
         source_info: SourceInfo { start, end },
     };
@@ -253,7 +253,7 @@ fn multiline_string_value(reader: &mut Reader) -> ParseResult<'static, Template>
     let elements = template::templatize(encoded_string)?;
 
     Ok(Template {
-        quotes: false,
+        delimiter: None,
         elements,
         source_info: SourceInfo { start, end },
     })
@@ -289,7 +289,7 @@ fn oneline_string_value(reader: &mut Reader) -> ParseResult<'static, Template> {
     let elements = template::templatize(encoded_string)?;
 
     Ok(Template {
-        quotes: false,
+        delimiter: None,
         elements,
         source_info: SourceInfo { start, end },
     })
@@ -314,7 +314,7 @@ mod tests {
                     source_info: SourceInfo::new(1, 4, 2, 1),
                 },
                 value: Template {
-                    quotes: false,
+                    delimiter: None,
                     elements: vec![TemplateElement::String {
                         value: "line1\nline2\nline3\n".to_string(),
                         encoded: "line1\nline2\nline3\n".to_string(),
@@ -337,7 +337,7 @@ mod tests {
                     source_info: SourceInfo::new(1, 13, 2, 1),
                 },
                 value: Template {
-                    quotes: false,
+                    delimiter: None,
                     elements: vec![TemplateElement::String {
                         value: "line1\nline2\nline3\n".to_string(),
                         encoded: "line1\nline2\nline3\n".to_string(),
@@ -363,7 +363,7 @@ mod tests {
                     source_info: SourceInfo::new(1, 8, 2, 1),
                 },
                 value: Template {
-                    quotes: false,
+                    delimiter: None,
                     elements: vec![TemplateElement::String {
                         value: "line1\nline2\nline3\n".to_string(),
                         encoded: "line1\nline2\nline3\n".to_string(),
@@ -389,7 +389,7 @@ mod tests {
                     source_info: SourceInfo::new(1, 11, 2, 1),
                 },
                 value: Template {
-                    quotes: false,
+                    delimiter: None,
                     elements: vec![TemplateElement::String {
                         value: "line1\nline2\nline3\n".to_string(),
                         encoded: "line1\nline2\nline3\n".to_string(),
@@ -413,7 +413,7 @@ mod tests {
                     source_info: SourceInfo::new(1, 17, 2, 1),
                 },
                 value: Template {
-                    quotes: false,
+                    delimiter: None,
                     elements: vec![TemplateElement::String {
                         value: "line1\nline2\nline3\n".to_string(),
                         encoded: "line1\nline2\nline3\n".to_string(),
@@ -444,7 +444,7 @@ mod tests {
         assert_eq!(
             multiline_string(&mut reader).unwrap(),
             MultilineString::OneLineText(Template {
-                quotes: false,
+                delimiter: None,
                 elements: vec![],
                 source_info: SourceInfo::new(1, 4, 1, 4),
             })
@@ -463,7 +463,7 @@ mod tests {
                     source_info: SourceInfo::new(1, 4, 2, 1),
                 },
                 value: Template {
-                    quotes: false,
+                    delimiter: None,
                     elements: vec![],
                     source_info: SourceInfo::new(2, 1, 2, 1),
                 },
@@ -482,7 +482,7 @@ mod tests {
                     source_info: SourceInfo::new(1, 4, 2, 1),
                 },
                 value: Template {
-                    quotes: false,
+                    delimiter: None,
                     elements: vec![],
                     source_info: SourceInfo::new(2, 1, 2, 1),
                 },
@@ -496,7 +496,7 @@ mod tests {
         assert_eq!(
             multiline_string(&mut reader).unwrap(),
             MultilineString::OneLineText(Template {
-                quotes: false,
+                delimiter: None,
                 elements: vec![TemplateElement::String {
                     value: "Hello World!".to_string(),
                     encoded: "Hello World!".to_string(),
@@ -512,7 +512,7 @@ mod tests {
         assert_eq!(
             multiline_string(&mut reader).unwrap(),
             MultilineString::OneLineText(Template {
-                quotes: false,
+                delimiter: None,
                 elements: vec![TemplateElement::String {
                     value: "base64_inline".to_string(),
                     encoded: "base64_inline".to_string(),
@@ -537,7 +537,7 @@ mod tests {
                     source_info: SourceInfo::new(1, 4, 2, 1),
                 },
                 value: Template {
-                    quotes: false,
+                    delimiter: None,
                     elements: vec![TemplateElement::String {
                         value: "line1\nline2\nline3\n".to_string(),
                         encoded: "line1\nline2\nline3\n".to_string(),
@@ -563,7 +563,7 @@ mod tests {
                     source_info: SourceInfo::new(1, 4, 2, 1),
                 },
                 value: Template {
-                    quotes: false,
+                    delimiter: None,
                     elements: vec![TemplateElement::String {
                         value: "\n".to_string(),
                         encoded: "\n".to_string(),
@@ -587,7 +587,7 @@ mod tests {
                     source_info: SourceInfo::new(1, 4, 2, 1),
                 },
                 value: Template {
-                    quotes: false,
+                    delimiter: None,
                     elements: vec![TemplateElement::String {
                         value: "\r\n".to_string(),
                         encoded: "\r\n".to_string(),
@@ -635,7 +635,7 @@ mod tests {
         assert_eq!(
             multiline_string_value(&mut reader).unwrap(),
             Template {
-                quotes: false,
+                delimiter: None,
                 elements: vec![],
                 source_info: SourceInfo::new(1, 1, 1, 1),
             }
@@ -646,7 +646,7 @@ mod tests {
         assert_eq!(
             multiline_string_value(&mut reader).unwrap(),
             Template {
-                quotes: false,
+                delimiter: None,
                 elements: vec![TemplateElement::String {
                     value: "hello".to_string(),
                     encoded: "hello".to_string(),
@@ -685,7 +685,7 @@ variables {
                     source_info: SourceInfo::new(1, 11, 2, 1),
                 },
                 value: Template {
-                    quotes: false,
+                    delimiter: None,
                     elements: vec![TemplateElement::String {
                         value: "query Human($name: String!) {\n  human(name: $name) {\n    name\n    height(unit: FOOT)\n}\n\n".to_string(),
                         encoded:
@@ -703,7 +703,7 @@ variables {
                         elements: vec![JsonObjectElement {
                             space0: "".to_string(),
                             name: Template {
-                                quotes: true,
+                                delimiter: Some('"'),
                                 elements: vec![
                                     TemplateElement::String {
                                         value: "name".to_string(),
@@ -715,7 +715,7 @@ variables {
                             space1: "".to_string(),
                             space2: " ".to_string(),
                             value: JsonValue::String(Template {
-                                quotes: true,
+                                delimiter: Some('"'),
                                 elements: vec![
                                     TemplateElement::String {
                                         value: "Han Solo".to_string(),

--- a/packages/hurl_core/src/parser/parsers.rs
+++ b/packages/hurl_core/src/parser/parsers.rs
@@ -328,7 +328,7 @@ mod tests {
                     value: String::from("http://google.fr"),
                     encoded: String::from("http://google.fr"),
                 }],
-                quotes: false,
+                delimiter: None,
                 source_info: SourceInfo::new(1, 5, 1, 21),
             },
             line_terminator0: LineTerminator {
@@ -366,7 +366,7 @@ mod tests {
                     value: String::from("http://google.fr"),
                     encoded: String::from("http://google.fr"),
                 }],
-                quotes: false,
+                delimiter: None,
                 source_info: SourceInfo::new(1, 6, 1, 22),
             },
             line_terminator0: LineTerminator {
@@ -427,7 +427,7 @@ mod tests {
                             value: String::from("Hello World!\n"),
                             encoded: String::from("Hello World!\n"),
                         }],
-                        quotes: false,
+                        delimiter: None,
                         source_info: SourceInfo::new(3, 1, 4, 1),
                     }
                 })),
@@ -484,7 +484,7 @@ mod tests {
             r.body.unwrap().value,
             Bytes::Json {
                 value: JsonValue::String(Template {
-                    quotes: true,
+                    delimiter: Some('"'),
                     elements: vec![TemplateElement::String {
                         value: "Hello".to_string(),
                         encoded: "Hello".to_string(),

--- a/packages/hurl_core/src/parser/predicate.rs
+++ b/packages/hurl_core/src/parser/predicate.rs
@@ -507,7 +507,7 @@ mod tests {
             equal_predicate(&mut reader).unwrap(),
             PredicateFuncValue::Equal {
                 value: PredicateValue::String(Template {
-                    quotes: true,
+                    delimiter: Some('"'),
                     elements: vec![TemplateElement::String {
                         value: "Bob".to_string(),
                         encoded: "Bob".to_string(),

--- a/packages/hurl_core/src/parser/primitives.rs
+++ b/packages/hurl_core/src/parser/primitives.rs
@@ -778,7 +778,7 @@ mod tests {
                     source_info: SourceInfo::new(1, 9, 1, 10),
                 },
                 value: Template {
-                    quotes: false,
+                    delimiter: None,
                     elements: vec![
                         TemplateElement::String {
                             value: "hello ".to_string(),

--- a/packages/hurl_core/src/parser/query.rs
+++ b/packages/hurl_core/src/parser/query.rs
@@ -221,7 +221,7 @@ mod tests {
                     source_info: SourceInfo::new(1, 7, 1, 8),
                 },
                 name: Template {
-                    quotes: true,
+                    delimiter: Some('"'),
                     elements: vec![TemplateElement::String {
                         value: "Foo".to_string(),
                         encoded: "Foo".to_string(),
@@ -244,7 +244,7 @@ mod tests {
                 },
                 expr: CookiePath {
                     name: Template {
-                        quotes: false,
+                        delimiter: None,
                         elements: vec![TemplateElement::String {
                             value: "Foo".to_string(),
                             encoded: "Foo".to_string(),
@@ -282,7 +282,7 @@ mod tests {
                     source_info: SourceInfo::new(1, 6, 1, 7),
                 },
                 expr: Template {
-                    quotes: true,
+                    delimiter: Some('"'),
                     elements: vec![TemplateElement::String {
                         value: String::from("normalize-space(//head/title)"),
                         encoded: String::from("normalize-space(//head/title)"),
@@ -296,7 +296,7 @@ mod tests {
         assert_eq!(xpath_query(&mut reader).unwrap(), QueryValue::Xpath {
             space0: Whitespace { value: String::from(" "), source_info: SourceInfo::new(1, 6, 1, 7) },
             expr: Template {
-                quotes: true,
+                delimiter: Some('"'),
                 elements: vec![
                     TemplateElement::String {
                         value: String::from("normalize-space(//div[contains(concat(' ',normalize-space(@class),' '),' monthly-price ')])"),
@@ -324,8 +324,7 @@ mod tests {
                         value: "$['statusCode']".to_string(),
                         encoded: "$['statusCode']".to_string(),
                     }],
-                    quotes: true,
-                    //delimiter: "\"".to_string(),
+                    delimiter: Some('"'),
                     source_info: SourceInfo::new(1, 10, 1, 27),
                 },
             },
@@ -343,8 +342,7 @@ mod tests {
                         value: "$.success".to_string(),
                         encoded: "$.success".to_string(),
                     }],
-                    quotes: true,
-                    //delimiter: "\"".to_string(),
+                    delimiter: Some('"'),
                     source_info: SourceInfo::new(1, 10, 1, 21),
                 },
             },

--- a/packages/hurl_core/src/parser/sections.rs
+++ b/packages/hurl_core/src/parser/sections.rs
@@ -771,7 +771,7 @@ mod tests {
                                 source_info: SourceInfo::new(2, 7, 2, 8),
                             },
                             name: Template {
-                                quotes: true,
+                                delimiter: Some('"'),
                                 elements: vec![TemplateElement::String {
                                     value: "Location".to_string(),
                                     encoded: "Location".to_string(),
@@ -799,7 +799,7 @@ mod tests {
                                     source_info: SourceInfo::new(2, 25, 2, 26),
                                 },
                                 value: PredicateValue::String(Template {
-                                    quotes: true,
+                                    delimiter: Some('"'),
                                     elements: vec![TemplateElement::String {
                                         value: "https://google.fr".to_string(),
                                         encoded: "https://google.fr".to_string(),
@@ -861,7 +861,7 @@ mod tests {
         assert_eq!(
             c.value,
             Template {
-                quotes: false,
+                delimiter: None,
                 elements: vec![TemplateElement::String {
                     value: "Bar".to_string(),
                     encoded: "Bar".to_string(),
@@ -1073,7 +1073,7 @@ mod tests {
         assert_eq!(
             variable_value(&mut reader).unwrap(),
             VariableValue::String(Template {
-                quotes: false,
+                delimiter: None,
                 elements: vec![TemplateElement::String {
                     value: "toto".to_string(),
                     encoded: "toto".to_string(),
@@ -1088,7 +1088,7 @@ mod tests {
         assert_eq!(
             variable_value(&mut reader).unwrap(),
             VariableValue::String(Template {
-                quotes: true,
+                delimiter: Some('"'),
                 elements: vec![TemplateElement::String {
                     value: "123".to_string(),
                     encoded: "123".to_string(),
@@ -1219,7 +1219,7 @@ mod tests {
                         source_info: SourceInfo::new(1, 12, 1, 13),
                     },
                     name: Template {
-                        quotes: true,
+                        delimiter: Some('"'),
                         elements: vec![TemplateElement::String {
                             value: "Location".to_string(),
                             encoded: "Location".to_string(),
@@ -1246,7 +1246,7 @@ mod tests {
                         source_info: SourceInfo::new(1, 14, 1, 15),
                     },
                     name: Template {
-                        quotes: true,
+                        delimiter: Some('"'),
                         elements: vec![TemplateElement::String {
                             value: "Location".to_string(),
                             encoded: "Location".to_string(),
@@ -1311,7 +1311,7 @@ mod tests {
                         source_info: SourceInfo::new(1, 7, 1, 8),
                     },
                     name: Template {
-                        quotes: true,
+                        delimiter: Some('"'),
                         elements: vec![TemplateElement::String {
                             value: "Location".to_string(),
                             encoded: "Location".to_string(),

--- a/packages/hurl_core/src/parser/string.rs
+++ b/packages/hurl_core/src/parser/string.rs
@@ -68,10 +68,9 @@ pub fn unquoted_template(reader: &mut Reader) -> ParseResult<'static, Template> 
         },
         chars,
     };
-    let quotes = false;
     let elements = template::templatize(encoded_string)?;
     Ok(Template {
-        quotes,
+        delimiter: None,
         elements,
         source_info: SourceInfo {
             start: start.pos,
@@ -145,7 +144,6 @@ pub fn quoted_string(reader: &mut Reader) -> ParseResult<'static, String> {
 }
 
 pub fn quoted_template(reader: &mut Reader) -> ParseResult<'static, Template> {
-    let quotes = true;
     let start = reader.state.clone().pos;
     let mut end = start.clone();
     try_literal("\"", reader)?;
@@ -178,7 +176,7 @@ pub fn quoted_template(reader: &mut Reader) -> ParseResult<'static, Template> {
     };
     let elements = template::templatize(encoded_string)?;
     Ok(Template {
-        quotes,
+        delimiter: Some('"'),
         elements,
         source_info: SourceInfo {
             start,
@@ -287,7 +285,7 @@ mod tests {
         assert_eq!(
             unquoted_template(&mut reader).unwrap(),
             Template {
-                quotes: false,
+                delimiter: None,
                 elements: vec![],
                 source_info: SourceInfo::new(1, 1, 1, 1),
             }
@@ -313,7 +311,7 @@ mod tests {
         assert_eq!(
             unquoted_template(&mut reader).unwrap(),
             Template {
-                quotes: false,
+                delimiter: None,
                 elements: vec![TemplateElement::String {
                     value: "a".to_string(),
                     encoded: "a".to_string(),
@@ -330,7 +328,7 @@ mod tests {
         assert_eq!(
             unquoted_template(&mut reader).unwrap(),
             Template {
-                quotes: false,
+                delimiter: None,
                 elements: vec![TemplateElement::String {
                     value: "a#".to_string(),
                     encoded: "a\\u{23}".to_string(),
@@ -347,7 +345,7 @@ mod tests {
         assert_eq!(
             unquoted_template(&mut reader).unwrap(),
             Template {
-                quotes: false,
+                delimiter: None,
                 elements: vec![TemplateElement::String {
                     value: "\"hi\"".to_string(),
                     encoded: "\"hi\"".to_string(),
@@ -364,7 +362,7 @@ mod tests {
         assert_eq!(
             unquoted_template(&mut reader).unwrap(),
             Template {
-                quotes: false,
+                delimiter: None,
                 elements: vec![
                     TemplateElement::String {
                         value: "hello ".to_string(),
@@ -401,7 +399,7 @@ mod tests {
         assert_eq!(
             unquoted_template(&mut reader).unwrap(),
             Template {
-                quotes: false,
+                delimiter: None,
                 elements: vec![TemplateElement::String {
                     value: "hello world".to_string(),
                     encoded: "hello world".to_string(),
@@ -532,7 +530,7 @@ mod tests {
         assert_eq!(
             quoted_template(&mut reader).unwrap(),
             Template {
-                quotes: true,
+                delimiter: Some('"'),
                 elements: vec![],
                 source_info: SourceInfo::new(1, 1, 1, 3),
             }
@@ -543,7 +541,7 @@ mod tests {
         assert_eq!(
             quoted_template(&mut reader).unwrap(),
             Template {
-                quotes: true,
+                delimiter: Some('"'),
                 elements: vec![TemplateElement::String {
                     value: "a#".to_string(),
                     encoded: "a#".to_string(),
@@ -557,7 +555,7 @@ mod tests {
         assert_eq!(
             quoted_template(&mut reader).unwrap(),
             Template {
-                quotes: true,
+                delimiter: Some('"'),
                 elements: vec![TemplateElement::String {
                     value: "{0}".to_string(),
                     encoded: "{0}".to_string(),
@@ -575,7 +573,7 @@ mod tests {
         assert_eq!(
             quoted_template(&mut reader).unwrap(),
             Template {
-                quotes: true,
+                delimiter: Some('"'),
                 elements: vec![TemplateElement::String {
                     value: "\"hi\"".to_string(),
                     encoded: "\\\"hi\\\"".to_string()

--- a/packages/hurl_core/src/parser/url.rs
+++ b/packages/hurl_core/src/parser/url.rs
@@ -126,7 +126,7 @@ pub fn url(reader: &mut Reader) -> ParseResult<'static, Template> {
 
     reader.state = save;
     Ok(Template {
-        quotes: false,
+        delimiter: None,
         elements,
         source_info: SourceInfo {
             start: start.pos,
@@ -149,7 +149,7 @@ mod tests {
                     value: String::from("http://google.fr"),
                     encoded: String::from("http://google.fr"),
                 }],
-                quotes: false,
+                delimiter: None,
                 source_info: SourceInfo::new(1, 1, 1, 17),
             }
         );
@@ -168,7 +168,7 @@ mod tests {
                         "http://localhost:8000/cookies/set-session-cookie2-valueA"
                     ),
                 }],
-                quotes: false,
+                delimiter: None,
                 source_info: SourceInfo::new(1, 1, 1, 57),
             }
         );
@@ -205,8 +205,7 @@ mod tests {
                         encoded: String::from(".fr"),
                     },
                 ],
-                //encoded: None,
-                quotes: false,
+                delimiter: None,
                 source_info: SourceInfo::new(1, 1, 1, 19),
             }
         );

--- a/packages/hurlfmt/src/format/json.rs
+++ b/packages/hurlfmt/src/format/json.rs
@@ -571,7 +571,7 @@ pub mod tests {
                 method: Method::Get,
                 space1: whitespace(),
                 url: Template {
-                    quotes: false,
+                    delimiter: None,
                     elements: vec![TemplateElement::String {
                         value: "http://example.com".to_string(),
                         encoded: "not_used".to_string(),
@@ -591,7 +591,7 @@ pub mod tests {
                     space1: whitespace(),
                     space2: whitespace(),
                     value: Template {
-                        quotes: false,
+                        delimiter: None,
                         elements: vec![TemplateElement::String {
                             value: "Bar".to_string(),
                             encoded: "unused".to_string(),
@@ -682,7 +682,7 @@ pub mod tests {
             value: QueryValue::Header {
                 space0: whitespace(),
                 name: Template {
-                    quotes: false,
+                    delimiter: None,
                     elements: vec![TemplateElement::String {
                         value: "Content-Length".to_string(),
                         encoded: "10".to_string(),

--- a/packages/hurlfmt/src/format/text.rs
+++ b/packages/hurlfmt/src/format/text.rs
@@ -92,7 +92,7 @@ pub fn format_token(token: Token, color: bool) -> String {
                 value
             }
         }
-        Token::Quote(value) => {
+        Token::StringDelimiter(value) => {
             if color {
                 value.green().to_string()
             } else {

--- a/packages/hurlfmt/tests/json.rs
+++ b/packages/hurlfmt/tests/json.rs
@@ -63,7 +63,7 @@ fn value_string() -> BoxedStrategy<JsonValue> {
     prop_oneof![
         Just(JsonValue::String(Template {
             elements: vec![],
-            quotes: true,
+            delimiter: Some('"'),
             source_info: source_info.clone()
         })),
         Just(JsonValue::String(Template {
@@ -71,7 +71,7 @@ fn value_string() -> BoxedStrategy<JsonValue> {
                 encoded: "Hello".to_string(),
                 value: "Hello".to_string(),
             }],
-            quotes: true,
+            delimiter: Some('"'),
             source_info: source_info.clone()
         })),
         Just(JsonValue::String(Template {
@@ -92,7 +92,7 @@ fn value_string() -> BoxedStrategy<JsonValue> {
                     },
                 })
             ],
-            quotes: true,
+            delimiter: Some('"'),
             source_info
         })),
     ]
@@ -219,7 +219,7 @@ fn value() -> BoxedStrategy<JsonValue> {
                             elements: vec![JsonObjectElement {
                                 space0: "".to_string(),
                                 name: Template {
-                                    quotes: false,
+                                    delimiter: None,
                                     elements: vec![TemplateElement::String {
                                         value: "key1".to_string(),
                                         encoded: "key1".to_string(),
@@ -250,7 +250,7 @@ fn format_token(token: Token) -> String {
         | Token::Boolean(s)
         | Token::String(s)
         | Token::Keyword(s)
-        | Token::Quote(s)
+        | Token::StringDelimiter(s)
         | Token::QueryType(s)
         | Token::CodeVariable(s)
         | Token::CodeDelimiter(s) => s,


### PR DESCRIPTION
We're changing the `Template` AST struct from:

```rust
pub struct Template {
    pub quotes: bool,
    pub elements: Vec<TemplateElement>,
    pub source_info: SourceInfo,
}
```

to 

```rust
pub struct Template {
    pub delimiter: Option<char>,
    pub elements: Vec<TemplateElement>,
    pub source_info: SourceInfo,
}
```

In order to facilitate incoming changes on one line string (body `` `foo` ``)