### PR TITLE
fix(hurlfmt): JSON key escaping in JValue formatting

### DIFF
--- a/packages/hurlfmt/src/format/serialize_json.rs
+++ b/packages/hurlfmt/src/format/serialize_json.rs
@@ -50,7 +50,13 @@ impl JValue {
             JValue::Object(key_values) => {
                 let s = key_values
                     .iter()
-                    .map(|(k, v)| format!("\"{}\":{}", k, v.format()))
+                    .map(|(k, v)| {
+                        format!(
+                            "\"{}\":{}",
+                            k.chars().map(format_char).collect::<String>(),
+                            v.format()
+                        )
+                    })
                     .collect::<Vec<String>>()
                     .join(",");
                 format!("{{{s}}}")
@@ -117,6 +123,18 @@ pub mod tests {
             ])
             .format(),
             "[1,2,3]"
+        );
+    }
+    #[test]
+    pub fn test_format_special_characters() {
+        let value = JValue::Object(vec![(
+            "sp\"ecial\\key".to_string(),
+            JValue::String("sp\nvalue\twith\x08control".to_string()),
+        )]);
+
+        assert_eq!(
+            value.format(),
+            r#"{"sp\"ecial\\key":"sp\nvalue\twith\bcontrol"}"#
         );
     }
 


### PR DESCRIPTION
- Keys in JValue::Object cause invalid JSON with characters like " and \.

- I applied  format_char function to both keys and values in the format method to ensure all special characters are correctly escaped

- Added test 