### PR TITLE
Add timestamps to the HTML reports

### DIFF
--- a/packages/hurl/src/main.rs
+++ b/packages/hurl/src/main.rs
@@ -346,6 +346,7 @@ pub mod tests {
                     time_in_ms: 0,
                     success,
                     cookies: vec![],
+                    timestamp: 1,
                 },
             }
         }

--- a/packages/hurl/src/report/html/mod.rs
+++ b/packages/hurl/src/report/html/mod.rs
@@ -36,6 +36,7 @@ struct HTMLResult {
     pub id: String,
     pub time_in_ms: u128,
     pub success: bool,
+    pub timestamp: i64,
 }
 
 impl HTMLResult {
@@ -46,6 +47,7 @@ impl HTMLResult {
             id: testcase.id.clone(),
             time_in_ms: testcase.time_in_ms,
             success: testcase.success,
+            timestamp: testcase.timestamp,
         }
     }
 }

--- a/packages/hurl/src/report/html/resources/report.html
+++ b/packages/hurl/src/report/html/resources/report.html
@@ -20,6 +20,7 @@
         <thead>
         <td>File</td>
         <td>Status</td>
+        <td>Start Time</td>
         <td>Duration</td>
         </thead>
         <tbody>

--- a/packages/hurl/src/report/html/testcase.rs
+++ b/packages/hurl/src/report/html/testcase.rs
@@ -30,6 +30,7 @@ pub struct Testcase {
     pub success: bool,
     pub time_in_ms: u128,
     pub errors: Vec<Error>,
+    pub timestamp: i64,
 }
 
 impl Testcase {
@@ -43,6 +44,7 @@ impl Testcase {
             time_in_ms: hurl_result.time_in_ms,
             success: hurl_result.success,
             errors,
+            timestamp: hurl_result.timestamp,
         }
     }
 

--- a/packages/hurl/src/report/junit/mod.rs
+++ b/packages/hurl/src/report/junit/mod.rs
@@ -161,6 +161,7 @@ mod tests {
             time_in_ms: 230,
             success: true,
             cookies: vec![],
+            timestamp: 1,
         };
         let tc = Testcase::from(&res, content, filename);
         testcases.push(tc);
@@ -184,6 +185,7 @@ mod tests {
             time_in_ms: 230,
             success: true,
             cookies: vec![],
+            timestamp: 1,
         };
         let tc = Testcase::from(&res, content, filename);
         testcases.push(tc);
@@ -208,6 +210,7 @@ mod tests {
             time_in_ms: 230,
             success: true,
             cookies: vec![],
+            timestamp: 1,
         };
         let tc = Testcase::from(&res, content, filename);
         testcases.push(tc);

--- a/packages/hurl/src/report/junit/testcase.rs
+++ b/packages/hurl/src/report/junit/testcase.rs
@@ -121,6 +121,7 @@ mod test {
             time_in_ms: 230,
             success: true,
             cookies: vec![],
+            timestamp: 1,
         };
 
         let mut buffer = Vec::new();
@@ -161,6 +162,7 @@ HTTP/1.0 200
             time_in_ms: 230,
             success: true,
             cookies: vec![],
+            timestamp: 1,
         };
         let mut buffer = Vec::new();
         Testcase::from(&hurl_result, content, filename)
@@ -202,6 +204,7 @@ HTTP/1.0 200
             time_in_ms: 230,
             success: true,
             cookies: vec![],
+            timestamp: 1,
         };
         let mut buffer = Vec::new();
         Testcase::from(&hurl_result, content, filename)

--- a/packages/hurl/src/runner/core.rs
+++ b/packages/hurl/src/runner/core.rs
@@ -28,6 +28,7 @@ pub struct HurlResult {
     pub time_in_ms: u128,
     pub success: bool,
     pub cookies: Vec<Cookie>,
+    pub timestamp: i64,
 }
 
 impl HurlResult {

--- a/packages/hurl/src/runner/hurl_file.rs
+++ b/packages/hurl/src/runner/hurl_file.rs
@@ -19,6 +19,8 @@ use std::collections::HashMap;
 use std::thread;
 use std::time::Instant;
 
+use chrono::Utc;
+
 use hurl_core::ast::VersionValue::VersionAnyLegacy;
 use hurl_core::ast::*;
 use hurl_core::error::Error;
@@ -101,6 +103,7 @@ pub fn run(
         hurl_file.entries.len()
     };
     let start = Instant::now();
+    let timestamp = Utc::now().timestamp();
 
     loop {
         if entry_index > n {
@@ -230,6 +233,7 @@ pub fn run(
         time_in_ms,
         success,
         cookies,
+        timestamp,
     })
 }
 


### PR DESCRIPTION
Issue: https://github.com/Orange-OpenSource/hurl/issues/1983

Adds an i64 `timestamp` to the HurlResult struct for use in HTML reports to report local start time of each file.


Result looks like: 
```
❯ echo "GET https://example.com" | ./target/release/hurl --test --report-html out
-: Running [1/1]
-: Success (1 request(s) in 83 ms)
--------------------------------------------------------------------------------
Executed files:  1
Succeeded files: 1 (100.0%)
Failed files:    0 (0.0%)
Duration:        93 ms
```

![image](https://github.com/Orange-OpenSource/hurl/assets/131019713/f0a3095e-4bfb-4d08-ad7e-cfd9846ffadd)

Reports are still updated 
```
❯ echo "GET https://example.com" | ./target/release/hurl --test --report-html out
-: Running [1/1]
-: Success (1 request(s) in 75 ms)
--------------------------------------------------------------------------------
Executed files:  1
Succeeded files: 1 (100.0%)
Failed files:    0 (0.0%)
Duration:        81 ms

❯ echo "GET https://example.com" | ./target/release/hurl --test --report-html out
-: Running [1/1]
-: Success (1 request(s) in 62 ms)
--------------------------------------------------------------------------------
Executed files:  1
Succeeded files: 1 (100.0%)
Failed files:    0 (0.0%)
Duration:        65 ms
```

![image](https://github.com/Orange-OpenSource/hurl/assets/131019713/3dfc2421-a863-457e-97dd-428783c03f2b)


For reports created before this change, the timestamp defaults to `0` internally and the report shows a `-`

```
echo "GET https://example.com" | hurl --test --report-html out
-: Running [1/1]
-: Success (1 request(s) in 67 ms)
--------------------------------------------------------------------------------
Executed files:  1
Succeeded files: 1 (100.0%)
Failed files:    0 (0.0%)
Duration:        76 ms

echo "GET https://example.com" | ./target/release/hurl --test --report-html out
-: Running [1/1]
-: Success (1 request(s) in 69 ms)
--------------------------------------------------------------------------------
Executed files:  1
Succeeded files: 1 (100.0%)
Failed files:    0 (0.0%)
Duration:        73 ms
```

![image](https://github.com/Orange-OpenSource/hurl/assets/131019713/efbb98c4-1845-4ba6-bf6f-0bd8f9a41b2b)

