### PR TITLE
fix debian installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -857,7 +857,7 @@ For Debian / Ubuntu, Hurl can be installed using a binary .deb file provided in 
 
 ```shell
 $ curl -LO https://github.com/Orange-OpenSource/hurl/releases/download/1.8.0/hurl_1.8.0_amd64.deb
-$ sudo apt update && apt install ./hurl_1.8.0_amd64.deb
+$ sudo dpkg -i ./hurl_1.8.0_amd64.deb
 ```
 
 #### Arch Linux / Manjaro

--- a/README.md
+++ b/README.md
@@ -857,7 +857,7 @@ For Debian / Ubuntu, Hurl can be installed using a binary .deb file provided in 
 
 ```shell
 $ curl -LO https://github.com/Orange-OpenSource/hurl/releases/download/1.8.0/hurl_1.8.0_amd64.deb
-$ sudo dpkg -i ./hurl_1.8.0_amd64.deb
+$ sudo dpkg -i hurl_1.8.0_amd64.deb
 ```
 
 #### Arch Linux / Manjaro


### PR DESCRIPTION
For installation on [Debian / Ubuntu](https://github.com/Orange-OpenSource/hurl#debian--ubuntu):

```shell
$ curl -LO https://github.com/Orange-OpenSource/hurl/releases/download/1.8.0/hurl_1.8.0_amd64.deb
$ sudo apt update && apt install ./hurl_1.8.0_amd64.deb
```
Doesn't work for me (On a debian distro). I guess it's because it miss the second ```sudo````.

But i suggest we use debian package manager (```dpkg```) since ```apt install``` also call ```dpkg``` under the hood