### PR TITLE
Docs: Use apt to install the local Debian/Ubuntu package to resolve dependencies

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -18,7 +18,7 @@ For Debian / Ubuntu, Hurl can be installed using a binary .deb file provided in 
 
 ```shell
 $ curl -LO https://github.com/Orange-OpenSource/hurl/releases/download/1.8.0/hurl_1.8.0_amd64.deb
-$ sudo dpkg -i hurl_1.8.0_amd64.deb
+$ sudo apt update && apt install ./hurl_1.8.0_amd64.deb
 ```
 
 #### Arch Linux / Manjaro


### PR DESCRIPTION
## Problem to solve 

Hurl has a dependency on libxml2 on Debian/Ubuntu. This package isn't automatically installed in a fresh Debian/Ubuntu docker container, and results in a broken installation experience.

## Steps to reproduce 

```
docker run -ti debian:11-slim bash

export HURL_VERSION=1.8.0

apt update && apt install -y curl jq ca-certificates

curl -LO "https://github.com/Orange-OpenSource/hurl/releases/download/${HURL_VERSION}/hurl_${HURL_VERSION}_amd64.deb"

dpkg -i "hurl_${HURL_VERSION}_amd64.deb"
Selecting previously unselected package hurl.
(Reading database ... 7120 files and directories currently installed.)
Preparing to unpack hurl_1.8.0_amd64.deb ...
Unpacking hurl (1.8.0) ...
dpkg: dependency problems prevent configuration of hurl:
 hurl depends on libxml2; however:
  Package libxml2 is not installed.

dpkg: error processing package hurl (--install):
 dependency problems - leaving unconfigured
Errors were encountered while processing:
 hurl
```

## Solution

Use `apt install ./local.deb` to unstall the downloaded debian package file, and resolve its dependencies automatically from the apt repositories. `dpkg` unfortunately does not provide this feature set. 

Tested and verified on Debian 11 Slim. 

```
apt -y install "./hurl_${HURL_VERSION}_amd64.deb"
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'hurl' instead of './hurl_1.8.0_amd64.deb'
The following additional packages will be installed:
  libicu67 libxml2
The following NEW packages will be installed:
  hurl libicu67 libxml2
0 upgraded, 3 newly installed, 0 to remove and 4 not upgraded.
Need to get 9315 kB/10.9 MB of archives.
After this operation, 35.9 MB of additional disk space will be used.
Get:1 /hurl_1.8.0_amd64.deb hurl amd64 1.8.0 [1602 kB]
Get:2 http://deb.debian.org/debian bullseye/main amd64 libicu67 amd64 67.1-7 [8622 kB]
Get:3 http://deb.debian.org/debian-security bullseye-security/main amd64 libxml2 amd64 2.9.10+dfsg-6.7+deb11u3 [693 kB]
Fetched 9315 kB in 2s (4067 kB/s)
debconf: delaying package configuration, since apt-utils is not installed
Selecting previously unselected package libicu67:amd64.
(Reading database ... 7120 files and directories currently installed.)
Preparing to unpack .../libicu67_67.1-7_amd64.deb ...
Unpacking libicu67:amd64 (67.1-7) ...
Selecting previously unselected package libxml2:amd64.
Preparing to unpack .../libxml2_2.9.10+dfsg-6.7+deb11u3_amd64.deb ...
Unpacking libxml2:amd64 (2.9.10+dfsg-6.7+deb11u3) ...
Selecting previously unselected package hurl.
Preparing to unpack /hurl_1.8.0_amd64.deb ...
Unpacking hurl (1.8.0) ...
Setting up libicu67:amd64 (67.1-7) ...
Setting up libxml2:amd64 (2.9.10+dfsg-6.7+deb11u3) ...
Setting up hurl (1.8.0) ...
Processing triggers for libc-bin (2.31-13+deb11u5) ...
```

fixes #1085 