### PR TITLE
Fix installation instruction with precompiled binaries on Linux

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,7 +10,7 @@ Precompiled binary is available at [Hurl latest GitHub release]:
 $ INSTALL_DIR=/tmp
 $ VERSION=4.3.0
 $ curl --silent --location https://github.com/Orange-OpenSource/hurl/releases/download/$VERSION/hurl-$VERSION-x86_64-unknown-linux-gnu.tar.gz | tar xvz -C $INSTALL_DIR
-$ export PATH=$INSTALL_DIR/hurl-$VERSION:$PATH
+$ export PATH=$INSTALL_DIR/hurl-$VERSION-x86_64-unknown-linux-gnu/bin:$PATH
 ```
 
 #### Debian / Ubuntu


### PR DESCRIPTION
The original `export PATH` command expected the archive to contain a folder named `hurl-$VERSION` with the binaries `hurl` and `hurlfmt` inside.

But it actually contains a folder named `hurl-$VERSION-$ARCH`  with the binaries inside the ` bin`  subfolder.