### PR TITLE
Add SourceInfo to Comment

### DIFF
--- a/packages/hurl/src/runner/request.rs
+++ b/packages/hurl/src/runner/request.rs
@@ -359,7 +359,8 @@ mod tests {
             line_terminators: vec![LineTerminator {
                 space0: whitespace(),
                 comment: Some(Comment {
-                    value: "@cookie_storage_clear".to_string()
+                    value: "@cookie_storage_clear".to_string(),
+                    source_info: SourceInfo::new(0, 0, 0, 0),
                 }),
                 newline: whitespace(),
             }],
@@ -399,7 +400,8 @@ mod tests {
                     comment: Some(Comment {
                         value:
                             "@cookie_storage_set: localhost\tFALSE\t/\tFALSE\t0\tcookie1\tvalueA"
-                                .to_string()
+                                .to_string(),
+                        source_info: SourceInfo::new(0, 0, 0, 0),
                     }),
                     newline: whitespace(),
                 }],

--- a/packages/hurl_core/src/ast/core.rs
+++ b/packages/hurl_core/src/ast/core.rs
@@ -575,6 +575,7 @@ pub enum TemplateElement {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Comment {
     pub value: String,
+    pub source_info: SourceInfo,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/packages/hurl_core/src/parser/parsers.rs
+++ b/packages/hurl_core/src/parser/parsers.rs
@@ -354,6 +354,7 @@ mod tests {
                 },
                 comment: Some(Comment {
                     value: " comment".to_string(),
+                    source_info: SourceInfo::new(1, 24, 1, 32),
                 }),
                 newline: Whitespace {
                     value: String::new(),

--- a/packages/hurl_core/src/parser/primitives.rs
+++ b/packages/hurl_core/src/parser/primitives.rs
@@ -133,6 +133,7 @@ pub fn optional_line_terminators(reader: &mut Reader) -> ParseResult<Vec<LineTer
 
 pub fn comment(reader: &mut Reader) -> ParseResult<Comment> {
     try_literal("#", reader)?;
+    let start = reader.state.clone();
     let mut value = String::new();
     loop {
         if reader.is_eof() {
@@ -152,7 +153,13 @@ pub fn comment(reader: &mut Reader) -> ParseResult<Comment> {
             }
         }
     }
-    Ok(Comment { value })
+    Ok(Comment {
+        value,
+        source_info: SourceInfo {
+            start: start.pos,
+            end: reader.state.clone().pos,
+        },
+    })
 }
 
 pub fn literal(s: &str, reader: &mut Reader) -> ParseResult<()> {
@@ -677,7 +684,8 @@ mod tests {
         assert_eq!(
             comment(&mut reader),
             Ok(Comment {
-                value: String::new()
+                value: String::new(),
+                source_info: SourceInfo::new(1, 2, 1, 2),
             })
         );
 
@@ -685,7 +693,8 @@ mod tests {
         assert_eq!(
             comment(&mut reader),
             Ok(Comment {
-                value: " comment".to_string()
+                value: " comment".to_string(),
+                source_info: SourceInfo::new(1, 2, 1, 10),
             })
         );
         assert_eq!(reader.state.cursor, 9);
@@ -809,7 +818,8 @@ mod tests {
                         source_info: SourceInfo::new(1, 25, 1, 26),
                     },
                     comment: Some(Comment {
-                        value: " comment".to_string()
+                        value: " comment".to_string(),
+                        source_info: SourceInfo::new(1, 27, 1, 35),
                     }),
                     newline: Whitespace {
                         value: String::new(),

--- a/packages/hurlfmt/src/linter/rules.rs
+++ b/packages/hurlfmt/src/linter/rules.rs
@@ -615,6 +615,7 @@ fn lint_comment(comment: &Comment) -> Comment {
         } else {
             format!(" {}", comment.value)
         },
+        source_info: SourceInfo::new(0, 0, 0, 0),
     }
 }
 


### PR DESCRIPTION
Hello. Yesterday, I started writing a LSP for Hurl  just for fun and I encountered a few roadblocks that could be addressed for a future project.

There is a LSP feature called [Semantic Tokens](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_semanticTokens), that is used to enable a smart highlighting called [Semantic Highlighting](https://code.visualstudio.com/api/language-extensions/semantic-highlight-guide). These tokens have their location on the source code as a member.

When getting the `comment` semantic token, it's necessary to get its location to pass to the token, so it would be way easier to do this if `Comment` on hurl's AST had any kind of position information.

I am still writing the semantic 'scanner' (transforms an ast into semantic tokens), so if I find another struct that would be good to have `SourceInfo`, I will make another PR.