### PR TITLE
Remove try_literal method from JSONPath reader.

### DIFF
--- a/packages/hurl/src/jsonpath/parser/parse.rs
+++ b/packages/hurl/src/jsonpath/parser/parse.rs
@@ -176,7 +176,7 @@ fn selector_object_key_bracket(reader: &mut Reader) -> Result<Selector, Error> {
 }
 
 fn selector_object_key(reader: &mut Reader) -> Result<Selector, Error> {
-    if !reader.try_literal(".") {
+    if reader.peek() != Some('.') {
         return Err(Error {
             pos: reader.state.pos,
             recoverable: true,
@@ -185,6 +185,7 @@ fn selector_object_key(reader: &mut Reader) -> Result<Selector, Error> {
             },
         });
     };
+    _ = reader.read();
 
     let s = reader.read_while(|c| c.is_alphanumeric() || *c == '_' || *c == '-');
     if s.is_empty() {

--- a/packages/hurl/src/jsonpath/parser/primitives.rs
+++ b/packages/hurl/src/jsonpath/parser/primitives.rs
@@ -59,7 +59,12 @@ pub fn natural(reader: &mut Reader) -> ParseResult<usize> {
 }
 
 pub fn integer(reader: &mut Reader) -> ParseResult<i64> {
-    let sign = if reader.try_literal("-") { -1 } else { 1 };
+    let sign = if reader.peek() == Some('-') {
+        _ = reader.read();
+        -1
+    } else {
+        1
+    };
     let nat = natural(reader)?;
     Ok(sign * (nat as i64))
 }
@@ -67,7 +72,8 @@ pub fn integer(reader: &mut Reader) -> ParseResult<i64> {
 pub fn number(reader: &mut Reader) -> ParseResult<Number> {
     let int = integer(reader)?;
 
-    let decimal = if reader.try_literal(".") {
+    let decimal = if reader.peek() == Some('.') {
+        _ = reader.read();
         if reader.is_eof() {
             return Err(Error {
                 pos: reader.state.pos,


### PR DESCRIPTION
There is still a try_literal function in the parser.