### PR TITLE
feature(jsonpath): adding possibility to filter by boolean

### DIFF
--- a/packages/hurl/src/jsonpath/ast.rs
+++ b/packages/hurl/src/jsonpath/ast.rs
@@ -54,6 +54,7 @@ pub struct Predicate {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum PredicateFunc {
     KeyExist,
+    EqualBool(bool),
     EqualString(String),
     Equal(Number),
     GreaterThan(Number),

--- a/packages/hurl/src/jsonpath/eval/query.rs
+++ b/packages/hurl/src/jsonpath/eval/query.rs
@@ -80,6 +80,7 @@ mod tests {
     pub fn json_first_book() -> serde_json::Value {
         json!({
             "category": "reference",
+            "published": false,
             "author": "Nigel Rees",
             "title": "Sayings of the Century",
             "price": 8.95
@@ -89,6 +90,7 @@ mod tests {
     pub fn json_second_book() -> serde_json::Value {
         json!({
             "category": "fiction",
+            "published": false,
             "author": "Evelyn Waugh",
             "title": "Sword of Honour",
             "price": 12.99
@@ -98,6 +100,7 @@ mod tests {
     pub fn json_third_book() -> serde_json::Value {
         json!({
             "category": "fiction",
+            "published": true,
             "author": "Herman Melville",
             "title": "Moby Dick",
             "isbn": "0-553-21311-3",
@@ -108,6 +111,7 @@ mod tests {
     pub fn json_fourth_book() -> serde_json::Value {
         json!({
             "category": "fiction",
+            "published": false,
             "author": "J. R. R. Tolkien",
             "title": "The Lord of the Rings",
             "isbn": "0-395-19395-8",
@@ -162,6 +166,44 @@ mod tests {
         assert_eq!(
             query.eval(&json_root()).unwrap(),
             JsonpathResult::Collection(vec![json!("Sayings of the Century"), json!("Moby Dick")])
+        );
+
+        // $.store.book[?(@.published==true)].title
+        let query = Query {
+            selectors: vec![
+                Selector::NameChild("store".to_string()),
+                Selector::NameChild("book".to_string()),
+                Selector::Filter(Predicate {
+                    key: vec!["published".to_string()],
+                    func: PredicateFunc::EqualBool(true),
+                }),
+                Selector::NameChild("title".to_string()),
+            ],
+        };
+        assert_eq!(
+            query.eval(&json_root()).unwrap(),
+            JsonpathResult::Collection(vec![json!("Moby Dick")])
+        );
+
+        // $.store.book[?(@.published==false)].title
+        let query = Query {
+            selectors: vec![
+                Selector::NameChild("store".to_string()),
+                Selector::NameChild("book".to_string()),
+                Selector::Filter(Predicate {
+                    key: vec!["published".to_string()],
+                    func: PredicateFunc::EqualBool(false),
+                }),
+                Selector::NameChild("title".to_string()),
+            ],
+        };
+        assert_eq!(
+            query.eval(&json_root()).unwrap(),
+            JsonpathResult::Collection(vec![
+                json!("Sayings of the Century"),
+                json!("Sword of Honour"),
+                json!("The Lord of the Rings")
+            ])
         );
 
         // $..author

--- a/packages/hurl/src/jsonpath/eval/selector.rs
+++ b/packages/hurl/src/jsonpath/eval/selector.rs
@@ -172,6 +172,7 @@ impl Predicate {
                         (serde_json::Value::String(v), PredicateFunc::EqualString(ref s)) => {
                             v == *s
                         }
+                        (serde_json::Value::Bool(v), PredicateFunc::EqualBool(ref s)) => v == *s,
                         _ => false,
                     }
                 } else {
@@ -392,6 +393,18 @@ mod tests {
             }),
         }
         .eval(json!({"key": 1})));
+
+        assert!(Predicate {
+            key: vec!["key".to_string()],
+            func: PredicateFunc::EqualBool(true),
+        }
+        .eval(json!({"key": true})));
+
+        assert!(Predicate {
+            key: vec!["key".to_string()],
+            func: PredicateFunc::EqualBool(false),
+        }
+        .eval(json!({"key": false})));
     }
 
     #[test]

--- a/packages/hurl/src/jsonpath/parser/primitives.rs
+++ b/packages/hurl/src/jsonpath/parser/primitives.rs
@@ -83,6 +83,23 @@ pub fn number(reader: &mut Reader) -> ParseResult<Number> {
     Ok(Number { int, decimal })
 }
 
+pub fn boolean(reader: &mut Reader) -> ParseResult<bool> {
+    let token = reader.read_while(|c| c.is_alphabetic());
+
+    // Match the token against the strings "true" and "false"
+    let result = match token.as_str() {
+        "true" => Ok(true),
+        "false" => Ok(false),
+        _ => {
+            let kind = ParseErrorKind::Expecting("bool".to_string());
+            let error = ParseError::new(reader.cursor().pos, true, kind);
+            Err(error)
+        }
+    };
+    whitespace(reader);
+    result
+}
+
 pub fn string_value(reader: &mut Reader) -> Result<String, ParseError> {
     try_literal("'", reader)?;
     let mut s = String::new();


### PR DESCRIPTION
With this change we will be able to use jsonpath to filter json arrays by a boolean. I found this feature missing for my use case and it would be great if you consider to accept this PR

Example:

For JSON

```
{
   "store":{
      "book":[
         {
            "category":"reference",
            "published":false,
            "author":"Nigel Rees",
            "title":"Sayings of the Century",
            "price":8.95
         },
         {
            "category":"fiction",
            "published":false,
            "author":"Evelyn Waugh",
            "title":"Sword of Honour",
            "price":12.99
         },
         {
            "category":"fiction",
            "published":true,
            "author":"Herman Melville",
            "title":"Moby Dick",
            "isbn":"0-553-21311-3",
            "price":8.99
         },
         {
            "category":"fiction",
            "published":false,
            "author":"J. R. R. Tolkien",
            "title":"The Lord of the Rings",
            "isbn":"0-395-19395-8",
            "price":22.99
         }
      ],
      "bicycle":[
         
      ]
   }
}
```

Using `$.store.book[?(@.published==true)].title` we will wet `["Moby Dick"]`