### PR TITLE
Use an uuid as identifier for the HTML Hurl file run report

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,6 +522,7 @@ dependencies = [
  "sha2",
  "termion",
  "url",
+ "uuid",
  "winres",
  "xmltree",
 ]
@@ -1191,6 +1192,16 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+]
+
+[[package]]
+name = "uuid"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
+dependencies = [
+ "getrandom",
+ "rand",
 ]
 
 [[package]]

--- a/packages/hurl/Cargo.toml
+++ b/packages/hurl/Cargo.toml
@@ -42,6 +42,8 @@ sha2 = "0.10.6"
 url = "2.3.1"
 xmltree = { version = "0.10.3",  features = ["attribute-order"] }
 lazy_static = "1.4.0"
+# uuid features: lets you generate random UUIDs and use a faster (but still sufficiently random) RNG
+uuid = { version = "1.3.0", features = ["v4" , "fast-rng"] }
 
 [target.'cfg(unix)'.dependencies]
 termion = "2.0.1"

--- a/packages/hurl/src/report/html/testcase.rs
+++ b/packages/hurl/src/report/html/testcase.rs
@@ -17,14 +17,14 @@
  */
 use super::Error;
 use crate::runner::HurlResult;
-use crate::util::path;
 use hurl_core::parser;
 use std::io::Write;
 use std::path::Path;
+use uuid::Uuid;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Testcase {
-    id: String,
+    pub id: String,
     pub filename: String,
     pub success: bool,
     pub time_in_ms: u128,
@@ -33,8 +33,9 @@ pub struct Testcase {
 impl Testcase {
     /// Creates an HTML testcase.
     pub fn from(hurl_result: &HurlResult) -> Testcase {
+        let id = Uuid::new_v4();
         Testcase {
-            id: "to-be-defined".to_string(),
+            id: id.to_string(),
             filename: hurl_result.filename.to_string(),
             time_in_ms: hurl_result.time_in_ms,
             success: hurl_result.success,
@@ -45,19 +46,14 @@ impl Testcase {
     ///
     /// For the moment, it's just an export of this HTML file, with syntax colored.
     pub fn write_html(&self, content: &str, dir_path: &Path) -> Result<(), Error> {
-        let relative_input_file = path::canonicalize_filename(&self.filename);
-        let absolute_input_file = dir_path.join(format!("{relative_input_file}.html"));
+        let output_file = dir_path.join("store").join(format!("{}.html", self.id));
 
-        let parent = absolute_input_file.parent().expect("a parent");
+        let parent = output_file.parent().expect("a parent");
         std::fs::create_dir_all(parent).unwrap();
-        let mut file = match std::fs::File::create(&absolute_input_file) {
+        let mut file = match std::fs::File::create(&output_file) {
             Err(why) => {
                 return Err(Error {
-                    message: format!(
-                        "Issue writing to {}: {:?}",
-                        absolute_input_file.display(),
-                        why
-                    ),
+                    message: format!("Issue writing to {}: {:?}", output_file.display(), why),
                 });
             }
             Ok(file) => file,
@@ -68,11 +64,7 @@ impl Testcase {
 
         if let Err(why) = file.write_all(s.as_bytes()) {
             return Err(Error {
-                message: format!(
-                    "Issue writing to {}: {:?}",
-                    absolute_input_file.display(),
-                    why
-                ),
+                message: format!("Issue writing to {}: {:?}", output_file.display(), why),
             });
         }
         Ok(())

--- a/packages/hurl/src/util/path.rs
+++ b/packages/hurl/src/util/path.rs
@@ -17,14 +17,6 @@
  */
 use std::path::{Component, Path, PathBuf};
 
-/// Returns the canonical fullname relative to / (technically a relative path)
-/// The function will panic if the input file does not exist
-pub fn canonicalize_filename(input_file: &str) -> String {
-    let relative_input_file = Path::new(input_file).canonicalize().expect("existing file");
-    let relative_input_file = relative_input_file.to_string_lossy();
-    relative_input_file.trim_start_matches('/').to_string()
-}
-
 /// Return true if `path` is a descendant path of `ancestor`, false otherwise.
 pub fn is_descendant(path: &Path, ancestor: &Path) -> bool {
     let path = normalize_path(path);


### PR DESCRIPTION
Fixes #1285, fixes #1283