### PR TITLE
Add better errors for unexpected JSON bodies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -333,6 +333,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7762d17f1241643615821a8455a0b2c3e803784b058693d990b11f2dce25a0ca"
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -517,6 +523,7 @@ dependencies = [
  "libxml",
  "md5",
  "percent-encoding",
+ "pretty_assertions",
  "regex",
  "serde",
  "serde_json",
@@ -764,6 +771,16 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
+dependencies = [
+ "diff",
+ "yansi",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -1383,6 +1400,12 @@ name = "xml-rs"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fcb9cbac069e033553e8bb871be2fbdffcab578eb25bd0f7c508cedc6dcd75a"
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zerocopy"

--- a/packages/hurl/Cargo.toml
+++ b/packages/hurl/Cargo.toml
@@ -34,6 +34,7 @@ libflate = "2.0.0"
 libxml = "0.3.3"
 md5 = "0.7.0"
 percent-encoding = "2.3.1"
+pretty_assertions = "1.4.0"
 regex = "1.10.3"
 serde = "1.0.196"
 serde_json = { version = "1.0.113", features = ["arbitrary_precision"] }

--- a/packages/hurl/src/runner/assert.rs
+++ b/packages/hurl/src/runner/assert.rs
@@ -98,21 +98,43 @@ impl AssertResult {
                     }
                 },
             },
+            AssertResult::JsonBody {
+                actual,
+                expected,
+                source_info,
+            } => match expected {
+                Err(e) => Some(e.clone()),
+                Ok(expected) => match actual {
+                    Err(e) => Some(e.clone()),
+                    Ok(actual) => {
+                        if actual == expected {
+                            None
+                        } else {
+                            let inner = RunnerError::AssertJsonBodyValueError {
+                                actual: actual.clone(),
+                                expected: expected.clone(),
+                            };
+                            Some(Error::new(*source_info, inner, false))
+                        }
+                    }
+                },
+            },
             AssertResult::Explicit { actual: Err(e), .. } => Some(e.clone()),
             AssertResult::Explicit {
                 predicate_result: Some(Err(e)),
                 ..
             } => Some(e.clone()),
-            _ => None,
+            AssertResult::Explicit { .. } => None,
         }
     }
     pub fn line(&self) -> usize {
         match self {
-            AssertResult::Version { source_info, .. } => source_info.start.line,
-            AssertResult::Status { source_info, .. } => source_info.start.line,
-            AssertResult::Header { source_info, .. } => source_info.start.line,
-            AssertResult::Body { source_info, .. } => source_info.start.line,
-            AssertResult::Explicit { source_info, .. } => source_info.start.line,
+            AssertResult::Version { source_info, .. }
+            | AssertResult::Status { source_info, .. }
+            | AssertResult::Header { source_info, .. }
+            | AssertResult::Body { source_info, .. }
+            | AssertResult::JsonBody { source_info, .. }
+            | AssertResult::Explicit { source_info, .. } => source_info.start.line,
         }
     }
 }

--- a/packages/hurl/src/runner/error.rs
+++ b/packages/hurl/src/runner/error.rs
@@ -17,7 +17,7 @@
  */
 use std::path::PathBuf;
 
-use hurl_core::ast::SourceInfo;
+use hurl_core::ast::{JsonValue, SourceInfo};
 
 use crate::http::{HttpError, RequestedHttpVersion};
 
@@ -47,6 +47,10 @@ pub enum RunnerError {
     AssertBodyValueError {
         actual: String,
         expected: String,
+    },
+    AssertJsonBodyValueError {
+        actual: JsonValue,
+        expected: JsonValue,
     },
     AssertFailure {
         actual: String,
@@ -125,7 +129,8 @@ impl hurl_core::error::Error for Error {
 
     fn description(&self) -> String {
         match &self.inner {
-            RunnerError::AssertBodyValueError { .. } => "Assert body value".to_string(),
+            RunnerError::AssertBodyValueError { .. }
+            | RunnerError::AssertJsonBodyValueError { .. } => "Assert body value".to_string(),
             RunnerError::AssertFailure { .. } => "Assert failure".to_string(),
             RunnerError::AssertHeaderValueError { .. } => "Assert header value".to_string(),
             RunnerError::AssertStatus { .. } => "Assert status code".to_string(),
@@ -165,6 +170,11 @@ impl hurl_core::error::Error for Error {
         match &self.inner {
             RunnerError::AssertBodyValueError { actual, .. } => {
                 format!("actual value is <{actual}>")
+            }
+            RunnerError::AssertJsonBodyValueError { actual, expected } => {
+                let actual = format!("{}", actual.pretty());
+                let expected = format!("{}", expected.pretty());
+                pretty_assertions::StrComparison::new(&actual, &expected).to_string()
             }
             RunnerError::AssertFailure {
                 actual,

--- a/packages/hurl/src/runner/result.rs
+++ b/packages/hurl/src/runner/result.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+use hurl_core::ast::JsonValue;
 use hurl_core::ast::{Pos, SourceInfo};
 
 use crate::http::{Call, Cookie};
@@ -94,6 +95,11 @@ pub enum AssertResult {
     Body {
         actual: Result<Value, Error>,
         expected: Result<Value, Error>,
+        source_info: SourceInfo,
+    },
+    JsonBody {
+        actual: Result<JsonValue, Error>,
+        expected: Result<JsonValue, Error>,
         source_info: SourceInfo,
     },
     Explicit {


### PR DESCRIPTION
The previous code would show the entire value of the expected and actual response bodies. For smaller bodies this is fine, but once you start testing larger response the error becomes borderline useless.

This commit changes the error printing to show a diff between the actual and expected bodies, if they are JSON, ignoring white space differences. This gives the user a much better idea what the actual difference is between the actual and expected values.

As stated this only does it for JSON, but a similar approach can be applied to XML or any text based format, or really anything for which a reasonable diff can be created.