### PR TITLE
Update commit signing docs in Contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ We like to discuss things before implementation and want to be sure that:
 
 ## Pull Requests
 
-- Commits have to be signed.
+- All Git commits are required to be [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification). For a single commit, use `git commit -S --amend` and force push the branch.
 - All tests must be green before merge.
 - Hurl git history is linear, so we ask to rebase your PR before final merge. 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ We like to discuss things before implementation and want to be sure that:
 
 ## Pull Requests
 
-- All Git commits are required to be [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification). For a single commit, use `git commit -S --amend` and force push the branch.
+- All Git commits are required to be [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) to be marked as "Verified": signed with a GPG, SSH, or S/MIME that is successfully verified by GitHub. For changing a single commit after creating the PR, use `git commit -S --amend` and force push the branch.
 - All tests must be green before merge.
 - Hurl git history is linear, so we ask to rebase your PR before final merge. 
 


### PR DESCRIPTION
Signing a commit can mean "signed off" or "signed with a GPG key". This PR updates the contributing docs, refines the wording and adds the GH documentation URL that usually pops up after the PR has been created. 