### PR TITLE
Add certificate query

### DIFF
--- a/docs/spec/hurl.grammar
+++ b/docs/spec/hurl.grammar
@@ -192,7 +192,7 @@ url-query: "url"
 
 header-query: "header" sp quoted-string
 
-certificate-query: "certificate" sp ("Subject" | "Issuer" | "Start date" | "Expire date" | "Serial Number")
+certificate-query: "certificate" sp ("Subject" | "Issuer" | "Start-Date" | "Expire-Date" | "Serial-Number")
 
 cookie-query: "cookie" sp quoted-string
 

--- a/integration/ssl/insecure.curl
+++ b/integration/ssl/insecure.curl
@@ -1,3 +1,3 @@
 curl --insecure 'https://localhost:8001/hello'
-curl --insecure 'https://localhost:8001/hello'
+
 

--- a/integration/ssl/insecure.hurl
+++ b/integration/ssl/insecure.hurl
@@ -1,7 +1,11 @@
 GET https://localhost:8001/hello
 
 HTTP 200
-`Hello World!`
+[Asserts]
+certificate "Subject" == "C=US, ST=Denial, L=Springfield, O=Dis, CN=localhost"
+certificate "Issuer" == "C=US, ST=Denial, L=Springfield, O=Dis, CN=localhost"
+certificate "Start-Date" format "%Y-%M-%d %H:%m:%S UTC" == "2023-29-10 08:01:52 UTC"
+certificate "Expire-Date" format "%Y-%M-%d %H:%m:%S UTC" == "2025-29-30 08:10:52 UTC"
+certificate "Serial-Number" == "1e:e8:b1:7f:1b:64:d8:d6:b3:de:87:01:03:d2:a4:f5:33:53:5a:b0"
 
-GET https://localhost:8001/hello
-HTTP 200
+`Hello World!`

--- a/packages/hurl_core/src/ast/core.rs
+++ b/packages/hurl_core/src/ast/core.rs
@@ -336,6 +336,10 @@ pub enum QueryValue {
     Bytes {},
     Sha256 {},
     Md5 {},
+    Certificate {
+        space0: Whitespace,
+        attribute_name: CertificateAttributeName,
+    },
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -382,6 +386,15 @@ impl CookieAttributeName {
             | CookieAttributeName::SameSite(value) => value.to_string(),
         }
     }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum CertificateAttributeName {
+    Subject,
+    Issuer,
+    StartDate,
+    ExpireDate,
+    SerialNumber,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/packages/hurl_core/src/format/html.rs
+++ b/packages/hurl_core/src/format/html.rs
@@ -649,6 +649,14 @@ impl Htmlable for QueryValue {
             QueryValue::Md5 {} => {
                 buffer.push_str("<span class=\"query-type\">md5</span>");
             }
+            QueryValue::Certificate {
+                space0,
+                attribute_name: field,
+            } => {
+                buffer.push_str("<span class=\"query-type\">certificate</span>");
+                buffer.push_str(space0.to_html().as_str());
+                buffer.push_str(field.to_html().as_str());
+            }
         }
         buffer
     }
@@ -685,6 +693,20 @@ impl Htmlable for CookieAttribute {
         buffer.push_str(self.name.value().as_str());
         buffer.push_str(self.space1.to_html().as_str());
         buffer
+    }
+}
+
+impl Htmlable for CertificateAttributeName {
+    fn to_html(&self) -> String {
+        let value = match self {
+            CertificateAttributeName::Subject => "Subject",
+            CertificateAttributeName::Issuer => "Issuer",
+            CertificateAttributeName::StartDate => "Start-Date",
+            CertificateAttributeName::ExpireDate => "Expire-Date",
+            CertificateAttributeName::SerialNumber => "Serial-Number",
+        }
+        .to_string();
+        format!("<span class=\"string\">{value}</span>")
     }
 }
 

--- a/packages/hurlfmt/src/format/json.rs
+++ b/packages/hurlfmt/src/format/json.rs
@@ -346,6 +346,16 @@ fn query_value_attributes(query_value: &QueryValue) -> Vec<(String, JValue)> {
         QueryValue::Md5 {} => {
             attributes.push(("type".to_string(), JValue::String("md5".to_string())));
         }
+        QueryValue::Certificate {
+            attribute_name: field,
+            ..
+        } => {
+            attributes.push((
+                "type".to_string(),
+                JValue::String("certificate".to_string()),
+            ));
+            attributes.push(("expr".to_string(), field.to_json()));
+        }
     };
     attributes
 }
