### PR TITLE
Add package metadata for cargo-binstall

### DIFF
--- a/packages/hurl/Cargo.toml
+++ b/packages/hurl/Cargo.toml
@@ -56,3 +56,9 @@ cc = "1.1.18"
 
 [lints]
 workspace = true
+
+# cargo-binstall metadata
+# See https://github.com/cargo-bins/cargo-binstall/blob/main/SUPPORT.md
+# for docs explaining the fields here.
+[package.metadata.binstall]
+bin-dir = "{ name }-{ version }-{ target }/bin/{ bin }{ binary-ext }"

--- a/packages/hurlfmt/Cargo.toml
+++ b/packages/hurlfmt/Cargo.toml
@@ -21,3 +21,10 @@ proptest = "1.5.0"
 
 [lints]
 workspace = true
+
+# cargo-binstall metadata
+# See https://github.com/cargo-bins/cargo-binstall/blob/main/SUPPORT.md
+# for docs explaining the fields here.
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/{ version }/hurl-{ version }-{ target }{ archive-suffix }"
+bin-dir = "hurl-{ version }-{ target }/bin/{ bin }{ binary-ext }"


### PR DESCRIPTION
Hello! I've been using [cargo-binstall](https://github.com/cargo-bins/cargo-binstall) to install hurl in CI. It is able to use release artifacts to install the required binaries without needing to rebuild the binary from scratch. Unfortunately, cargo-binstall isn't able to use the release artifacts you have published because the binaries aren't in a location it checks. (I think this previously worked because there is a pre-built binary cache over in [cargo-quickinstall](https://github.com/cargo-bins/cargo-quickinstall)). 

This PR adds some package metadata which cargo-binstall can use to download the release binaries directly from your release artifacts.

You can verify that this works yourself by running
```bash
cargo binstall --dry-run --manifest-path /path/to/hurl/repo hurl
cargo binstall --dry-run --manifest-path /path/to/hurl/repo hurlfmt
```

If it works correctly you should a line containing
```
 WARN The package hurl v5.0.1 (x86_64-unknown-linux-gnu) has been downloaded from github.com
```