### PR TITLE
Add XPath body cache

### DIFF
--- a/packages/hurl/src/runner/cache.rs
+++ b/packages/hurl/src/runner/cache.rs
@@ -1,0 +1,78 @@
+/*
+ * Hurl (https://hurl.dev)
+ * Copyright (C) 2024 Orange
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+use crate::runner::xpath::Document;
+
+/// This is a cache to hold parsed structured data (XML/JSON/text), computed from an HTTP response
+/// body bytes. This cache lives for a given request, and allows reusing parsed response for
+/// multiple queries of the same type (for instance, two XPath queries will share their XML document
+/// through this cache).
+#[derive(Default)]
+pub struct BodyCache {
+    /// The parsed XML document.
+    xml: Option<Document>,
+}
+
+impl BodyCache {
+    /// Creates a new empty cache.
+    pub fn new() -> Self {
+        BodyCache::default()
+    }
+
+    /// Returns a reference to a cached XML response.
+    pub fn xml(&self) -> Option<&Document> {
+        self.xml.as_ref()
+    }
+
+    /// Set a XML document `doc` to the cache.
+    pub fn set_xml(&mut self, doc: Document) {
+        self.xml = Some(doc);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::runner::cache::BodyCache;
+    use crate::runner::xpath::{Document, Format};
+    use crate::runner::Value;
+
+    #[test]
+    fn add_and_retry_html() {
+        let html = "<!DOCTYPE html> \
+                    <html> \
+                        <body> \
+                            <h1>My First Heading</h1> \
+                            <p>My first paragraph.</p> \
+                        </body> \
+                    </html>";
+        let doc = Document::parse(html, Format::Html).unwrap();
+        assert_eq!(
+            doc.eval_xpath("string(//h1)").unwrap(),
+            Value::String("My First Heading".to_string())
+        );
+
+        let mut cache = BodyCache::new();
+        assert!(cache.xml().is_none());
+
+        cache.set_xml(doc);
+        let doc = cache.xml().unwrap();
+        assert_eq!(
+            doc.eval_xpath("string(//h1)").unwrap(),
+            Value::String("My First Heading".to_string())
+        );
+    }
+}

--- a/packages/hurl/src/runner/capture.rs
+++ b/packages/hurl/src/runner/capture.rs
@@ -20,6 +20,7 @@ use std::collections::HashMap;
 use hurl_core::ast::*;
 
 use crate::http;
+use crate::runner::cache::BodyCache;
 use crate::runner::error::{RunnerError, RunnerErrorKind};
 use crate::runner::filter::eval_filters;
 use crate::runner::query::eval_query;
@@ -28,14 +29,18 @@ use crate::runner::template::eval_template;
 use crate::runner::Value;
 
 /// Evaluates a `capture` with `variables` map and `http_response`, returns a
-/// [`CaptureResult`] on success or an [`RunnerError`] .
+/// [`CaptureResult`] on success or an [`RunnerError`].
+///
+/// The `cache` is used to store XML / JSON structured response data and avoid redundant parsing
+/// operation on the response.
 pub fn eval_capture(
     capture: &Capture,
     variables: &HashMap<String, Value>,
     http_response: &http::Response,
+    cache: &mut BodyCache,
 ) -> Result<CaptureResult, RunnerError> {
     let name = eval_template(&capture.name, variables)?;
-    let value = eval_query(&capture.query, variables, http_response)?;
+    let value = eval_query(&capture.query, variables, http_response, cache)?;
     let value = match value {
         None => {
             return Err(RunnerError::new(
@@ -143,6 +148,7 @@ pub mod tests {
     #[test]
     fn test_invalid_xpath() {
         let variables = HashMap::new();
+        let mut cache = BodyCache::new();
         let whitespace = Whitespace {
             value: String::new(),
             source_info: SourceInfo::new(Pos::new(0, 0), Pos::new(0, 0)),
@@ -170,9 +176,14 @@ pub mod tests {
             },
         };
 
-        let error = eval_capture(&capture, &variables, &http::xml_three_users_http_response())
-            .err()
-            .unwrap();
+        let error = eval_capture(
+            &capture,
+            &variables,
+            &http::xml_three_users_http_response(),
+            &mut cache,
+        )
+        .err()
+        .unwrap();
         assert_eq!(error.source_info.start, Pos { line: 1, column: 7 });
         assert_eq!(error.kind, RunnerErrorKind::QueryInvalidXpathEval);
     }
@@ -225,11 +236,14 @@ pub mod tests {
     #[test]
     fn test_capture() {
         let variables = HashMap::new();
+        let mut cache = BodyCache::new();
+
         assert_eq!(
             eval_capture(
                 &user_count_capture(),
                 &variables,
                 &http::xml_three_users_http_response(),
+                &mut cache,
             )
             .unwrap(),
             CaptureResult {
@@ -239,7 +253,13 @@ pub mod tests {
         );
 
         assert_eq!(
-            eval_capture(&duration_capture(), &variables, &http::json_http_response()).unwrap(),
+            eval_capture(
+                &duration_capture(),
+                &variables,
+                &http::json_http_response(),
+                &mut cache
+            )
+            .unwrap(),
             CaptureResult {
                 name: "duration".to_string(),
                 value: Value::Number(Number::from(1.5)),

--- a/packages/hurl/src/runner/filter/mod.rs
+++ b/packages/hurl/src/runner/filter/mod.rs
@@ -18,7 +18,7 @@
 
 pub use eval::eval_filters;
 pub use jsonpath::eval_jsonpath_string;
-pub use xpath::eval_xpath_string;
+pub use xpath::eval_xpath_doc;
 
 mod count;
 mod days_after_now;

--- a/packages/hurl/src/runner/mod.rs
+++ b/packages/hurl/src/runner/mod.rs
@@ -33,6 +33,7 @@ pub use self::value::Value;
 
 mod assert;
 mod body;
+mod cache;
 mod capture;
 mod diff;
 mod entry;

--- a/packages/hurl/src/runner/response.rs
+++ b/packages/hurl/src/runner/response.rs
@@ -20,6 +20,7 @@ use std::collections::HashMap;
 use hurl_core::ast::*;
 
 use crate::http;
+use crate::runner::cache::BodyCache;
 use crate::runner::error::{RunnerError, RunnerErrorKind};
 use crate::runner::result::{AssertResult, CaptureResult};
 use crate::runner::{assert, body, capture, json, multiline, template, Value};
@@ -55,10 +56,14 @@ pub fn eval_version_status_asserts(
 ///
 /// Asserts on status and version and not run in this function, there are run with `eval_version_status_asserts`
 /// as they're semantically stronger.
+///
+/// The `cache` is used to store XML / JSON structured response data and avoid redundant parsing
+/// operation on the response.
 pub fn eval_asserts(
     response: &Response,
     variables: &HashMap<String, Value>,
     http_response: &http::Response,
+    cache: &mut BodyCache,
     context_dir: &ContextDir,
 ) -> Vec<AssertResult> {
     let mut asserts = vec![];
@@ -145,7 +150,7 @@ pub fn eval_asserts(
     // Then, checks all the explicit asserts.
     for assert in response.asserts() {
         let assert_result =
-            assert::eval_explicit_assert(assert, variables, http_response, context_dir);
+            assert::eval_explicit_assert(assert, variables, http_response, cache, context_dir);
         asserts.push(assert_result);
     }
     asserts
@@ -348,11 +353,12 @@ fn eval_implicit_body_asserts(
 pub fn eval_captures(
     response: &Response,
     http_response: &http::Response,
+    cache: &mut BodyCache,
     variables: &mut HashMap<String, Value>,
 ) -> Result<Vec<CaptureResult>, RunnerError> {
     let mut captures = vec![];
     for capture in response.captures() {
-        let capture_result = capture::eval_capture(capture, variables, http_response)?;
+        let capture_result = capture::eval_capture(capture, variables, http_response, cache)?;
         // Update variables now so the captures set is ready in case
         // the next captures reference this new variable.
         variables.insert(capture_result.name.clone(), capture_result.value.clone());
@@ -417,12 +423,15 @@ mod tests {
     #[test]
     pub fn test_eval_asserts() {
         let variables = HashMap::new();
+        let mut cache = BodyCache::new();
+
         let context_dir = ContextDir::default();
         assert_eq!(
             eval_asserts(
                 &user_response(),
                 &variables,
                 &http::xml_two_users_http_response(),
+                &mut cache,
                 &context_dir,
             ),
             vec![AssertResult::Explicit {
@@ -463,10 +472,13 @@ mod tests {
     #[test]
     pub fn test_eval_captures() {
         let mut variables = HashMap::new();
+        let mut cache = BodyCache::new();
+
         assert_eq!(
             eval_captures(
                 &user_response(),
                 &http::xml_two_users_http_response(),
+                &mut cache,
                 &mut variables,
             )
             .unwrap(),


### PR DESCRIPTION
Add a cache on XML parsed body response.

Methods that takes a `http::Response` has been modified to take alos a `&mut BodyCache`.

With Hurl 4.3.0, on `tests_ok/parse_cache.hurl` (multiple XPath query on a 260K HTML doc):

![hurl-4 3 0](https://github.com/Orange-OpenSource/hurl/assets/16323814/3f8e39f4-f635-4be9-b18b-de8b87f0cbee)

With Hurl 5.0.0, on `tests_ok/parse_cache.hurl`:
  
![hurl-5 0 0](https://github.com/Orange-OpenSource/hurl/assets/16323814/8573100b-0fcb-4d3b-8b2a-c538e47beea1)

A nice x17 improvement on this extreme use case 🥳

To note: there is still a delay between two requests on 5.0.0 which corresponds to the only one XML cached response parsing.
