### PR TITLE
Fix clippy warnings for all targets

### DIFF
--- a/packages/hurl/src/http/client.rs
+++ b/packages/hurl/src/http/client.rs
@@ -1196,7 +1196,7 @@ mod tests {
 
         let logger_options = LoggerOptionsBuilder::default().build();
         let stderr = Stderr::new(WriteMode::Immediate);
-        let mut logger = Logger::new(&logger_options, stderr, &vec![]);
+        let mut logger = Logger::new(&logger_options, stderr, &[]);
 
         let cmd = client.curl_command_line(&request, &context_dir, output, &options, &mut logger);
         assert_eq!(
@@ -1261,6 +1261,6 @@ mod tests {
         assert_eq!(
             list.iter().collect::<Vec<_>>(),
             vec!["foo: a".as_bytes(), "bar: b".as_bytes(), "baz;".as_bytes()]
-        )
+        );
     }
 }

--- a/packages/hurl/src/http/curl_cmd.rs
+++ b/packages/hurl/src/http/curl_cmd.rs
@@ -543,12 +543,12 @@ mod tests {
         let options = ClientOptions::default();
         let output = None;
 
-        let cmd = CurlCmd::new(&request, &cookies, &context_dir, output.as_ref(), &options);
+        let cmd = CurlCmd::new(&request, &cookies, context_dir, output.as_ref(), &options);
         assert_eq!(cmd.to_string(), "curl 'http://localhost:8000/hello'");
 
         // Same requests with some output:
         let output = Some(Output::new("foo.out"));
-        let cmd = CurlCmd::new(&request, &cookies, &context_dir, output.as_ref(), &options);
+        let cmd = CurlCmd::new(&request, &cookies, context_dir, output.as_ref(), &options);
         assert_eq!(
             cmd.to_string(),
             "curl \
@@ -561,7 +561,7 @@ mod tests {
         headers.push(Header::new("User-Agent", "iPhone"));
         headers.push(Header::new("Foo", "Bar"));
         request.headers = headers;
-        let cmd = CurlCmd::new(&request, &cookies, &context_dir, output.as_ref(), &options);
+        let cmd = CurlCmd::new(&request, &cookies, context_dir, output.as_ref(), &options);
         assert_eq!(
             cmd.to_string(),
             "curl \
@@ -594,7 +594,7 @@ mod tests {
                 http_only: true,
             },
         ];
-        let cmd = CurlCmd::new(&request, &cookies, &context_dir, output.as_ref(), &options);
+        let cmd = CurlCmd::new(&request, &cookies, context_dir, output.as_ref(), &options);
         assert_eq!(
             cmd.to_string(),
             "curl \
@@ -657,7 +657,7 @@ mod tests {
             verbosity: None,
         };
 
-        let cmd = CurlCmd::new(&request, &cookies, &context_dir, None, &options);
+        let cmd = CurlCmd::new(&request, &cookies, context_dir, None, &options);
         assert_eq!(
             cmd.to_string(),
             "curl \
@@ -701,7 +701,7 @@ mod tests {
         let options = ClientOptions::default();
         let output = None;
 
-        let cmd = CurlCmd::new(&request, &cookies, &context_dir, output.as_ref(), &options);
+        let cmd = CurlCmd::new(&request, &cookies, context_dir, output.as_ref(), &options);
         assert_eq!(
             cmd.to_string(),
             "curl 'https://example.org/hello/../to/../your/../file'"
@@ -721,7 +721,7 @@ mod tests {
         let options = ClientOptions::default();
         let output = None;
 
-        let cmd = CurlCmd::new(&request, &cookies, &context_dir, output.as_ref(), &options);
+        let cmd = CurlCmd::new(&request, &cookies, context_dir, output.as_ref(), &options);
         assert_eq!(
             cmd.to_string(),
             "curl \
@@ -753,7 +753,7 @@ mod tests {
         let options = ClientOptions::default();
         let output = None;
 
-        let cmd = CurlCmd::new(&request, &cookies, &context_dir, output.as_ref(), &options);
+        let cmd = CurlCmd::new(&request, &cookies, context_dir, output.as_ref(), &options);
         assert_eq!(
             cmd.to_string(),
             "curl 'http://localhost:8000/querystring-params?param1=value1&param2=a%20b'",
@@ -763,7 +763,7 @@ mod tests {
         request.url =
             Url::from_str("http://localhost:8000/querystring-params?param3=foo&param4=bar")
                 .unwrap();
-        let cmd = CurlCmd::new(&request, &cookies, &context_dir, output.as_ref(), &options);
+        let cmd = CurlCmd::new(&request, &cookies, context_dir, output.as_ref(), &options);
         assert_eq!(
             cmd.to_string(),
             "curl 'http://localhost:8000/querystring-params?param3=foo&param4=bar&param1=value1&param2=a%20b'",
@@ -792,7 +792,7 @@ mod tests {
         let options = ClientOptions::default();
         let output = None;
 
-        let cmd = CurlCmd::new(&request, &cookies, &context_dir, output.as_ref(), &options);
+        let cmd = CurlCmd::new(&request, &cookies, context_dir, output.as_ref(), &options);
         assert_eq!(
             cmd.to_string(),
             "curl \
@@ -811,7 +811,7 @@ mod tests {
             method: Method("POST".to_string()),
             url: Url::from_str("http://localhost/json").unwrap(),
             headers,
-            body: Body::Text("".to_string()),
+            body: Body::Text(String::new()),
             implicit_content_type: Some("application/json".to_string()),
             ..Default::default()
         };
@@ -821,7 +821,7 @@ mod tests {
         let options = ClientOptions::default();
         let output = None;
 
-        let cmd = CurlCmd::new(&request, &cookies, &context_dir, output.as_ref(), &options);
+        let cmd = CurlCmd::new(&request, &cookies, context_dir, output.as_ref(), &options);
         assert_eq!(
             cmd.to_string(),
             "curl \
@@ -832,7 +832,7 @@ mod tests {
 
         // Add a non-empty body
         request.body = Body::Text("{\"foo\":\"bar\"}".to_string());
-        let cmd = CurlCmd::new(&request, &cookies, &context_dir, output.as_ref(), &options);
+        let cmd = CurlCmd::new(&request, &cookies, context_dir, output.as_ref(), &options);
         assert_eq!(
             cmd.to_string(),
             "curl \
@@ -843,7 +843,7 @@ mod tests {
 
         // Change method
         request.method = Method("PUT".to_string());
-        let cmd = CurlCmd::new(&request, &cookies, &context_dir, output.as_ref(), &options);
+        let cmd = CurlCmd::new(&request, &cookies, context_dir, output.as_ref(), &options);
         assert_eq!(
             cmd.to_string(),
             "curl \
@@ -868,7 +868,7 @@ mod tests {
         let options = ClientOptions::default();
         let output = None;
 
-        let cmd = CurlCmd::new(&request, &cookies, &context_dir, output.as_ref(), &options);
+        let cmd = CurlCmd::new(&request, &cookies, context_dir, output.as_ref(), &options);
         assert_eq!(
             cmd.to_string(),
             "curl \

--- a/packages/hurl/src/http/tests/mod.rs
+++ b/packages/hurl/src/http/tests/mod.rs
@@ -21,7 +21,7 @@ use crate::http::{
     Header, HeaderVec, HttpVersion, Method, Param, RequestCookie, RequestSpec, Response, Url,
 };
 
-/// Some Request Response to be used by tests
+// Some Request Response to be used by tests
 
 fn default_response() -> Response {
     Response {

--- a/packages/hurl/src/parallel/progress.rs
+++ b/packages/hurl/src/parallel/progress.rs
@@ -359,7 +359,7 @@ mod tests {
             .enumerate()
             .map(|(index, file)| {
                 Job::new(
-                    &Input::new(*file),
+                    &Input::new(file),
                     index,
                     &runner_options,
                     &variables,

--- a/packages/hurl/src/runner/filter/to_float.rs
+++ b/packages/hurl/src/runner/filter/to_float.rs
@@ -60,24 +60,24 @@ mod tests {
         assert_eq!(
             eval_filter(
                 &filter,
-                &Value::String("3.1415".to_string()),
+                &Value::String("3.5415".to_string()),
                 &variable,
                 false
             )
             .unwrap()
             .unwrap(),
-            Value::Number(Number::Float(3.1415))
+            Value::Number(Number::Float(3.5415))
         );
         assert_eq!(
             eval_filter(
                 &filter,
-                &Value::Number(Number::Float(3.1415)),
+                &Value::Number(Number::Float(3.5415)),
                 &variable,
                 false
             )
             .unwrap()
             .unwrap(),
-            Value::Number(Number::Float(3.1415))
+            Value::Number(Number::Float(3.5415))
         );
         assert_eq!(
             eval_filter(

--- a/packages/hurl/src/runner/number.rs
+++ b/packages/hurl/src/runner/number.rs
@@ -155,8 +155,8 @@ mod tests {
         let integer_minus_one = Number::from(-1);
         let integer_one = Number::from(1);
         let integer_two = Number::from(2);
-        let integer_max = Number::from(i64::max_value());
-        let integer_min = Number::from(i64::min_value());
+        let integer_max = Number::from(i64::MAX);
+        let integer_min = Number::from(i64::MIN);
 
         let float_zero = Number::from(0.0);
         let float_one = Number::from(1.0);

--- a/packages/hurl/src/runner/variable.rs
+++ b/packages/hurl/src/runner/variable.rs
@@ -223,7 +223,7 @@ mod test {
                 Visibility::Secret
             ))
         );
-        assert!(variables.get("BAZ").is_none())
+        assert!(variables.get("BAZ").is_none());
     }
 
     #[test]
@@ -286,6 +286,6 @@ mod test {
 
         let mut secrets = variables.secrets();
         secrets.sort();
-        assert_eq!(secrets, vec!["1234", "42"])
+        assert_eq!(secrets, vec!["1234", "42"]);
     }
 }

--- a/packages/hurl_core/src/parser/function.rs
+++ b/packages/hurl_core/src/parser/function.rs
@@ -54,6 +54,6 @@ mod tests {
         let mut reader = Reader::new("name");
         let err = parse(&mut reader).unwrap_err();
         assert_eq!(err.pos, Pos::new(1, 1));
-        assert_eq!(err.recoverable, true);
+        assert!(err.recoverable);
     }
 }


### PR DESCRIPTION
Fix for all lint warnings  #3665. Using clippy 0.1.84 (current rust stable)