### PR TITLE
Move clippy lint rules to Cargo.toml

### DIFF
--- a/bin/check/clippy.sh
+++ b/bin/check/clippy.sh
@@ -1,9 +1,4 @@
 #!/bin/bash
 set -Eeuo pipefail
-# https://rust-lang.github.io/rust-clippy/master/index.html
-cargo clippy -- \
-  --deny warnings \
-  --deny clippy::empty_structs_with_brackets \
-  --deny clippy::manual_string_new \
-  --deny clippy::semicolon_if_nothing_returned
+cargo clippy
 

--- a/packages/hurl/Cargo.toml
+++ b/packages/hurl/Cargo.toml
@@ -53,3 +53,10 @@ winres = "0.1.12"
 [build-dependencies]
 cc = "1.0.88"
 
+[lints.rust]
+warnings = "deny"
+
+[lints.clippy]
+empty_structs_with_brackets = "deny"
+manual_string_new = "deny"
+semicolon_if_nothing_returned = "deny"

--- a/packages/hurl_core/Cargo.toml
+++ b/packages/hurl_core/Cargo.toml
@@ -13,3 +13,11 @@ repository = "https://github.com/Orange-OpenSource/hurl"
 float-cmp = "0.9.0"
 libxml = "0.3.3"
 regex = "1.10.3"
+
+[lints.rust]
+warnings = "deny"
+
+[lints.clippy]
+empty_structs_with_brackets = "deny"
+manual_string_new = "deny"
+semicolon_if_nothing_returned = "deny"

--- a/packages/hurlfmt/Cargo.toml
+++ b/packages/hurlfmt/Cargo.toml
@@ -20,5 +20,10 @@ regex = "1.10.3"
 [dev-dependencies]
 proptest = "1.4.0"
 
+[lints.rust]
+warnings = "deny"
 
-
+[lints.clippy]
+empty_structs_with_brackets = "deny"
+manual_string_new = "deny"
+semicolon_if_nothing_returned = "deny"


### PR DESCRIPTION
Move clippy rules to Cargo.toml.

Pro:

- we can run `cargo clippy`and have the same rules as the CI

Cons:

- we must duplicate clippy rules settings in every Cargo.toml's package (can't use the global Cargo.toml)

I think it's okay considering the benefit that we can just run `cargo clippy`