### PR TITLE
Delete unsupported HTTP version in runner_errors.sh.

### DIFF
--- a/integration/hurl/tests_failed/runner_errors.err.pattern
+++ b/integration/hurl/tests_failed/runner_errors.err.pattern
@@ -258,10 +258,3 @@ error: Decompression error
     | ^^^^^ compression unknown is not supported
     |
 
-error: Unsupported HTTP version
-   --> tests_failed/runner_errors.hurl:169:5
-    |
-169 | GET http://localhost:8000/runner_errors
-    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ HTTP/3 is not supported, check --version
-    |
-

--- a/integration/hurl/tests_failed/runner_errors.hurl
+++ b/integration/hurl/tests_failed/runner_errors.hurl
@@ -164,8 +164,3 @@ GET http://localhost:8000/runner_errors/unsupported-content-encoding
 HTTP 200
 [Asserts]
 bytes count == 10
-
-# UnsupportedHttpVersion
-GET http://localhost:8000/runner_errors
-[Options]
-http3: true

--- a/integration/hurl/tests_failed/runner_errors_color.err.pattern
+++ b/integration/hurl/tests_failed/runner_errors_color.err.pattern
@@ -258,10 +258,3 @@
 [1;34m    |[0m[1;31m ^^^^^ compression unknown is not supported[0m
 [1;34m    |[0m
 
-[1;31merror[0m: [1mUnsupported HTTP version[0m
-   [1;34m-->[0m tests_failed/runner_errors.hurl:169:5
-[1;34m    |[0m
-[1;34m169 |[0m GET http://localhost:8000/runner_errors
-[1;34m    |[0m[1;31m     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ HTTP/3 is not supported, check --version[0m
-[1;34m    |[0m
-


### PR DESCRIPTION
There is already a test for unsupported HTTP version http_version_not_supported.sh that can be skipped if libcurl support HTTP3.