### PR TITLE
wip: Initial include support

### DIFF
--- a/packages/hurl/src/parallel/worker.rs
+++ b/packages/hurl/src/parallel/worker.rs
@@ -120,7 +120,7 @@ impl Worker {
 
             // Now, we have a syntactically correct HurlFile instance, we can run it.
             let result = runner::run_entries(
-                &hurl_file.entries,
+                &hurl_file.entries().collect::<Vec<_>>(),
                 &content,
                 Some(&job.filename),
                 &job.runner_options,

--- a/packages/hurl/src/runner/hurl_file.rs
+++ b/packages/hurl/src/runner/hurl_file.rs
@@ -112,9 +112,11 @@ pub fn run(
         }
     };
 
+    // TODO: resolve the file here
+
     // Now, we have a syntactically correct HurlFile instance, we can run it.
     let result = run_entries(
-        &hurl_file.entries,
+        &hurl_file.entries().collect::<Vec<_>>(),
         content,
         filename,
         runner_options,
@@ -140,7 +142,7 @@ pub fn run(
 /// New entry run events are reported to `progress` and are usually used to display a progress bar
 /// in test mode.
 pub fn run_entries(
-    entries: &[Entry],
+    entries: &[&Entry],
     content: &str,
     filename: Option<&Input>,
     runner_options: &RunnerOptions,
@@ -504,7 +506,7 @@ fn get_non_default_options(options: &RunnerOptions) -> Vec<(&'static str, String
 
 /// Logs various debug information at the start of `hurl_file` run.
 fn log_run_info(
-    entries: &[Entry],
+    entries: &[&Entry],
     runner_options: &RunnerOptions,
     variables: &VariableSet,
     logger: &mut Logger,

--- a/packages/hurl_core/src/ast/core.rs
+++ b/packages/hurl_core/src/ast/core.rs
@@ -26,8 +26,78 @@ use crate::typing::{Count, Duration};
 ///
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct HurlFile {
-    pub entries: Vec<Entry>,
+    pub entries: Vec<EntryOrDirective>,
     pub line_terminators: Vec<LineTerminator>,
+}
+
+impl HurlFile {
+    /// Iterates over the available entries
+    pub fn entries(&self) -> impl Iterator<Item = &Entry> {
+        self.entries
+            .iter()
+            .filter_map(|entry_or_directive| match entry_or_directive {
+                EntryOrDirective::Entry(e) => Some(e),
+                _ => None,
+            })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum EntryOrDirective {
+    Entry(Entry),
+    Directive(Directive),
+}
+
+impl EntryOrDirective {
+    pub fn source_info(&self) -> SourceInfo {
+        match self {
+            EntryOrDirective::Entry(e) => e.source_info(),
+            EntryOrDirective::Directive(d) => d.source_info(),
+        }
+    }
+}
+
+impl From<Entry> for EntryOrDirective {
+    fn from(v: Entry) -> Self {
+        EntryOrDirective::Entry(v)
+    }
+}
+
+impl From<Directive> for EntryOrDirective {
+    fn from(v: Directive) -> Self {
+        EntryOrDirective::Directive(v)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Directive {
+    pub line_terminators: Vec<LineTerminator>,
+    pub space0: Whitespace,
+    pub line_terminator0: LineTerminator,
+    pub value: DirectiveValue,
+    pub source_info: SourceInfo,
+}
+
+impl Directive {
+    /// Returns the source information for this directive.
+    pub fn source_info(&self) -> SourceInfo {
+        self.space0.source_info
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DirectiveValue {
+    Include(Include),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Include {
+    pub line_terminators: Vec<LineTerminator>,
+    pub space0: Whitespace,
+    pub space1: Whitespace,
+    pub space2: Whitespace,
+    pub path: Template,
+    pub line_terminator0: LineTerminator,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/packages/hurl_core/src/format/html.rs
+++ b/packages/hurl_core/src/format/html.rs
@@ -76,7 +76,7 @@ impl HtmlFormatter {
     pub fn fmt_hurl_file(&mut self, hurl_file: &HurlFile) -> &str {
         self.buffer.clear();
         self.fmt_pre_open("language-hurl");
-        hurl_file.entries.iter().for_each(|e| self.fmt_entry(e));
+        hurl_file.entries().for_each(|e| self.fmt_entry(e));
         self.fmt_lts(&hurl_file.line_terminators);
         self.fmt_pre_close();
         &self.buffer

--- a/packages/hurlfmt/src/format/json.rs
+++ b/packages/hurlfmt/src/format/json.rs
@@ -40,7 +40,7 @@ impl ToJson for HurlFile {
     fn to_json(&self) -> JValue {
         JValue::Object(vec![(
             "entries".to_string(),
-            JValue::List(self.entries.iter().map(|e| e.to_json()).collect()),
+            JValue::List(self.entries().map(|e| e.to_json()).collect()),
         )])
     }
 }

--- a/packages/hurlfmt/src/format/token.rs
+++ b/packages/hurlfmt/src/format/token.rs
@@ -17,14 +17,14 @@
  */
 use hurl_core::ast::{
     Assert, Base64, Body, BooleanOption, Bytes, Capture, CertificateAttributeName, Comment, Cookie,
-    CookieAttribute, CookiePath, CountOption, DurationOption, EncodedString, Entry, EntryOption,
-    Expr, ExprKind, File, FileParam, FileValue, Filter, FilterValue, Function, GraphQl,
-    GraphQlVariables, Hex, HurlFile, JsonListElement, JsonObjectElement, JsonValue, KeyValue,
-    LineTerminator, Method, MultilineString, MultilineStringAttribute, MultilineStringKind,
-    MultipartParam, NaturalOption, OptionKind, Placeholder, Predicate, PredicateFunc,
-    PredicateFuncValue, PredicateValue, Query, QueryValue, Regex, RegexValue, Request, Response,
-    Section, SectionValue, Status, StatusValue, Template, TemplateElement, Text, Variable,
-    VariableDefinition, VariableValue, Version, Whitespace, I64, U64,
+    CookieAttribute, CookiePath, CountOption, Directive, DurationOption, EncodedString, Entry,
+    EntryOption, EntryOrDirective, Expr, ExprKind, File, FileParam, FileValue, Filter, FilterValue,
+    Function, GraphQl, GraphQlVariables, Hex, HurlFile, JsonListElement, JsonObjectElement,
+    JsonValue, KeyValue, LineTerminator, Method, MultilineString, MultilineStringAttribute,
+    MultilineStringKind, MultipartParam, NaturalOption, OptionKind, Placeholder, Predicate,
+    PredicateFunc, PredicateFuncValue, PredicateValue, Query, QueryValue, Regex, RegexValue,
+    Request, Response, Section, SectionValue, Status, StatusValue, Template, TemplateElement, Text,
+    Variable, VariableDefinition, VariableValue, Version, Whitespace, I64, U64,
 };
 use hurl_core::typing::{Count, Duration};
 
@@ -71,6 +71,21 @@ impl Tokenizable for HurlFile {
                 .collect(),
         );
         tokens
+    }
+}
+
+impl Tokenizable for EntryOrDirective {
+    fn tokenize(&self) -> Vec<Token> {
+        match self {
+            EntryOrDirective::Entry(e) => e.tokenize(),
+            EntryOrDirective::Directive(d) => d.tokenize(),
+        }
+    }
+}
+
+impl Tokenizable for Directive {
+    fn tokenize(&self) -> Vec<Token> {
+        todo!("To be done once the rest is accepted")
     }
 }
 


### PR DESCRIPTION
Here what I'd propose for adding the ability to reuse some hurl file fragment over others
- [x] Have a `Directive` that can be intermixed with `Entry` syntax element
   - [x] Have an `[Include]` directive with a `path` that must be another hurl file
- [ ] Add a `fn resolve(context: Context)` that produces a new `HurlFile` with all the directives resolved

Usage wise `resolve()` needs to know what is its root base and pass it down so every hurl files that gets included.
It will need some mechanism to detect inclusion cycles so the Context will have to keep track on where it is.

Fixes #2110 and #317