### PR TITLE
Add test attributes to junit XML

### DIFF
--- a/packages/hurl/src/report/junit/mod.rs
+++ b/packages/hurl/src/report/junit/mod.rs
@@ -112,6 +112,21 @@ pub fn write_report(filename: &str, testcases: &[Testcase]) -> Result<(), Error>
 }
 
 fn create_testsuite(testcases: &[Testcase]) -> XMLNode {
+    let mut attributes = indexmap::map::IndexMap::new();
+    let mut tests = 0;
+    let mut errors = 0;
+    let mut failures = 0;
+
+    for cases in testcases.iter() {
+        tests += 1;
+        errors += cases.get_error_count();
+        failures += cases.get_fail_count();
+    }
+
+    attributes.insert("tests".to_string(), tests.to_string());
+    attributes.insert("errors".to_string(), errors.to_string());
+    attributes.insert("failures".to_string(), failures.to_string());
+
     let children = testcases
         .iter()
         .map(|t| XMLNode::Element(t.to_xml()))
@@ -121,7 +136,7 @@ fn create_testsuite(testcases: &[Testcase]) -> XMLNode {
         prefix: None,
         namespace: None,
         namespaces: None,
-        attributes: indexmap::map::IndexMap::new(),
+        attributes: attributes,
         children,
     };
     XMLNode::Element(element)

--- a/packages/hurl/src/report/junit/testcase.rs
+++ b/packages/hurl/src/report/junit/testcase.rs
@@ -96,6 +96,14 @@ impl Testcase {
             children,
         }
     }
+
+    pub fn get_error_count(&self) -> usize {
+        self.errors.len()
+    }
+
+    pub fn get_fail_count(&self) -> usize {
+        self.failures.len()
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Hello,

This PR adds "tests", "failures", and  "errors" attributes to the JUnit report xml.

The JUnit xml generated currently lacks the "tests", "failures", and  "errors" attributes that can go in the "testsuite" tag of the JUnit report xml. Adding these attributes allows even more CI/CD pipelines, like Bitbucket to identify and parse test results correctly.

For example, before we had:

`<?xml version="1.0" encoding="UTF-8"?>
<testsuites>
    <testsuite />
    <testsuite>
        <testcase id="/hurl-files/missing_owner/http_asserts.hurl"
            name="/hurl-files/missing_owner/http_asserts.hurl" time="0.001" />
    </testsuite>
    <testsuite>
        <testcase id="/hurl-files/nil_origin_service/http_asserts.hurl"
            name="/hurl-files/nil_origin_service/http_asserts.hurl" time="0.079" />
    </testsuite>
</testsuites>`

And now we'll have:

`<?xml version="1.0" encoding="UTF-8"?>
<testsuites>
    <testsuite />
    <testsuite tests="1" failures="0" errors="0">
        <testcase id="/hurl-files/missing_owner/http_asserts.hurl"
            name="/hurl-files/missing_owner/http_asserts.hurl" time="0.001" />
    </testsuite>
    <testsuite tests="1" failures="0" errors="0">
        <testcase id="/hurl-files/nil_origin_service/http_asserts.hurl"
            name="/hurl-files/nil_origin_service/http_asserts.hurl" time="0.079" />
    </testsuite>
</testsuites>`
