### PR TITLE
Add Alpine required packages info to build from sources

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -136,6 +136,12 @@ $ yum install -y pkg-config gcc openssl-devel libxml2-devel
 $ pacman -Sy --noconfirm pkgconf gcc glibc openssl libxml2
 ```
 
+#### Alpine based distributions
+
+```shell
+$ apk add curl-dev gcc libxml2-dev musl-dev openssl-dev 
+```
+
 ### Build on macOS
 
 ```shell


### PR DESCRIPTION
I was able to build `hurl` on Apple Silicon using latest `alpine` Docker image with mentioned packages and instructions in this guide.

Resolves #1352.