### PR TITLE
Remove hurl_file from run api

### DIFF
--- a/packages/hurl/src/http/tests/runner.rs
+++ b/packages/hurl/src/http/tests/runner.rs
@@ -18,126 +18,16 @@
 
 use std::collections::HashMap;
 
-use hurl_core::ast::*;
-
 use crate::runner;
 use crate::runner::RunnerOptions;
 use crate::util::logger::LoggerBuilder;
 
-fn hello_request() -> Request {
-    // GET http://localhost;8000/hello
-    let source_info = SourceInfo {
-        start: Pos { line: 1, column: 1 },
-        end: Pos { line: 1, column: 1 },
-    };
-    let whitespace = Whitespace {
-        value: "".to_string(),
-        source_info: source_info.clone(),
-    };
-    let line_terminator = LineTerminator {
-        space0: whitespace.clone(),
-        comment: None,
-        newline: whitespace.clone(),
-    };
-    Request {
-        line_terminators: vec![],
-        space0: whitespace.clone(),
-        method: Method::Get,
-        space1: whitespace.clone(),
-        url: Template {
-            delimiter: None,
-            elements: vec![TemplateElement::String {
-                value: "http://localhost:8000/hello".to_string(),
-                encoded: "http://localhost:8000/hello".to_string(),
-            }],
-            source_info: source_info.clone(),
-        },
-        line_terminator0: LineTerminator {
-            space0: whitespace.clone(),
-            comment: None,
-            newline: whitespace.clone(),
-        },
-        headers: vec![KeyValue {
-            line_terminators: vec![],
-            space0: whitespace.clone(),
-            key: EncodedString {
-                quotes: false,
-                value: "User-Agent".to_string(),
-                encoded: "User-Agent".to_string(),
-                source_info: source_info.clone(),
-            },
-            space1: whitespace.clone(),
-            space2: whitespace,
-            value: Template {
-                delimiter: None,
-                elements: vec![TemplateElement::String {
-                    value: "test".to_string(),
-                    encoded: "test".to_string(),
-                }],
-                source_info: source_info.clone(),
-            },
-            line_terminator0: line_terminator,
-        }],
-        sections: vec![],
-        body: None,
-        source_info,
-    }
-}
-
 #[test]
 fn test_hello() {
-    // We construct a Hurl file ast "by hand", with fake source info.
-    // In this particular case, the raw content is empty as the Hurl file hasn't
-    // been built from a text content.
-    let content = "";
-    let filename = "filename";
+    let content = "GET http://localhost;8000/hello";
+    let filename = "";
     let logger = LoggerBuilder::new().build();
-
-    let source_info = SourceInfo {
-        start: Pos { line: 1, column: 1 },
-        end: Pos { line: 1, column: 1 },
-    };
-    let whitespace = Whitespace {
-        value: "".to_string(),
-        source_info: source_info.clone(),
-    };
-    let request = hello_request();
-    let hurl_file = HurlFile {
-        entries: vec![Entry {
-            request,
-            response: Some(Response {
-                line_terminators: vec![],
-                version: Version {
-                    value: VersionValue::Version11,
-                    source_info: source_info.clone(),
-                },
-                space0: whitespace.clone(),
-                status: Status {
-                    value: StatusValue::Specific(200),
-                    source_info: source_info.clone(),
-                },
-                space1: whitespace.clone(),
-                line_terminator0: LineTerminator {
-                    space0: whitespace.clone(),
-                    comment: None,
-                    newline: whitespace,
-                },
-                headers: vec![],
-                sections: vec![],
-                body: None,
-                source_info,
-            }),
-        }],
-        line_terminators: vec![],
-    };
     let variables = HashMap::new();
     let runner_options = RunnerOptions::default();
-    runner::run(
-        &hurl_file,
-        content,
-        filename,
-        &runner_options,
-        &variables,
-        &logger,
-    );
+    runner::run(content, filename, &runner_options, &variables, &logger).unwrap();
 }

--- a/packages/hurl/src/report/html/testcase.rs
+++ b/packages/hurl/src/report/html/testcase.rs
@@ -18,7 +18,7 @@
 use std::io::Write;
 use std::path::Path;
 
-use hurl_core::ast::HurlFile;
+use hurl_core::parser;
 use uuid::Uuid;
 
 use super::Error;
@@ -47,7 +47,7 @@ impl Testcase {
     /// Exports a [`Testcase`] to HTML.
     ///
     /// For the moment, it's just an export of this HTML file, with syntax colored.
-    pub fn write_html(&self, hurl_file: &HurlFile, dir_path: &Path) -> Result<(), Error> {
+    pub fn write_html(&self, content: &str, dir_path: &Path) -> Result<(), Error> {
         let output_file = dir_path.join("store").join(format!("{}.html", self.id));
 
         let parent = output_file.parent().expect("a parent");
@@ -60,7 +60,8 @@ impl Testcase {
             }
             Ok(file) => file,
         };
-        let s = hurl_core::format::format_html(hurl_file, true);
+        let hurl_file = parser::parse_hurl_file(content).unwrap();
+        let s = hurl_core::format::format_html(&hurl_file, true);
 
         if let Err(why) = file.write_all(s.as_bytes()) {
             return Err(Error {

--- a/packages/hurl/src/runner/core.rs
+++ b/packages/hurl/src/runner/core.rs
@@ -112,10 +112,6 @@ pub struct CaptureResult {
 
 pub type PredicateResult = Result<(), Error>;
 
-// endregion
-
-// region error
-
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Error {
     pub source_info: SourceInfo,
@@ -209,5 +205,3 @@ pub enum RunnerError {
     FilterInvalidInput(String),
     FilterRegexNoCapture {},
 }
-
-// endregion


### PR DESCRIPTION
We only use the content as input and do the parsing inside run method.