### PR TITLE
Simplify the curl examples in docs

### DIFF
--- a/docs/frequently-asked-questions.md
+++ b/docs/frequently-asked-questions.md
@@ -32,9 +32,7 @@ POST http://localhost:3000/api/login
 With [curl]:
 
 ```
-curl --header "Content-Type: application/json" \
-     --request POST \
-     --data '{"username": "xyz","password": "xyz"}' \
+curl --json --data '{"username": "xyz","password": "xyz"}' \
      http://localhost:3000/api/login
 ``` 
 

--- a/docs/standalone/hurl-5.0.1.md
+++ b/docs/standalone/hurl-5.0.1.md
@@ -1981,9 +1981,7 @@ POST http://localhost:3000/api/login
 With [curl](https://curl.haxx.se):
 
 ```
-curl --header "Content-Type: application/json" \
-     --request POST \
-     --data '{"username": "xyz","password": "xyz"}' \
+curl --json --data '{"username": "xyz","password": "xyz"}' \
      http://localhost:3000/api/login
 ``` 
 

--- a/docs/standalone/hurl-6.0.0.md
+++ b/docs/standalone/hurl-6.0.0.md
@@ -2011,9 +2011,7 @@ POST http://localhost:3000/api/login
 With [curl](https://curl.haxx.se):
 
 ```
-curl --header "Content-Type: application/json" \
-     --request POST \
-     --data '{"username": "xyz","password": "xyz"}' \
+curl --json --data '{"username": "xyz","password": "xyz"}' \
      http://localhost:3000/api/login
 ``` 
 


### PR DESCRIPTION
--request is redundant (and potentially dangerous) in most cases (see
https://daniel.haxx.se/blog/2015/09/11/unnecessary-use-of-curl-x/)
Since 7.82.0 curl offers the --json command-line option to simplify use
of JSON payloads.

Generated pages are not touched in this change nor are uses of these
redundant options in code.