### PR TITLE
Do not parse key/value in certificate subject/issue any more

### DIFF
--- a/integration/ssl/insecure.hurl
+++ b/integration/ssl/insecure.hurl
@@ -2,8 +2,9 @@ GET https://localhost:8001/hello
 
 HTTP 200
 [Asserts]
-certificate "Subject" == "C=US, ST=Denial, L=Springfield, O=Dis, CN=localhost"
-certificate "Issuer" == "C=US, ST=Denial, L=Springfield, O=Dis, CN=localhost"
+
+certificate "Subject" replace " = " "=" replace ";" ", " == "C=US, ST=Denial, L=Springfield, O=Dis, CN=localhost"
+certificate "Issuer" replace " = " "=" replace ";" ", " == "C=US, ST=Denial, L=Springfield, O=Dis, CN=localhost"
 certificate "Start-Date" format "%Y-%m-%d %H:%M:%S UTC" == "2023-01-10 08:29:52 UTC"
 certificate "Expire-Date" format "%Y-%m-%d %H:%M:%S UTC" == "2025-10-30 08:29:52 UTC"
 certificate "Serial-Number" == "1e:e8:b1:7f:1b:64:d8:d6:b3:de:87:01:03:d2:a4:f5:33:53:5a:b0"

--- a/integration/ssl/letsencrypt.hurl
+++ b/integration/ssl/letsencrypt.hurl
@@ -1,7 +1,7 @@
 GET https://hurl.dev
 HTTP 200
 [Asserts]
-certificate "Subject" == "CN=hurl.dev"
-certificate "Issuer" == "C=US, O=Let's Encrypt, CN=R3"
+certificate "Subject" replace " = " "=" replace ";" ", " == "CN=hurl.dev"
+certificate "Issuer"  replace " = " "=" replace ";" ", " == "C=US, O=Let's Encrypt, CN=R3"
 certificate "Expire-Date" daysAfterNow > 15
 certificate "Serial-Number" matches "[0-9af]+"

--- a/packages/hurl/src/http/tests/libcurl.rs
+++ b/packages/hurl/src/http/tests/libcurl.rs
@@ -653,12 +653,12 @@ fn test_cacert() {
     let certificate = response.certificate.unwrap();
 
     assert_eq!(
-        certificate.issuer,
-        "C = US, ST = Denial, L = Springfield, O = Dis, CN = localhost".to_string()
+        certificate.issuer.replace(" = ", "=").replace(";", " "),
+        "C=US, ST=Denial, L=Springfield, O=Dis, CN=localhost".to_string()
     );
     assert_eq!(
-        certificate.subject,
-        "C = US, ST = Denial, L = Springfield, O = Dis, CN = localhost".to_string()
+        certificate.subject.replace(" = ", "=").replace(";", " "),
+        "C=US, ST=Denial, L=Springfield, O=Dis, CN=localhost".to_string()
     );
     assert_eq!(
         certificate.start_date,


### PR DESCRIPTION
normalize subject/issuer value in the test itself