### PR TITLE
Add issue templates: Bug report, feature proposal

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,48 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: 'bug'
+assignees: ''
+---
+<!---
+Please read this!
+Before opening a new issue, make sure to search for keywords in the issues
+filtered by the "bug" label
+- https://github.com/Orange-OpenSource/hurl/issues?q=is%3Aopen+is%3Aissue+label%3Abug
+and verify the issue you're about to submit isn't a duplicate.
+--->
+
+### Summary
+<!-- Summarize the bug encountered concisely. -->
+
+### Steps to reproduce
+<!-- Describe how one can reproduce the issue - this is very important. Please use an ordered list. -->
+
+### Example Project
+<!-- If possible, please create an example project on GitHub.com or GitLab.com that exhibits the problematic
+behavior, and link to it here in the bug report. If you are using an older version of Hurl, this
+will also determine whether the bug is fixed in a more recent version. -->
+
+### What is the current *bug* behavior?
+<!-- Describe what actually happens. -->
+
+### What is the expected *correct* behavior?
+<!-- Describe what you should see instead. -->
+
+### Relevant logs and/or screenshots
+<!-- Paste any relevant logs - please use code blocks (```) to format console output, logs, and code
+ as it's tough to read otherwise. -->
+
+### Output of checks
+<!-- Please include all details about your environment. -->
+
+- Version (`hurl --version`):
+- Operating system and version:
+
+### Possible fixes
+<!-- If you can, link to the line of code that might be responsible for the problem.
+Consider creating a fix and link the pull request here. Thanks in advance!
+-->
+
+

--- a/.github/ISSUE_TEMPLATE/feature_proposal.md
+++ b/.github/ISSUE_TEMPLATE/feature_proposal.md
@@ -1,0 +1,29 @@
+---
+name: Feature proposal
+about: Suggest an idea for this project
+title: ''
+labels: 'enhancement'
+assignees: ''
+
+---
+
+### Problem to solve
+
+<!-- What is the user problem you are trying to solve with this issue? -->
+
+### Proposal
+
+<!-- Use this section to explain the feature and how it will work. It can be helpful to
+add technical details, design proposals, and links to related epics or issues. -->
+
+### Additional context and resources
+
+<!-- Describe the context, use cases, environments, dependencies, and alternative ideas.
+Add helpful URLs when applicable. -->
+
+
+### Tasks to complete
+
+<!-- Tasks that are required to provide this feature. Technical challenges, dependencies, security, documentation, etc. -->
+
+- [ ] ...


### PR DESCRIPTION
Context: I created a few issues and reviewed existing issues, and did some repetitive work to add everything that is helpful. I'm used to following a guided structure in the form of an issue template but do not really like the GitHub-provided defaults. 

This PR includes the following issue templates as a first iteration:

- Bug report
- Feature proposal (intentionally proposal instead of request - everyone can contribute)

The templates are inspired by https://gitlab.com/gitlab-org/gitlab/-/tree/master/.gitlab/issue_templates 