### PR TITLE
Fix deb install script: use brackets to delineate var before underscores

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -19,8 +19,8 @@ For Debian / Ubuntu, Hurl can be installed using a binary .deb file provided in 
 
 ```shell
 $ VERSION=4.1.0
-$ curl --location --remote-name https://github.com/Orange-OpenSource/hurl/releases/download/$VERSION/hurl_$VERSION_amd64.deb
-$ sudo apt update && sudo apt install ./hurl_$VERSION_amd64.deb
+$ curl --location --remote-name https://github.com/Orange-OpenSource/hurl/releases/download/$VERSION/hurl_${VERSION}_amd64.deb
+$ sudo apt update && sudo apt install ./hurl_${VERSION}_amd64.deb
 ```
 
 #### Alpine


### PR DESCRIPTION
Without brackets, the shell reads `$VARIABLE_amd64` as a single variable name.