### PR TITLE
Add unit test of repeated headers for `aggregate_raw_headers`

### DIFF
--- a/packages/hurl/src/http/headers_helper.rs
+++ b/packages/hurl/src/http/headers_helper.rs
@@ -124,7 +124,12 @@ mod tests {
         let mut headers = HeaderVec::new();
         headers.push(Header::new("Host", "localhost:8000"));
 
-        let raw_headers = &["User-Agent: hurl/6.1.0", "Invalid-Header"];
+        let raw_headers = &[
+            "User-Agent: hurl/6.1.0",
+            "Invalid-Header",
+            "Repeated-Header: content-1",
+            "Repeated-Header: content-2",
+        ];
         let aggregated = headers.aggregate_raw_headers(raw_headers);
 
         assert_eq!(
@@ -136,5 +141,12 @@ mod tests {
             Some(&Header::new("User-Agent", "hurl/6.1.0"))
         );
         assert_eq!(aggregated.get("Invalid-Header"), None);
+        assert_eq!(
+            aggregated.get_all("Repeated-Header"),
+            vec![
+                &Header::new("Repeated-Header", "content-1"),
+                &Header::new("Repeated-Header", "content-2")
+            ]
+        );
     }
 }


### PR DESCRIPTION
### Description

This PR adds to the unit test for `aggregate_raw_headers`. It includes additional testing for headers with the same name but different values.

Requested [here](https://github.com/Orange-OpenSource/hurl/pull/3419#issuecomment-2521230930).