### PR TITLE
Use Value equality in == and != predicates

### DIFF
--- a/integration/hurl/tests_failed/assert_query_cookie.err
+++ b/integration/hurl/tests_failed/assert_query_cookie.err
@@ -16,17 +16,5 @@ error: Assert failure
 11 | cookie "cookie2[Secure]" == true       # This is not valid, Secure attribute exists or not but does have a value
    |   actual:   unit
    |   expected: boolean <true>
-   |   >>> types between actual and expected are not consistent
-   |
-
-error: Assert failure
-  --> tests_failed/assert_query_cookie.hurl:12:0
-   |
-   | GET http://localhost:8000/error-assert-query-cookie
-   | ...
-12 | cookie "cookie2[Secure]" not == true   # This is not valid, Secure attribute exists or not but does have a value
-   |   actual:   unit
-   |   expected: not boolean <true>
-   |   >>> types between actual and expected are not consistent
    |
 

--- a/integration/hurl/tests_failed/assert_query_cookie.hurl
+++ b/integration/hurl/tests_failed/assert_query_cookie.hurl
@@ -9,7 +9,5 @@ cookie "cookie1[Secure]" not == true
 
 cookie "cookie2[Secure]" exists
 cookie "cookie2[Secure]" == true       # This is not valid, Secure attribute exists or not but does have a value
-cookie "cookie2[Secure]" not == true   # This is not valid, Secure attribute exists or not but does have a value
-
-
+cookie "cookie2[Secure]" not == true 
 

