### PR TITLE
Fix key-string parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,9 +60,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
-version = "0.13.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
 
 [[package]]
 name = "bit-set"
@@ -780,9 +780,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.78"
+version = "0.9.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07d5c8cb6e57b3a3612064d7b18b117912b4ce70955c2504d4b741c9e244b132"
+checksum = "5454462c0eced1e97f2ec09036abc8da362e66802f66fd20f86854d9d8cbcbc4"
 dependencies = [
  "autocfg",
  "cc",
@@ -962,9 +962,9 @@ checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
 name = "rustix"
-version = "0.36.4"
+version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb93e85278e08bb5788653183213d3a60fc242b10cb9be96586f5a73dcb67c23"
+checksum = "a3807b5d10909833d3e9acd1eb5fb988f79376ff10fce42937de71a449c4c588"
 dependencies = [
  "bitflags",
  "errno",
@@ -1150,9 +1150,9 @@ checksum = "a9b2228007eba4120145f785df0f6c92ea538f5a3635a612ecf4e334c8c1446d"
 
 [[package]]
 name = "typenum"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "unicode-bidi"

--- a/docs/spec/hurl.grammar
+++ b/docs/spec/hurl.grammar
@@ -319,7 +319,7 @@ key-string: (key-string-content | template)+
 
 key-string-content: (key-string-text | key-string-escaped-char)*
 
-key-string-text: ~[#: \n\r\t\\]+
+key-string-text: (alphanum | "_" | "-" | "." | "[" | "]" | "@" | "$") +
 
 key-string-escaped-char: "\\" ("#" | ":" | "\\" | "\b" | "\f" | "\n" | "\r" | "\t" | "\u" unicode-char )
 
@@ -418,7 +418,9 @@ filter:
   | count-filter
   | url-encode-filter
   | url-decode-filter
-  | to-int
+  | html-encode-filter
+  | html-decode-filter
+  | to-int-filter
 
 regex-filter: "regex" sp (quoted-string | regex)
 
@@ -432,13 +434,15 @@ html-encode-filter: "htmlEscape"
 
 html-decode-filter: "htmlUnescape"
 
-to-int: "toInt"
+to-int-filter: "toInt"
 
 # Lexical Grammar
 
 boolean: "true" | "false"
 
 null: "null"
+
+alphanum: [A-Za-z0-9]
 
 integer: digit+
 

--- a/packages/hurl/Cargo.toml
+++ b/packages/hurl/Cargo.toml
@@ -18,7 +18,7 @@ strict = []
 
 [dependencies]
 atty = "0.2.14"
-base64 = "0.13.1"
+base64 = "0.20.0"
 brotli = "3.3.4"
 chrono = { version = "0.4.23", default-features = false, features = ["clock"] }
 clap = { version = "4.0.29", features = ["cargo", "string", "wrap_help"] }

--- a/packages/hurlfmt/Cargo.toml
+++ b/packages/hurlfmt/Cargo.toml
@@ -15,7 +15,7 @@ strict = []
 
 [dependencies]
 atty = "0.2.14"
-base64 = "0.13.1"
+base64 = "0.20.0"
 clap = { version = "4.0.29", features = ["cargo", "wrap_help"] }
 colored = "2.0.0"
 hurl_core = { version = "2.0.0-SNAPSHOT", path = "../hurl_core" }


### PR DESCRIPTION
in #1045, we aligned the parser implementation for the key-string with the grammar using a blacklist pattern `~[#:\n\\]+`
It turns out to be not very robust as it can now accept one-line JSON such as `{"id":1}`.

We will therefore come back to a whitelist pattern.
`(alphanum | "_" | "-" | "." | "[" | "]" | "@" | "$") +`