### PR TITLE
Use `serde_with` helpers to simplify the implementation of `Timings::to_json()`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,6 +209,7 @@ dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
+ "serde",
  "winapi",
 ]
 
@@ -329,6 +330,41 @@ dependencies = [
  "pkg-config",
  "vcpkg",
  "winapi",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -549,6 +585,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "serde_with",
  "sha2",
  "termion",
  "url",
@@ -602,6 +639,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -619,6 +662,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -1027,6 +1071,20 @@ name = "serde"
 version = "1.0.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b88756493a5bd5e5395d53baa70b194b05764ab85b59e43e4b8f4e1192fa9b1"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.174"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e5c3a298c7f978e53536f95a63bdc4c4a64550582f31a0359a9afda6aede62e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "serde_json"
@@ -1037,6 +1095,34 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21e47d95bc83ed33b2ecf84f4187ad1ab9685d18ff28db000c99deac8ce180e3"
+dependencies = [
+ "base64",
+ "chrono",
+ "hex",
+ "indexmap",
+ "serde",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea3cee93715c2e266b9338b7544da68a9f24e227722ba482bd1c024367c77c65"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1120,6 +1206,33 @@ dependencies = [
  "numtoa",
  "redox_syscall 0.2.16",
  "redox_termios",
+]
+
+[[package]]
+name = "time"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446"
+dependencies = [
+ "itoa",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+
+[[package]]
+name = "time-macros"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96ba15a897f3c86766b757e5ac7221554c6750054d74d5b28844fce5fb36a6c4"
+dependencies = [
+ "time-core",
 ]
 
 [[package]]

--- a/packages/hurl/Cargo.toml
+++ b/packages/hurl/Cargo.toml
@@ -37,8 +37,9 @@ libxml = "0.3.3"
 md5 = "0.7.0"
 percent-encoding = "2.3.0"
 regex = "1.9.1"
-serde = "1.0.174"
+serde = { version = "1.0.174", features = ["derive"] }
 serde_json = "1.0.103"
+serde_with = "3.1.0"
 sha2 = "0.10.7"
 url = "2.4.0"
 xmltree = { version = "0.10.3",  features = ["attribute-order"] }

--- a/packages/hurl/src/http/timings.rs
+++ b/packages/hurl/src/http/timings.rs
@@ -25,15 +25,24 @@ use crate::http::easy_ext;
 // See [`easy_ext::namelookup_time_t`], [`easy_ext::connect_time_t`], [`easy_ext::app_connect_time_t`],
 // [`easy_ext::pre_transfer_time_t`], [`easy_ext::start_transfer_time_t`] and [`easy_ext::total_time_t`]
 // for fields definition.
-#[derive(Clone, Debug, PartialEq, Eq, Default)]
+#[serde_with::serde_as]
+#[derive(Clone, Debug, PartialEq, Eq, Default, serde::Serialize)]
 pub struct Timings {
+    #[serde_as(as = "serde_with::DisplayFromStr")]
     pub begin_call: DateTime<Utc>,
+    #[serde_as(as = "serde_with::DisplayFromStr")]
     pub end_call: DateTime<Utc>,
+    #[serde_as(as = "serde_with::DurationMicroSeconds")]
     pub name_lookup: Duration,
+    #[serde_as(as = "serde_with::DurationMicroSeconds")]
     pub connect: Duration,
+    #[serde_as(as = "serde_with::DurationMicroSeconds")]
     pub app_connect: Duration,
+    #[serde_as(as = "serde_with::DurationMicroSeconds")]
     pub pre_transfer: Duration,
+    #[serde_as(as = "serde_with::DurationMicroSeconds")]
     pub start_transfer: Duration,
+    #[serde_as(as = "serde_with::DurationMicroSeconds")]
     pub total: Duration,
 }
 

--- a/packages/hurl/src/json/result.rs
+++ b/packages/hurl/src/json/result.rs
@@ -16,7 +16,6 @@
  *
  */
 use chrono::{DateTime, Utc};
-use serde_json::Number;
 
 use crate::http::{
     Call, Certificate, Cookie, Header, Param, Request, RequestCookie, Response, ResponseCookie,
@@ -268,46 +267,7 @@ impl Certificate {
 
 impl Timings {
     fn to_json(&self) -> serde_json::Value {
-        let mut map = serde_json::Map::new();
-        map.insert(
-            "begin_call".to_string(),
-            serde_json::Value::String(self.begin_call.to_string()),
-        );
-        map.insert(
-            "end_call".to_string(),
-            serde_json::Value::String(self.end_call.to_string()),
-        );
-        let value = self.name_lookup.as_micros() as u64;
-        map.insert(
-            "name_lookup".to_string(),
-            serde_json::Value::Number(Number::from(value)),
-        );
-        let value = self.connect.as_micros() as u64;
-        map.insert(
-            "connect".to_string(),
-            serde_json::Value::Number(Number::from(value)),
-        );
-        let value = self.app_connect.as_micros() as u64;
-        map.insert(
-            "app_connect".to_string(),
-            serde_json::Value::Number(Number::from(value)),
-        );
-        let value = self.pre_transfer.as_micros() as u64;
-        map.insert(
-            "pre_transfer".to_string(),
-            serde_json::Value::Number(Number::from(value)),
-        );
-        let value = self.start_transfer.as_micros() as u64;
-        map.insert(
-            "start_transfer".to_string(),
-            serde_json::Value::Number(Number::from(value)),
-        );
-        let value = self.total.as_micros() as u64;
-        map.insert(
-            "total".to_string(),
-            serde_json::Value::Number(Number::from(value)),
-        );
-        serde_json::Value::Object(map)
+        serde_json::to_value(self).expect("must succeed")
     }
 }
 


### PR DESCRIPTION
I was looking at the codebase and noticed quite a bit of repetition around the JSON serialisation code. Here's what I came up for one of the structs. It is, of course, generalisable to all the other ones that expose `to_json()`, but I wanted to hear what you think first before converting the rest. Not everyone subscribes to the “less code is better code” philosophy that I personally do, so I'm keen to hear some feedback first.