--- a/packages/hurl/src/runner/predicate.rs
+++ b/packages/hurl/src/runner/predicate.rs
@@ -652,126 +652,28 @@ fn eval_is_number(actual: &Value) -> Result<AssertResult, RunnerError> {
 }
 
 fn assert_values_equal(actual: &Value, expected: &Value) -> AssertResult {
-    let actual_display = actual.repr();
-    let expected_display = expected.repr();
-    match (actual, expected) {
-        (Value::Null, Value::Null) => AssertResult {
-            success: true,
-            actual: actual_display,
-            expected: expected_display,
-            type_mismatch: false,
-        },
-        (Value::Bool(value1), Value::Bool(value2)) => AssertResult {
-            success: value1 == value2,
-            actual: actual_display,
-            expected: expected_display,
-            type_mismatch: false,
-        },
-        (Value::Number(number1), Value::Number(number2)) => AssertResult {
-            success: number1.cmp_value(number2) == Ordering::Equal,
-            actual: actual_display,
-            expected: expected_display,
-            type_mismatch: false,
-        },
-        (Value::String(value1), Value::String(value2)) => AssertResult {
-            success: value1 == value2,
-            actual: actual_display,
-            expected: expected_display,
-            type_mismatch: false,
-        },
-        (Value::List(value1), Value::List(value2)) => AssertResult {
-            success: value1 == value2,
-            actual: actual_display,
-            expected: expected_display,
-            type_mismatch: false,
-        },
-        (Value::Bytes(value1), Value::Bytes(value2)) => AssertResult {
-            success: value1 == value2,
-            actual: actual_display,
-            expected: expected_display,
-            type_mismatch: false,
-        },
-        (Value::Date(value1), Value::Date(value2)) => AssertResult {
-            success: value1 == value2,
-            actual: actual_display,
-            expected: expected_display,
-            type_mismatch: false,
-        },
-        // FIXME: why case (UNIT UNIT) is not treated?
-        (Value::Unit, _) => AssertResult {
-            success: false,
-            actual: actual_display,
-            expected: expected_display,
-            type_mismatch: true,
-        },
-        _ => AssertResult {
-            success: false,
-            actual: actual_display,
-            expected: expected_display,
-            // FIXME: why type_mismatch is not true here?
-            type_mismatch: false,
-        },
+    let success = actual == expected;
+    let actual = actual.repr();
+    let expected = expected.repr();
+    let type_mismatch = false;
+    AssertResult {
+        success,
+        actual,
+        expected,
+        type_mismatch,
     }
 }
 
 fn assert_values_not_equal(actual: &Value, expected: &Value) -> AssertResult {
-    let actual_display = actual.repr();
-    let expected_display = expected.repr();
-    match (actual, expected) {
-        (Value::Null, Value::Null) => AssertResult {
-            success: false,
-            actual: actual_display,
-            expected: expected_display,
-            type_mismatch: false,
-        },
-        (Value::Bool(value1), Value::Bool(value2)) => AssertResult {
-            success: value1 != value2,
-            actual: actual_display,
-            expected: expected_display,
-            type_mismatch: false,
-        },
-        (Value::Number(number1), Value::Number(number2)) => AssertResult {
-            success: number1.cmp_value(number2) != Ordering::Equal,
-            actual: actual_display,
-            expected: expected_display,
-            type_mismatch: false,
-        },
-        (Value::String(value1), Value::String(value2)) => AssertResult {
-            success: value1 != value2,
-            actual: actual_display,
-            expected: expected_display,
-            type_mismatch: false,
-        },
-        (Value::List(value1), Value::List(value2)) => AssertResult {
-            success: value1 == value2,
-            actual: actual_display,
-            expected: expected_display,
-            type_mismatch: false,
-        },
-        (Value::Bytes(value1), Value::Bytes(value2)) => AssertResult {
-            success: value1 != value2,
-            actual: actual_display,
-            expected: expected_display,
-            type_mismatch: false,
-        },
-        (Value::Date(value1), Value::Date(value2)) => AssertResult {
-            success: value1 != value2,
-            actual: actual_display,
-            expected: expected_display,
-            type_mismatch: false,
-        },
-        (Value::Unit, _) => AssertResult {
-            success: false,
-            actual: actual_display,
-            expected: expected_display,
-            type_mismatch: true,
-        },
-        _ => AssertResult {
-            success: true,
-            actual: actual_display,
-            expected: expected_display,
-            type_mismatch: false,
-        },
+    let success = actual != expected;
+    let actual = actual.repr();
+    let expected = expected.repr();
+    let type_mismatch = false;
+    AssertResult {
+        success,
+        actual,
+        expected,
+        type_mismatch,
     }
 }
 
@@ -1027,7 +929,7 @@ mod tests {
         let value = Value::Unit;
         let assert_result = eval_equal(&expected, &variables, &value, &context_dir).unwrap();
         assert!(!assert_result.success);
-        assert!(assert_result.type_mismatch);
+        assert!(!assert_result.type_mismatch);
         assert_eq!(assert_result.actual, "unit");
         assert_eq!(assert_result.expected, "integer <10>");
     }

--- a/packages/hurl/src/runner/value.rs
+++ b/packages/hurl/src/runner/value.rs
@@ -15,7 +15,7 @@
  * limitations under the License.
  *
  */
-use std::fmt;
+use std::{cmp::Ordering, fmt};
 
 use crate::runner::Number;
 
@@ -65,14 +65,17 @@ pub enum ValueKind {
     Unit,
 }
 
-// You must implement it yourself because of the Regex Value
+/// Equality of values
+/// as used in the predicate ==
+///
+/// Any combination of value type can be used in the equality. There isn't any type/mismatch errors.
 impl PartialEq for Value {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (Value::Bool(v1), Value::Bool(v2)) => v1 == v2,
             (Value::Bytes(v1), Value::Bytes(v2)) => v1 == v2,
             (Value::Date(v1), Value::Date(v2)) => v1 == v2,
-            (Value::Number(v1), Value::Number(v2)) => v1 == v2,
+            (Value::Number(v1), Value::Number(v2)) => v1.cmp_value(v2) == Ordering::Equal,
             (Value::List(v1), Value::List(v2)) => v1 == v2,
             (Value::Nodeset(v1), Value::Nodeset(v2)) => v1 == v2,
             (Value::Null, Value::Null) => true,
@@ -233,6 +236,13 @@ mod tests {
     fn test_is_scalar() {
         assert!(Value::Number(Number::Integer(1)).is_scalar());
         assert!(!Value::List(vec![]).is_scalar());
+    }
+
+    #[test]
+    fn test_eq() {
+        assert!(!(Value::Bool(true) == Value::Bool(false)));
+        assert!(Value::Number(Number::Integer(1)) == Value::Number(Number::Float(1.0)));
+        assert!(!(Value::Bool(true) == Value::String("Hello".to_string())));
     }
 
     #[test]


### PR DESCRIPTION
There is only one behavior change relating to the unit type.
We can now include it in the equality.

For example.
```
cookie "cookie[Secure]" not == true
```
The query `cookie "cookie[Secure]"` return a Unit, that will always be different from the bool true.


