### PR TITLE
Add integration tests for the `--header` option

### DIFF
--- a/integration/hurl/tests_ok/add_header.hurl
+++ b/integration/hurl/tests_ok/add_header.hurl
@@ -1,0 +1,11 @@
+GET http://localhost:8000/add-header
+HTTP 200
+
+GET http://localhost:8000/add-header-with-aggregation
+header-a: foo
+HTTP 200
+
+GET http://localhost:8000/add-header-with-duplicate
+header-b: bar
+{"message":"hi!"}
+HTTP 200

--- a/integration/hurl/tests_ok/add_header.ps1
+++ b/integration/hurl/tests_ok/add_header.ps1
@@ -1,0 +1,4 @@
+Set-StrictMode -Version latest
+$ErrorActionPreference = 'Stop'
+
+hurl --header 'header-b:baz' --header 'header-c:qux' tests_ok/add_header.hurl

--- a/integration/hurl/tests_ok/add_header.py
+++ b/integration/hurl/tests_ok/add_header.py
@@ -1,0 +1,25 @@
+from app import app
+from flask import request
+
+
+@app.route("/add-header")
+def add_header():
+    assert request.headers.get("header-b") == "baz"
+    assert request.headers.get("header-c") == "qux"
+    return ""
+
+
+@app.route("/add-header-with-aggregation")
+def add_header_with_aggregation():
+    assert request.headers.get("header-a") == "foo"
+    assert request.headers.get("header-b") == "baz"
+    assert request.headers.get("header-c") == "qux"
+    return ""
+
+
+@app.route("/add-header-with-duplicate")
+def add_header_with_duplicate():
+    assert request.headers.get("header-b") == "bar,baz"
+    assert request.headers.get("header-c") == "qux"
+    assert request.get_json()["message"] == "hi!"
+    return ""

--- a/integration/hurl/tests_ok/add_header.sh
+++ b/integration/hurl/tests_ok/add_header.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+hurl --header 'header-b:baz' --header 'header-c:qux' tests_ok/add_header.hurl

--- a/integration/hurl/tests_ok/override_header.hurl
+++ b/integration/hurl/tests_ok/override_header.hurl
@@ -1,0 +1,2 @@
+GET http://localhost:8000/override-header
+HTTP 200

--- a/integration/hurl/tests_ok/override_header.ps1
+++ b/integration/hurl/tests_ok/override_header.ps1
@@ -1,0 +1,4 @@
+Set-StrictMode -Version latest
+$ErrorActionPreference = 'Stop'
+
+hurl --header 'User-Agent: different-user-agent' --header 'Accept: different-accept' --header 'Host: different-host' tests_ok/override_header.hurl

--- a/integration/hurl/tests_ok/override_header.py
+++ b/integration/hurl/tests_ok/override_header.py
@@ -1,0 +1,10 @@
+from app import app
+from flask import request
+
+
+@app.route("/override-header")
+def override_user_agent():
+    assert request.headers.get("User-Agent") == "different-user-agent"
+    assert request.headers.get("Accept") == "different-accept"
+    assert request.headers.get("Host") == "different-host"
+    return ""

--- a/integration/hurl/tests_ok/override_header.sh
+++ b/integration/hurl/tests_ok/override_header.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+hurl --header 'User-Agent: different-user-agent' --header 'Accept: different-accept' --header 'Host: different-host' tests_ok/override_header.hurl


### PR DESCRIPTION
Closes #3504.
## Description
This PR adds the following two integration tests:

### add_header
Use `--header` to add headers to: 
- A request with no additional headers in the hurl file
- A request with some additional headers in the hurl file
- A request with a duplicate header in the hurl file

### override_header
Use `--header` to override built-in headers: `User-Agent`, `Accept`, `Host`