### PR TITLE
Log only non-default options in verbose mode

### DIFF
--- a/integration/tests_failed/retry.err.pattern
+++ b/integration/tests_failed/retry.err.pattern
@@ -1,9 +1,4 @@
 * Options:
-*     continue on error: false
-*     delay: 0ms
-*     follow redirect: false
-*     insecure: false
-*     max redirect: 50
 *     retry: 5
 * ------------------------------------------------------------------------------
 * Executing entry 1

--- a/integration/tests_failed/retry_option.err.pattern
+++ b/integration/tests_failed/retry_option.err.pattern
@@ -1,10 +1,4 @@
 * Options:
-*     continue on error: false
-*     delay: 0ms
-*     follow redirect: false
-*     insecure: false
-*     max redirect: 50
-*     retry: 0
 * ------------------------------------------------------------------------------
 * Executing entry 1
 *

--- a/integration/tests_ok/color.err
+++ b/integration/tests_ok/color.err
@@ -1,8 +1,2 @@
 [1;34m*[0m [1mOptions:[0m
-[1;34m*[0m     continue on error: false
-[1;34m*[0m     delay: 0ms
-[1;34m*[0m     follow redirect: false
-[1;34m*[0m     insecure: false
-[1;34m*[0m     max redirect: 50
-[1;34m*[0m     retry: 0
 [1;33mwarning[0m: [1mNo entry have been executed for file tests_ok/color.hurl[0m

--- a/integration/tests_ok/delay_option.err.pattern
+++ b/integration/tests_ok/delay_option.err.pattern
@@ -1,10 +1,4 @@
 * Options:
-*     continue on error: false
-*     delay: 0ms
-*     follow redirect: false
-*     insecure: false
-*     max redirect: 50
-*     retry: 0
 * ------------------------------------------------------------------------------
 * Executing entry 1
 *

--- a/integration/tests_ok/post_large.err.pattern
+++ b/integration/tests_ok/post_large.err.pattern
@@ -1,10 +1,4 @@
 * Options:
-*     continue on error: false
-*     delay: 0ms
-*     follow redirect: false
-*     insecure: false
-*     max redirect: 50
-*     retry: 0
 * ------------------------------------------------------------------------------
 * Executing entry 1
 *

--- a/integration/tests_ok/retry.err.pattern
+++ b/integration/tests_ok/retry.err.pattern
@@ -1,9 +1,4 @@
 * Options:
-*     continue on error: false
-*     delay: 0ms
-*     follow redirect: false
-*     insecure: false
-*     max redirect: 50
 *     retry: 10
 * ------------------------------------------------------------------------------
 * Executing entry 1

--- a/integration/tests_ok/retry_option.err.pattern
+++ b/integration/tests_ok/retry_option.err.pattern
@@ -1,10 +1,4 @@
 * Options:
-*     continue on error: false
-*     delay: 0ms
-*     follow redirect: false
-*     insecure: false
-*     max redirect: 50
-*     retry: 0
 * ------------------------------------------------------------------------------
 * Executing entry 1
 *

--- a/integration/tests_ok/verbose.err.pattern
+++ b/integration/tests_ok/verbose.err.pattern
@@ -1,10 +1,4 @@
 * Options:
-*     continue on error: false
-*     delay: 0ms
-*     follow redirect: false
-*     insecure: false
-*     max redirect: 50
-*     retry: 0
 * ------------------------------------------------------------------------------
 * Executing entry 1
 *

--- a/packages/hurl/src/runner/hurl_file.rs
+++ b/packages/hurl/src/runner/hurl_file.rs
@@ -29,7 +29,7 @@ use crate::http::Call;
 use crate::runner::core::*;
 use crate::runner::runner_options::RunnerOptions;
 use crate::runner::{entry, options, Value};
-use crate::util::logger::{ErrorFormat, Logger, LoggerOptions, LoggerOptionsBuilder};
+use crate::util::logger::{ErrorFormat, Logger, LoggerOptions, LoggerOptionsBuilder, Verbosity};
 
 /// Runs a Hurl `content` and returns a [`HurlResult`] upon completion.
 ///
@@ -327,28 +327,88 @@ fn log_run_info(
     variables: &HashMap<String, Value>,
     logger: &Logger,
 ) {
+    // Log only non-default options in verbose mode.
+    // This would be better as a closure to avoid passing `is_very_verbose` as a parameter,
+    // but we cannot define a closure with generic arguments bounded by a trait.
+    fn should_log<T: PartialEq>(is_very_verbose: bool, current: T, default: T) -> bool {
+        is_very_verbose || current != default
+    }
+
+    let default_runner_options = RunnerOptions::default();
+    let is_very_verbose = logger.verbosity == Some(Verbosity::VeryVerbose);
+
     logger.debug_important("Options:");
-    logger.debug(
-        format!(
-            "    continue on error: {}",
-            runner_options.continue_on_error
-        )
-        .as_str(),
-    );
-    // FIXME: the cast to u64 seems not necessary.
-    //  If we dont cast from u128 and try to format! or println!
-    //  we have a segfault on Alpine Docker images and Rust 1.68.0, whereas it was
-    //  ok with Rust >= 1.67.0.
-    logger.debug(format!("    delay: {}ms", runner_options.delay.as_millis() as u64).as_str());
-    logger.debug(format!("    follow redirect: {}", runner_options.follow_location).as_str());
-    logger.debug(format!("    insecure: {}", runner_options.insecure).as_str());
-    if let Some(n) = runner_options.max_redirect {
-        logger.debug(format!("    max redirect: {n}").as_str());
+
+    if should_log(
+        is_very_verbose,
+        runner_options.continue_on_error,
+        default_runner_options.continue_on_error,
+    ) {
+        logger.debug(
+            format!(
+                "    continue on error: {}",
+                runner_options.continue_on_error
+            )
+            .as_str(),
+        );
     }
-    if let Some(proxy) = &runner_options.proxy {
-        logger.debug(format!("    proxy: {proxy}").as_str());
+
+    if should_log(
+        is_very_verbose,
+        runner_options.delay,
+        default_runner_options.delay,
+    ) {
+        // FIXME: the cast to u64 seems not necessary.
+        //  If we dont cast from u128 and try to format! or println!
+        //  we have a segfault on Alpine Docker images and Rust 1.68.0, whereas it was
+        //  ok with Rust >= 1.67.0.
+        logger.debug(format!("    delay: {}ms", runner_options.delay.as_millis() as u64).as_str());
     }
-    logger.debug(format!("    retry: {}", runner_options.retry).as_str());
+
+    if should_log(
+        is_very_verbose,
+        runner_options.follow_location,
+        default_runner_options.follow_location,
+    ) {
+        logger.debug(format!("    follow redirect: {}", runner_options.follow_location).as_str());
+    }
+
+    if should_log(
+        is_very_verbose,
+        runner_options.insecure,
+        default_runner_options.insecure,
+    ) {
+        logger.debug(format!("    insecure: {}", runner_options.insecure).as_str());
+    }
+
+    if should_log(
+        is_very_verbose,
+        runner_options.max_redirect,
+        default_runner_options.max_redirect,
+    ) {
+        if let Some(n) = runner_options.max_redirect {
+            logger.debug(format!("    max redirect: {n}").as_str());
+        }
+    }
+
+    if should_log(
+        is_very_verbose,
+        &runner_options.proxy,
+        &default_runner_options.proxy,
+    ) {
+        if let Some(proxy) = &runner_options.proxy {
+            logger.debug(format!("    proxy: {proxy}").as_str());
+        }
+    }
+
+    if should_log(
+        is_very_verbose,
+        runner_options.retry,
+        default_runner_options.retry,
+    ) {
+        logger.debug(format!("    retry: {}", runner_options.retry).as_str());
+    }
+
     if !variables.is_empty() {
         logger.debug_important("Variables:");
         for (name, value) in variables.iter() {


### PR DESCRIPTION
This patch alters the logging of options to only display non-default options when running with --verbose. The behavior of --very-verbose is not affected.

It also fixes all integration tests that were broken with the change to the logger output.

The code is not very pretty but I couldn't think of a better solution. Let me know if any changes are needed.

Closes #1927 