### PR TITLE
Add certificate in HTTP response

### DIFF
--- a/packages/hurl/src/http/certificate.rs
+++ b/packages/hurl/src/http/certificate.rs
@@ -16,7 +16,9 @@
  *
  */
 
-use chrono::{DateTime, Utc};
+use crate::http::easy_ext::CertInfo;
+use chrono::{DateTime, NaiveDateTime, Utc};
+use std::collections::HashMap;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Certificate {
@@ -25,4 +27,161 @@ pub struct Certificate {
     pub start_date: DateTime<Utc>,
     pub expire_date: DateTime<Utc>,
     pub serial_number: String,
+}
+
+impl TryFrom<CertInfo> for Certificate {
+    type Error = String;
+
+    /// parse `cert_info`
+    /// support different "formats" in cert info
+    /// - attribute name: "Start date" vs "Start Date"
+    /// - date format: "Jan 10 08:29:52 2023 GMT" vs "2023-01-10 08:29:52 GMT"
+    fn try_from(cert_info: CertInfo) -> Result<Self, Self::Error> {
+        let attributes = parse_attributes(&cert_info.data);
+        let subject = parse_subject(&attributes)?;
+        let issuer = parse_issuer(&attributes)?;
+        let start_date = parse_start_date(&attributes)?;
+        let expire_date = parse_expire_date(&attributes)?;
+        let serial_number = parse_serial_number(&attributes)?;
+        Ok(Certificate {
+            subject,
+            issuer,
+            start_date,
+            expire_date,
+            serial_number,
+        })
+    }
+}
+
+fn parse_subject(attributes: &HashMap<String, String>) -> Result<String, String> {
+    attributes
+        .get("subject")
+        .cloned()
+        .ok_or(format!("missing Subject attribute in {attributes:?}"))
+}
+
+fn parse_issuer(attributes: &HashMap<String, String>) -> Result<String, String> {
+    attributes
+        .get("issuer")
+        .cloned()
+        .ok_or(format!("missing issuer attribute in {attributes:?}"))
+}
+
+fn parse_start_date(attributes: &HashMap<String, String>) -> Result<DateTime<Utc>, String> {
+    match attributes.get("start date") {
+        None => Err(format!("missing start date attribute in {attributes:?}")),
+        Some(value) => Ok(parse_date(value)?),
+    }
+}
+
+fn parse_expire_date(attributes: &HashMap<String, String>) -> Result<DateTime<Utc>, String> {
+    match attributes.get("expire date") {
+        None => Err("missing expire date attribute".to_string()),
+        Some(value) => Ok(parse_date(value)?),
+    }
+}
+
+fn parse_date(value: &str) -> Result<DateTime<Utc>, String> {
+    let naive_date_time = match NaiveDateTime::parse_from_str(value, "%b %d %H:%M:%S %Y GMT") {
+        Ok(d) => d,
+        Err(_) => NaiveDateTime::parse_from_str(value, "%Y-%m-%d %H:%M:%S GMT")
+            .map_err(|_| format!("can not parse date <{value}>"))?,
+    };
+    Ok(naive_date_time.and_local_timezone(Utc).unwrap())
+}
+
+fn parse_serial_number(attributes: &HashMap<String, String>) -> Result<String, String> {
+    attributes
+        .get("serial number")
+        .cloned()
+        .ok_or(format!("Missing serial number attribute in {attributes:?}"))
+}
+
+fn parse_attributes(data: &Vec<String>) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+    for s in data {
+        if let Some((name, value)) = parse_attribute(s) {
+            map.insert(name.to_lowercase(), value);
+        }
+    }
+    map
+}
+
+fn parse_attribute(s: &str) -> Option<(String, String)> {
+    if let Some(index) = s.find(':') {
+        let (name, value) = s.split_at(index);
+        Some((name.to_string(), value[1..].to_string()))
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::http::certificate::Certificate;
+    use crate::http::easy_ext::CertInfo;
+
+    #[test]
+    fn test_parse_start_date() {
+        let mut attributes = HashMap::new();
+        attributes.insert(
+            "start date".to_string(),
+            "Jan 10 08:29:52 2023 GMT".to_string(),
+        );
+        assert_eq!(
+            parse_start_date(&attributes).unwrap(),
+            chrono::DateTime::parse_from_rfc2822("Tue, 10 Jan 2023 08:29:52 GMT")
+                .unwrap()
+                .with_timezone(&chrono::Utc)
+        );
+
+        let mut attributes = HashMap::new();
+        attributes.insert(
+            "start date".to_string(),
+            "2023-01-10 08:29:52 GMT".to_string(),
+        );
+        assert_eq!(
+            parse_start_date(&attributes).unwrap(),
+            chrono::DateTime::parse_from_rfc2822("Tue, 10 Jan 2023 08:29:52 GMT")
+                .unwrap()
+                .with_timezone(&chrono::Utc)
+        )
+    }
+
+    #[test]
+    fn test_try_from() {
+        assert_eq!(
+            Certificate::try_from(CertInfo {
+                data: vec![
+                    "Subject:C = US, ST = Denial, L = Springfield, O = Dis, CN = localhost"
+                        .to_string(),
+                    "Issuer:C = US, ST = Denial, L = Springfield, O = Dis, CN = localhost"
+                        .to_string(),
+                    "Serial Number:1ee8b17f1b64d8d6b3de870103d2a4f533535ab0".to_string(),
+                    "Start date:Jan 10 08:29:52 2023 GMT".to_string(),
+                    "Expire date:Oct 30 08:29:52 2025 GMT".to_string(),
+                ]
+            })
+            .unwrap(),
+            Certificate {
+                subject: "C = US, ST = Denial, L = Springfield, O = Dis, CN = localhost"
+                    .to_string(),
+                issuer: "C = US, ST = Denial, L = Springfield, O = Dis, CN = localhost".to_string(),
+                start_date: chrono::DateTime::parse_from_rfc2822("Tue, 10 Jan 2023 08:29:52 GMT")
+                    .unwrap()
+                    .with_timezone(&chrono::Utc),
+                expire_date: chrono::DateTime::parse_from_rfc2822("Thu, 30 Oct 2025 08:29:52 GMT")
+                    .unwrap()
+                    .with_timezone(&chrono::Utc),
+                serial_number: "1ee8b17f1b64d8d6b3de870103d2a4f533535ab0".to_string()
+            }
+        );
+        assert_eq!(
+            Certificate::try_from(CertInfo { data: vec![] })
+                .err()
+                .unwrap(),
+            "missing Subject attribute in {}".to_string()
+        );
+    }
 }

--- a/packages/hurl/src/http/easy_ext.rs
+++ b/packages/hurl/src/http/easy_ext.rs
@@ -23,6 +23,7 @@ use std::ptr;
 
 /// Represents certificate information.
 /// `data` has format "name:content";
+#[derive(Clone)]
 pub struct CertInfo {
     pub data: Vec<String>,
 }

--- a/packages/hurl/src/http/mod.rs
+++ b/packages/hurl/src/http/mod.rs
@@ -16,6 +16,7 @@
  *
  */
 
+pub use self::certificate::Certificate;
 pub use self::client::Client;
 pub use self::context_dir::ContextDir;
 pub use self::cookie::{CookieAttribute, ResponseCookie};

--- a/packages/hurl/tests/libcurl.rs
+++ b/packages/hurl/tests/libcurl.rs
@@ -613,6 +613,45 @@ fn test_cacert() {
     let request_spec = default_get_request("https://localhost:8001/hello");
     let (_, response) = client.execute(&request_spec, &options, &logger).unwrap();
     assert_eq!(response.status, 200);
+
+    let certificate = response.certificate.unwrap();
+
+    let issuer = certificate.issuer;
+    let issuers = [
+        "C = US, ST = Denial, L = Springfield, O = Dis, CN = localhost".to_string(),
+        "C=US, ST=Denial, L=Springfield, O=Dis, CN=localhost".to_string(),
+    ];
+    assert!(issuers.contains(&issuer), "actual issuer is {issuer}");
+
+    let subject = certificate.subject;
+    let subjects = [
+        "C = US, ST = Denial, L = Springfield, O = Dis, CN = localhost".to_string(),
+        "C=US, ST=Denial, L=Springfield, O=Dis, CN=localhost".to_string(),
+    ];
+    assert!(subjects.contains(&subject), "actual subject is {subject}");
+
+    assert_eq!(
+        certificate.start_date,
+        chrono::DateTime::parse_from_rfc2822("Tue, 10 Jan 2023 08:29:52 GMT")
+            .unwrap()
+            .with_timezone(&chrono::Utc)
+    );
+    assert_eq!(
+        certificate.expire_date,
+        chrono::DateTime::parse_from_rfc2822("Thu, 30 Oct 2025 08:29:52 GMT")
+            .unwrap()
+            .with_timezone(&chrono::Utc)
+    );
+
+    let serial_number = certificate.serial_number;
+    let serial_numbers = [
+        "1ee8b17f1b64d8d6b3de870103d2a4f533535ab0".to_string(),
+        "1e:e8:b1:7f:1b:64:d8:d6:b3:de:87:01:03:d2:a4:f5:33:53:5a:b0:".to_string(),
+    ];
+    assert!(
+        serial_numbers.contains(&serial_number),
+        "actual serial_number is {serial_number}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
```
$ hurl <<<"GET https://hurl.dev" --json | jq '.entries|.[0].calls|.[0].response.certificate'
{
  "expire_date": "2023-04-29 10:44:12 UTC",
  "issue": "C = US, O = Let's Encrypt, CN = R3",
  "serial_number": "03dbc4f3c85e1366cc52a3692cfa04a07bb1",
  "start_date": "2023-01-29 10:44:13 UTC",
  "subject": "CN = hurl.dev"
}
```
Remarks:
The cert_info strings can be different in Linux/Mac and windows:
- attribute name: `Start date` vs `Start Date`
- issuer:  `C = US, ST = Denial, L = Springfield, O = Dis, CN = localhost` vs `C=US, ST=Denial, L=Springfield, O=Dis, CN=localhost`
- serial number:  `1ee8b17f1b64d8d6b3de870103d2a4f533535ab0` vs `1e:e8:b1:7f:1b:64:d8:d6:b3:de:87:01:03:d2:a4:f5:33:53:5a:b0:`
- date format: `Jan 10 08:29:52 2023 GMT" vs "2023-01-10 08:29:52 GMT`