@@ -366,6 +376,19 @@ impl ToJson for Regex {
             ("value".to_string(), JValue::String(self.to_string())),
         ];
         JValue::Object(attributes)
+    }
+}
+
+impl ToJson for CertificateAttributeName {
+    fn to_json(&self) -> JValue {
+        let value = match self {
+            CertificateAttributeName::Subject => "Subject",
+            CertificateAttributeName::Issuer => "Issuer",
+            CertificateAttributeName::StartDate => "Start-Date",
+            CertificateAttributeName::ExpireDate => "Expire-Date",
+            CertificateAttributeName::SerialNumber => "Serial-Number",
+        };
+        JValue::String(value.to_string())
     }
 }
 

--- a/packages/hurlfmt/src/format/token.rs
+++ b/packages/hurlfmt/src/format/token.rs
@@ -434,6 +434,14 @@ impl Tokenizable for QueryValue {
             QueryValue::Bytes {} => tokens.push(Token::QueryType(String::from("bytes"))),
             QueryValue::Sha256 {} => tokens.push(Token::QueryType(String::from("sha256"))),
             QueryValue::Md5 {} => tokens.push(Token::QueryType(String::from("md5"))),
+            QueryValue::Certificate {
+                space0,
+                attribute_name: field,
+            } => {
+                tokens.push(Token::QueryType(String::from("certificate")));
+                tokens.append(&mut space0.tokenize());
+                tokens.append(&mut field.tokenize());
+            }
         }
         tokens
     }
@@ -467,6 +475,19 @@ impl Tokenizable for CookieAttribute {
         tokens.append(&mut self.space1.tokenize());
         tokens.push(Token::CodeDelimiter("]".to_string()));
         tokens
+    }
+}
+
+impl Tokenizable for CertificateAttributeName {
+    fn tokenize(&self) -> Vec<Token> {
+        let value = match self {
+            CertificateAttributeName::Subject => "Subject",
+            CertificateAttributeName::Issuer => "Issuer",
+            CertificateAttributeName::StartDate => "Start-Date",
+            CertificateAttributeName::ExpireDate => "Expire-Date",
+            CertificateAttributeName::SerialNumber => "Serial-Number",
+        };
+        vec![Token::String(value.to_string())]
     }
 }
 

--- a/packages/hurlfmt/src/linter/rules.rs
+++ b/packages/hurlfmt/src/linter/rules.rs
@@ -272,6 +272,13 @@ fn lint_query_value(query_value: &QueryValue) -> QueryValue {
         QueryValue::Bytes {} => QueryValue::Bytes {},
         QueryValue::Sha256 {} => QueryValue::Sha256 {},
         QueryValue::Md5 {} => QueryValue::Md5 {},
+        QueryValue::Certificate {
+            attribute_name: field,
+            ..
+        } => QueryValue::Certificate {
+            attribute_name: field.clone(),
+            space0: one_whitespace(),
+        },
     }
 }
 


### PR DESCRIPTION
```
GET https://localhost:8001/hello

HTTP 200
[Asserts]
certificate "Subject" == "C=US, ST=Denial, L=Springfield, O=Dis, CN=localhost"
certificate "Issuer" == "C=US, ST=Denial, L=Springfield, O=Dis, CN=localhost"
certificate "Start-Date" format "%Y-%M-%d %H:%m:%S UTC" == "2023-29-10 08:01:52 UTC"
certificate "Expire-Date" format "%Y-%M-%d %H:%m:%S UTC" == "2025-29-30 08:10:52 UTC"
certificate "Serial-Number" == "1e:e8:b1:7f:1b:64:d8:d6:b3:de:87:01:03:d2:a4:f5:33:53:5a:b0"

`Hello World!`
```

The asserts on the certificate are independent of the HTTPS connection.
We can access an HTTPS  endpoint with an invalid certificate using an insecure connection (`--insecure /-k`) and still be able to check the certificate attributes.

