### PR TITLE
Remove unnecessary Box.

### DIFF
--- a/packages/hurl/src/http/client.rs
+++ b/packages/hurl/src/http/client.rs
@@ -50,7 +50,7 @@ use crate::util::path::ContextDir;
 #[derive(Debug)]
 pub struct Client {
     /// The handle to libcurl binding
-    handle: Box<easy::Easy>,
+    handle: easy::Easy,
     /// Current State
     state: ClientState,
     /// HTTP version support
@@ -89,7 +89,7 @@ impl Client {
         let handle = easy::Easy::new();
         let version = Version::get();
         Client {
-            handle: Box::new(handle),
+            handle,
             state: ClientState::default(),
             http2: version.feature_http2(),
             http3: version.feature_http3(),


### PR DESCRIPTION
Remove unnecessary Box on libcurl Easy handle.

If it's compiling, and integration tests are passing, it should be OK!