### PR TITLE
Delete xmltree rs dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,6 +539,7 @@ dependencies = [
  "url",
  "uuid",
  "winres",
+ "xml-rs",
  "xmltree",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,12 +476,6 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
@@ -525,7 +519,6 @@ dependencies = [
  "hex",
  "hex-literal",
  "hurl_core",
- "indexmap",
  "lazy_static",
  "libflate",
  "libxml",
@@ -540,7 +533,6 @@ dependencies = [
  "uuid",
  "winres",
  "xml-rs",
- "xmltree",
 ]
 
 [[package]]
@@ -595,16 +587,6 @@ checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
-]
-
-[[package]]
-name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -665,7 +647,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be5f52fb8c451576ec6b79d3f4deb327398bc05bbdbd99021a6e77a4c855d524"
 dependencies = [
  "core2",
- "hashbrown 0.13.2",
+ "hashbrown",
  "rle-decode-fast",
 ]
 
@@ -1361,16 +1343,6 @@ name = "xml-rs"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fcb9cbac069e033553e8bb871be2fbdffcab578eb25bd0f7c508cedc6dcd75a"
-
-[[package]]
-name = "xmltree"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7d8a75eaf6557bb84a65ace8609883db44a29951042ada9b393151532e41fcb"
-dependencies = [
- "indexmap",
- "xml-rs",
-]
 
 [[package]]
 name = "zerocopy"

--- a/bin/update_crates.sh
+++ b/bin/update_crates.sh
@@ -116,9 +116,7 @@ main() {
     check_args "${arg}"
     updated_count=0
 
-    # xmltree-rs crate v0.10.3 doesn't build with the latest indexmap crates
-    # see <https://github.com/eminence/xmltree-rs/issues/39>
-    blacklisted="indexmap"
+    blacklisted=""
 
     # update toml
     for package in packages/*; do

--- a/integration/tests_ok/junit.out.pattern
+++ b/integration/tests_ok/junit.out.pattern
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><testsuites><testsuite tests="2" errors="0" failures="1"><testcase id="tests_ok/test.1.hurl" name="tests_ok/test.1.hurl" time="~~~" /><testcase id="tests_ok/test.2.hurl" name="tests_ok/test.2.hurl" time="~~~"><failure>Assert body value
+<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite tests="2" errors="0" failures="1"><testcase id="tests_ok/test.1.hurl" name="tests_ok/test.1.hurl" time="~~~" /><testcase id="tests_ok/test.2.hurl" name="tests_ok/test.2.hurl" time="~~~"><failure>Assert body value
   --> tests_ok/test.2.hurl:8:1
    |
  8 | `Goodbye World!`

--- a/packages/hurl/Cargo.toml
+++ b/packages/hurl/Cargo.toml
@@ -41,6 +41,7 @@ serde_json = "1.0.108"
 sha2 = "0.10.8"
 url = "2.4.1"
 xmltree = { version = "0.10.3",  features = ["attribute-order"] }
+xml-rs = { version = "0.8.19"}
 lazy_static = "1.4.0"
 # uuid features: lets you generate random UUIDs and use a faster (but still sufficiently random) RNG
 uuid = { version = "1.5.0", features = ["v4" , "fast-rng"] }

--- a/packages/hurl/Cargo.toml
+++ b/packages/hurl/Cargo.toml
@@ -30,7 +30,6 @@ glob = "0.3.1"
 hex = "0.4.3"
 hex-literal = "0.4.1"
 hurl_core = { version = "4.2.0-SNAPSHOT", path = "../hurl_core" }
-indexmap = "1.9.3"
 libflate = "2.0.0"
 libxml = "0.3.3"
 md5 = "0.7.0"
@@ -40,7 +39,6 @@ serde = "1.0.190"
 serde_json = "1.0.108"
 sha2 = "0.10.8"
 url = "2.4.1"
-xmltree = { version = "0.10.3",  features = ["attribute-order"] }
 xml-rs = { version = "0.8.19"}
 lazy_static = "1.4.0"
 # uuid features: lets you generate random UUIDs and use a faster (but still sufficiently random) RNG

--- a/packages/hurl/src/report/junit/mod.rs
+++ b/packages/hurl/src/report/junit/mod.rs
@@ -55,7 +55,7 @@
 //! ```
 //!
 mod testcase;
-
+mod xml;
 use std::fs::File;
 
 use indexmap::IndexMap;

--- a/packages/hurl/src/report/junit/testcase.rs
+++ b/packages/hurl/src/report/junit/testcase.rs
@@ -15,11 +15,11 @@
  * limitations under the License.
  *
  */
-use indexmap::map::IndexMap;
-use xmltree::{Element, XMLNode};
-
+use super::xml::XmlDocument;
 use crate::runner::HurlResult;
 use crate::util::logger;
+use indexmap::map::IndexMap;
+use xmltree::{Element, XMLNode};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Testcase {

--- a/packages/hurl/src/report/junit/xml/mod.rs
+++ b/packages/hurl/src/report/junit/xml/mod.rs
@@ -1,0 +1,112 @@
+/*
+ * Hurl (https://hurl.dev)
+ * Copyright (C) 2023 Orange
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+mod reader;
+mod writer;
+
+/// An XML element document.
+///
+/// This struct provides support for serialization to and from standard XML.
+/// This is a lightweight object wrapper around [xml-rs crate](https://github.com/netvl/xml-rs)
+/// to simplify XML in-memory tree manipulation.
+///
+/// XML namespaces are not supported, as the main usage of this class is
+/// to support JUnit report.
+///
+pub struct XmlDocument {
+    pub root: Option<Element>,
+}
+
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub enum XmlNode {
+    /// An XML element.
+    Element(Element),
+    /// A CDATA section.
+    CData(String),
+    /// A comment.
+    Comment(String),
+    /// A text content.
+    Text(String),
+    /// Processing instruction.
+    ProcessingInstruction(String, Option<String>),
+}
+
+/// A XML attribute.
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub struct Attribute {
+    pub name: String,
+    pub value: String,
+}
+
+impl Attribute {
+    fn new(name: &str, value: &str) -> Self {
+        Attribute {
+            name: name.to_string(),
+            value: value.to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct Element {
+    // We are only using local name, namespaces are not managed
+    pub name: String,
+    /// This element's attributes.
+    pub attrs: Vec<Attribute>,
+    /// This element's children.
+    pub children: Vec<XmlNode>,
+}
+
+impl Element {
+    pub fn new(name: &str) -> Element {
+        Element {
+            name: name.to_string(),
+            attrs: Vec::new(),
+            children: Vec::new(),
+        }
+    }
+
+    /// Add a new attribute to `self`.
+    pub fn attr(mut self, name: &str, value: &str) -> Self {
+        self.attrs.push(Attribute::new(name, value));
+        self
+    }
+
+    /// Add a new child `element`.
+    pub fn add_child(mut self, element: Element) -> Self {
+        self.children.push(XmlNode::Element(element));
+        self
+    }
+
+    /// Add a text content to `self`.
+    pub fn text(mut self, text: &str) -> Self {
+        self.children.push(XmlNode::Text(text.to_string()));
+        self
+    }
+
+    /// Add a comment `self`.
+    pub fn comment(mut self, comment: &str) -> Self {
+        self.children.push(XmlNode::Comment(comment.to_string()));
+        self
+    }
+
+    /// Add a CDATA section `self`.
+    pub fn cdata(mut self, cdata: &str) -> Self {
+        self.children.push(XmlNode::CData(cdata.to_string()));
+        self
+    }
+}

--- a/packages/hurl/src/report/junit/xml/mod.rs
+++ b/packages/hurl/src/report/junit/xml/mod.rs
@@ -31,6 +31,12 @@ pub struct XmlDocument {
     pub root: Option<Element>,
 }
 
+impl XmlDocument {
+    pub fn new(root: Element) -> XmlDocument {
+        XmlDocument { root: Some(root) }
+    }
+}
+
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub enum XmlNode {
     /// An XML element.

--- a/packages/hurl/src/report/junit/xml/reader.rs
+++ b/packages/hurl/src/report/junit/xml/reader.rs
@@ -32,6 +32,7 @@ pub enum ParserError {
 /// document returned is a in-memory tree representation of the whole document.
 impl XmlDocument {
     /// Convenient associated method to read and parse a XML string `source`.
+    #[allow(dead_code)]
     pub fn parse_str(source: &str) -> Result<XmlDocument, ParserError> {
         let bytes = source.as_bytes();
         XmlDocument::parse(bytes)

--- a/packages/hurl/src/report/junit/xml/reader.rs
+++ b/packages/hurl/src/report/junit/xml/reader.rs
@@ -1,0 +1,402 @@
+/*
+ * Hurl (https://hurl.dev)
+ * Copyright (C) 2023 Orange
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+use crate::report::junit::xml::reader::ParserError::{GenericError, InvalidXml};
+use crate::report::junit::xml::{Attribute, Element, XmlDocument, XmlNode};
+use xml::attribute::OwnedAttribute;
+use xml::name::OwnedName;
+use xml::reader::{EventReader, XmlEvent};
+
+/// Errors raised when deserializing a buffer.
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub enum ParserError {
+    InvalidXml(String),
+    GenericError(String),
+}
+
+/// Deserializes a XML document from [`std::io::Read`] source. The XML
+/// document returned is a in-memory tree representation of the whole document.
+impl XmlDocument {
+    /// Convenient associated method to read and parse a XML string `source`.
+    pub fn parse_str(source: &str) -> Result<XmlDocument, ParserError> {
+        let bytes = source.as_bytes();
+        XmlDocument::parse(bytes)
+    }
+
+    /// Read a XML `source` and parses it to a [`XmlDocument`].
+    pub fn parse<R>(source: R) -> Result<XmlDocument, ParserError>
+    where
+        R: std::io::Read,
+    {
+        let mut reader = EventReader::new(source);
+        let mut initialized = false;
+        let mut root: Option<Element> = None;
+        loop {
+            match reader.next() {
+                Ok(XmlEvent::StartDocument { .. }) => initialized = true,
+                Ok(XmlEvent::EndDocument) => {
+                    if !initialized {
+                        return Err(InvalidXml("Invalid end of document".to_string()));
+                    }
+                    return Ok(XmlDocument { root });
+                }
+                Ok(XmlEvent::ProcessingInstruction { .. }) => {}
+                Ok(XmlEvent::StartElement {
+                    name, attributes, ..
+                }) => {
+                    // At this point of the parsing, we must have an initialized document
+                    // and no root.
+                    if !initialized || root.is_some() {
+                        return Err(InvalidXml("Invalid start of document".to_string()));
+                    }
+                    let element = Element::try_parse(&name, &attributes, &mut reader)?;
+                    root = Some(element);
+                }
+                Ok(XmlEvent::EndElement { .. }) => {
+                    return Err(InvalidXml("Invalid end of element".to_string()))
+                }
+                Ok(XmlEvent::CData(_)) => {}
+                Ok(XmlEvent::Comment(_)) => {}
+                Ok(XmlEvent::Characters(_)) => {}
+                Ok(XmlEvent::Whitespace(_)) => {}
+                Err(e) => return Err(GenericError(e.to_string())),
+            }
+        }
+    }
+}
+
+impl Element {
+    fn try_parse<R: std::io::Read>(
+        name: &OwnedName,
+        attributes: &[OwnedAttribute],
+        reader: &mut EventReader<R>,
+    ) -> Result<Element, ParserError> {
+        let mut element = Element::new(&name.local_name);
+        element.attrs = attributes
+            .iter()
+            .map(|a| Attribute::new(&a.name.to_string(), &a.value))
+            .collect();
+
+        loop {
+            match reader.next() {
+                Ok(XmlEvent::StartDocument { .. }) => {
+                    return Err(InvalidXml("Invalid start of document".to_string()))
+                }
+                Ok(XmlEvent::EndDocument) => {
+                    return Err(InvalidXml("Invalid stop of document".to_string()))
+                }
+                Ok(XmlEvent::ProcessingInstruction { name, data }) => {
+                    let child = XmlNode::ProcessingInstruction(name, data);
+                    element.children.push(child);
+                }
+                Ok(XmlEvent::StartElement {
+                    name, attributes, ..
+                }) => {
+                    let child = Element::try_parse(&name, &attributes, reader)?;
+                    element.children.push(XmlNode::Element(child));
+                }
+                Ok(XmlEvent::EndElement { name, .. }) => {
+                    return if element.name == name.local_name {
+                        Ok(element)
+                    } else {
+                        Err(InvalidXml(format!("Bag closing element {name}")))
+                    }
+                }
+                Ok(XmlEvent::CData(value)) => {
+                    let child = XmlNode::CData(value);
+                    element.children.push(child);
+                }
+                Ok(XmlEvent::Comment(value)) => {
+                    let child = XmlNode::Comment(value);
+                    element.children.push(child);
+                }
+                Ok(XmlEvent::Characters(value)) => {
+                    let child = XmlNode::Text(value);
+                    element.children.push(child);
+                }
+                Ok(XmlEvent::Whitespace(_)) => {}
+                Err(e) => return Err(GenericError(e.to_string())),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::report::junit::xml::{Element, XmlDocument};
+
+    #[test]
+    fn read_xml_0_succeed() {
+        let xml = r#"<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<names>
+    <name first="bob" last="jones" />
+    <name first="elizabeth" last="smith" />
+</names>
+"#;
+        let doc = XmlDocument::parse_str(xml).unwrap();
+        assert_eq!(
+            doc.root.unwrap(),
+            Element::new("names")
+                .add_child(
+                    Element::new("name")
+                        .attr("first", "bob")
+                        .attr("last", "jones")
+                )
+                .add_child(
+                    Element::new("name")
+                        .attr("first", "elizabeth")
+                        .attr("last", "smith")
+                )
+        );
+    }
+
+    #[test]
+    fn read_xml_1_succeed() {
+        let xml = r#"<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<project name="project-name">
+    <libraries>
+        <library groupId="org.example" artifactId="&lt;name&gt;" version="0.1"/>
+        <library groupId="com.example" artifactId="&quot;cool-lib&amp;" version="999"/>
+    </libraries>
+    <module name="module-1">
+        <files>
+            <file name="somefile.java" type="java">
+                Some &lt;java&gt; class
+            </file>
+            <file name="another_file.java" type="java">
+                Another &quot;java&quot; class
+            </file>
+            <file name="config.xml" type="xml">
+                Weird &apos;XML&apos; config
+            </file>
+        </files>
+        <libraries>
+            <library groupId="junit" artifactId="junit" version="1.9.5"/>
+        </libraries>
+    </module>
+    <module name="module-2">
+        <files>
+            <file name="program.js" type="javascript">
+                JavaScript &amp; program
+            </file>
+            <file name="style.css" type="css">
+                Cascading style sheet: &#xA9; - &#1161;
+            </file>
+        </files>
+    </module>
+</project>
+        "#;
+
+        let doc = XmlDocument::parse_str(xml).unwrap();
+        assert_eq!(
+            doc.root.unwrap(),
+            Element::new("project")
+                        .attr("name", "project-name")
+                        .add_child(
+                            Element::new("libraries")
+                                .add_child(
+                                    Element::new("library")
+                                        .attr("groupId", "org.example")
+                                        .attr("artifactId", "<name>")
+                                        .attr("version", "0.1")
+                                )
+                                .add_child(
+                                    Element::new("library")
+                                        .attr("groupId", "com.example")
+                                        .attr("artifactId", "\"cool-lib&")
+                                        .attr("version", "999")
+                                )
+                        )
+                        .add_child(
+                            Element::new("module")
+                                .attr("name", "module-1")
+                                .add_child(
+                                    Element::new("files")
+                                        .add_child(
+                                            Element::new("file")
+                                                .attr("name", "somefile.java")
+                                                .attr("type", "java")
+                                                .text("\n                Some <java> class\n            ")
+                                        )
+                                        .add_child(
+                                            Element::new("file")
+                                                .attr("name", "another_file.java")
+                                                .attr("type", "java")
+                                                .text("\n                Another \"java\" class\n            ")
+                                        )
+                                        .add_child(
+                                            Element::new("file")
+                                                .attr("name", "config.xml")
+                                                .attr("type", "xml")
+                                                .text("\n                Weird 'XML' config\n            ")
+                                        )
+                                )
+                                .add_child(
+                                    Element::new("libraries")
+                                        .add_child(Element::new("library")
+                                            .attr("groupId", "junit")
+                                            .attr("artifactId", "junit")
+                                            .attr("version", "1.9.5")
+                                        )
+                                )
+                        )
+                        .add_child(
+                            Element::new("module")
+                                .attr("name", "module-2")
+                                .add_child(
+                                    Element::new("files")
+                                        .add_child(
+                                            Element::new("file")
+                                                .attr("name", "program.js")
+                                                .attr("type", "javascript")
+                                                .text("\n                JavaScript & program\n            ")
+                                        )
+                                        .add_child(
+                                            Element::new("file")
+                                                .attr("name", "style.css")
+                                                .attr("type", "css")
+                                                .text("\n                Cascading style sheet: © - \u{489}\n            ")
+                                        )
+                                )
+                        )
+                );
+    }
+
+    #[test]
+    fn read_xml_with_namespaces() {
+        let xml = r#"<?xml version="1.0" encoding="utf-8"?>
+<p:data xmlns:p="urn:example:namespace" xmlns:d="urn:example:double" xmlns:h="urn:example:header">
+  <p:datum id="34">
+    <p:name>Name</p:name>
+    <d:name>Another name</d:name>
+    <d:arg>0.3</d:arg>
+    <d:arg>0.2</d:arg>
+    <p:arg>0.1</p:arg>
+    <p:arg>0.01</p:arg>
+    <h:header name="Header-1">header 1 value</h:header>
+    <h:header name="Header-2">
+      Some bigger value
+    </h:header>
+  </p:datum>
+</p:data>"#;
+
+        let doc = XmlDocument::parse_str(xml).unwrap();
+        assert_eq!(
+            doc.root.unwrap(),
+            Element::new("data").add_child(
+                Element::new("datum")
+                    .attr("id", "34")
+                    .add_child(Element::new("name").text("Name"))
+                    .add_child(Element::new("name").text("Another name"))
+                    .add_child(Element::new("arg").text("0.3"))
+                    .add_child(Element::new("arg").text("0.2"))
+                    .add_child(Element::new("arg").text("0.1"))
+                    .add_child(Element::new("arg").text("0.01"))
+                    .add_child(
+                        Element::new("header")
+                            .attr("name", "Header-1")
+                            .text("header 1 value")
+                    )
+                    .add_child(
+                        Element::new("header")
+                            .attr("name", "Header-2")
+                            .text("\n      Some bigger value\n    ")
+                    )
+            )
+        );
+    }
+
+    #[test]
+    fn read_junit_xml() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?><testsuites><testsuite tests="3" errors="0" failures="1"><testcase id="/tmp/a.hurl" name="/tmp/a.hurl" time="0.438" /><testcase id="/tmp/b.hurl" name="/tmp/b.hurl" time="0.234"><failure>Assert status code
+  --> /tmp/b.hurl:4:6
+   |
+ 4 | HTTP 300
+   |      ^^^ actual value is &lt;200>
+   |</failure></testcase><testcase id="/tmp/c.hurl" name="/tmp/c.hurl" time="0.236" /></testsuite><testsuite tests="2" errors="0" failures="1"><testcase id="/tmp/a.hurl" name="/tmp/a.hurl" time="0.370" /><testcase id="/tmp/c.hurl" name="/tmp/c.hurl" time="0.247"><failure>Assert failure
+  --> /tmp/c.hurl:6:0
+   |
+ 6 | xpath "normalize-space(//title)" == "Hello World!"
+   |   actual:   string &lt;Hurl - Run and Test HTTP Requests>
+   |   expected: string &lt;Hello World!>
+   |</failure></testcase></testsuite></testsuites>"#;
+        let doc = XmlDocument::parse_str(xml).unwrap();
+        assert_eq!(
+            doc.root.unwrap(),
+            Element::new("testsuites")
+                .add_child(
+                    Element::new("testsuite")
+                        .attr("tests", "3")
+                        .attr("errors", "0")
+                        .attr("failures", "1")
+                        .add_child(
+                            Element::new("testcase")
+                                .attr("id", "/tmp/a.hurl")
+                                .attr("name", "/tmp/a.hurl")
+                                .attr("time", "0.438")
+                        )
+                        .add_child(
+                            Element::new("testcase")
+                                .attr("id", "/tmp/b.hurl")
+                                .attr("name", "/tmp/b.hurl")
+                                .attr("time", "0.234")
+                                .add_child(Element::new("failure").text(
+                                    r#"Assert status code
+  --> /tmp/b.hurl:4:6
+   |
+ 4 | HTTP 300
+   |      ^^^ actual value is <200>
+   |"#
+                                ))
+                        )
+                        .add_child(
+                            Element::new("testcase")
+                                .attr("id", "/tmp/c.hurl")
+                                .attr("name", "/tmp/c.hurl")
+                                .attr("time", "0.236")
+                        )
+                )
+                .add_child(
+                    Element::new("testsuite")
+                        .attr("tests", "2")
+                        .attr("errors", "0")
+                        .attr("failures", "1")
+                        .add_child(
+                            Element::new("testcase")
+                                .attr("id", "/tmp/a.hurl")
+                                .attr("name", "/tmp/a.hurl")
+                                .attr("time", "0.370")
+                        )
+                        .add_child(
+                            Element::new("testcase")
+                                .attr("id", "/tmp/c.hurl")
+                                .attr("name", "/tmp/c.hurl")
+                                .attr("time", "0.247")
+                                .add_child(Element::new("failure").text(
+                                    r#"Assert failure
+  --> /tmp/c.hurl:6:0
+   |
+ 6 | xpath "normalize-space(//title)" == "Hello World!"
+   |   actual:   string <Hurl - Run and Test HTTP Requests>
+   |   expected: string <Hello World!>
+   |"#
+                                ))
+                        )
+                )
+        )
+    }
+}

--- a/packages/hurl/src/report/junit/xml/writer.rs
+++ b/packages/hurl/src/report/junit/xml/writer.rs
@@ -52,8 +52,9 @@ impl From<FromUtf8Error> for WriterError {
 }
 
 impl XmlDocument {
-    /// Convenient method to seralize an XML document to a string.
-    pub fn write_string(&self) -> Result<String, WriterError> {
+    /// Convenient method to serialize an XML document to a string.
+    #[allow(dead_code)]
+    pub fn to_string(&self) -> Result<String, WriterError> {
         let buffer = vec![];
         let buffer = self.write(buffer)?;
         let str = String::from_utf8(buffer)?;
@@ -194,7 +195,7 @@ mod tests {
             ;
         let doc = XmlDocument { root: Some(root) };
         assert_eq!(
-            doc.write_string().unwrap(),
+            doc.to_string().unwrap(),
             "<?xml version=\"1.0\" encoding=\"utf-8\"?>\
             <catalog>\
                 <book id=\"bk101\">\

--- a/packages/hurl/src/report/junit/xml/writer.rs
+++ b/packages/hurl/src/report/junit/xml/writer.rs
@@ -1,0 +1,219 @@
+/*
+ * Hurl (https://hurl.dev)
+ * Copyright (C) 2023 Orange
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+use crate::report::junit::xml::writer::WriterError::GenericError;
+use crate::report::junit::xml::{Element, XmlDocument, XmlNode};
+use std::borrow::Cow;
+use std::string::FromUtf8Error;
+use xml::attribute::Attribute;
+use xml::name::Name;
+use xml::namespace::Namespace;
+use xml::writer::{Error, XmlEvent};
+use xml::EventWriter;
+
+/// Errors raised when serializing an XML document.
+#[derive(Debug)]
+pub enum WriterError {
+    Io(std::io::Error),
+    FromUtf8Error(FromUtf8Error),
+    GenericError(String),
+}
+
+impl From<Error> for WriterError {
+    fn from(value: Error) -> Self {
+        match value {
+            Error::Io(error) => WriterError::Io(error),
+            Error::DocumentStartAlreadyEmitted
+            | Error::LastElementNameNotAvailable
+            | Error::EndElementNameIsNotEqualToLastStartElementName
+            | Error::EndElementNameIsNotSpecified => GenericError(value.to_string()),
+        }
+    }
+}
+
+impl From<FromUtf8Error> for WriterError {
+    fn from(value: FromUtf8Error) -> Self {
+        WriterError::FromUtf8Error(value)
+    }
+}
+
+impl XmlDocument {
+    /// Convenient method to seralize an XML document to a string.
+    pub fn write_string(&self) -> Result<String, WriterError> {
+        let buffer = vec![];
+        let buffer = self.write(buffer)?;
+        let str = String::from_utf8(buffer)?;
+        Ok(str)
+    }
+
+    /// Serializes an XML document to a `buffer`.
+    pub fn write<W>(&self, buffer: W) -> Result<W, WriterError>
+    where
+        W: std::io::Write,
+    {
+        let mut writer = EventWriter::new(buffer);
+        if let Some(root) = &self.root {
+            root.write(&mut writer)?;
+        }
+        Ok(writer.into_inner())
+    }
+}
+
+impl XmlNode {
+    fn write<W>(&self, writer: &mut EventWriter<W>) -> Result<(), Error>
+    where
+        W: std::io::Write,
+    {
+        match self {
+            XmlNode::Element(elem) => elem.write(writer)?,
+            XmlNode::CData(cdata) => writer.write(XmlEvent::CData(cdata))?,
+            XmlNode::Comment(comment) => writer.write(XmlEvent::Comment(comment))?,
+            XmlNode::Text(text) => writer.write(XmlEvent::Characters(text))?,
+            XmlNode::ProcessingInstruction(name, data) => match data {
+                Some(string) => writer.write(XmlEvent::ProcessingInstruction {
+                    name,
+                    data: Some(string),
+                })?,
+                None => writer.write(XmlEvent::ProcessingInstruction { name, data: None })?,
+            },
+        }
+        Ok(())
+    }
+}
+
+impl Element {
+    fn write<W>(&self, writer: &mut EventWriter<W>) -> Result<(), Error>
+    where
+        W: std::io::Write,
+    {
+        let name = Name::local(&self.name);
+        let attributes = self
+            .attrs
+            .iter()
+            .map(|attr| Attribute {
+                name: Name::local(&attr.name),
+                value: &attr.value,
+            })
+            .collect();
+
+        // TODO: manage namespaces
+        let empty_ns = Namespace::empty();
+        writer.write(XmlEvent::StartElement {
+            name,
+            attributes: Cow::Owned(attributes),
+            namespace: Cow::Owned(empty_ns),
+        })?;
+
+        for child in self.children.iter() {
+            child.write(writer)?;
+        }
+
+        writer.write(XmlEvent::EndElement { name: Some(name) })?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::report::junit::xml::{Element, XmlDocument};
+
+    #[test]
+    fn write_xml_0() {
+        let root = Element::new("catalog")
+            .add_child(
+                Element::new("book")
+                    .attr("id", "bk101")
+                    .add_child(
+                        Element::new("author")
+                            .text("Gambardella, Matthew")
+                    )
+                    .add_child(
+                        Element::new("title")
+                            .text("XML Developer's Guide")
+                    )
+                    .add_child(
+                        Element::new("genre")
+                            .text("Computer")
+                    )
+                    .add_child(
+                        Element::new("price")
+                            .text("44.95")
+                    )
+                    .add_child(
+                        Element::new("publish_date")
+                            .text("2000-10-01")
+                    )
+                    .add_child(
+                        Element::new("description")
+                            .text("An in-depth look at creating applications with XML.")
+                    )
+            )
+            .add_child(
+                Element::new("book")
+                    .attr("id", "bk102")
+                    .add_child(
+                        Element::new("author")
+                            .text("Ralls, Kim")
+                    )
+                    .add_child(
+                        Element::new("title")
+                            .text("Midnight Rain")
+                    )
+                    .add_child(
+                        Element::new("genre")
+                            .text("Fantasy")
+                    )
+                    .add_child(
+                        Element::new("price")
+                            .text("5.95")
+                    )
+                    .add_child(
+                        Element::new("publish_date")
+                            .text("2000-12-16")
+                    )
+                    .add_child(
+                        Element::new("description")
+                            .text("A former architect battles corporate zombies, an evil sorceress, and her own childhood to become queen of the world.")
+                    )
+            )
+            ;
+        let doc = XmlDocument { root: Some(root) };
+        assert_eq!(
+            doc.write_string().unwrap(),
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?>\
+            <catalog>\
+                <book id=\"bk101\">\
+                    <author>Gambardella, Matthew</author>\
+                    <title>XML Developer's Guide</title>\
+                    <genre>Computer</genre>\
+                    <price>44.95</price>\
+                    <publish_date>2000-10-01</publish_date>\
+                    <description>An in-depth look at creating applications with XML.</description>\
+                </book>\
+                <book id=\"bk102\">\
+                    <author>Ralls, Kim</author>\
+                    <title>Midnight Rain</title>\
+                    <genre>Fantasy</genre>\
+                    <price>5.95</price>\
+                    <publish_date>2000-12-16</publish_date>\
+                    <description>A former architect battles corporate zombies, an evil sorceress, and her own childhood to become queen of the world.</description>\
+                </book>\
+            </catalog>"
+        );
+    }
+}


### PR DESCRIPTION
Due to xmltree re-exposing an older version of indexmap, we couldnt' upgrade to the latest version of indemap.
xmltree is a tree in-memory representation of an XML document that we use for JUnit export. As xmltree is a thin layer above xml-rs, we re-implement a thin tree in-memory XML document using xml-rs directly and remove xmltree/indexmap dependency.