### PR TITLE
hurlfmt: handle empty headers from curl input

### DIFF
--- a/integration/hurlfmt/tests_ok/import_curl.in
+++ b/integration/hurlfmt/tests_ok/import_curl.in
@@ -6,4 +6,5 @@ curl --header 'Content-Type:' --data '@tests_ok/data.bin' 'http://localhost:8000
 curl --location 'http://localhost:8000/redirect-absolute'
 curl --retry 4 'http://localhost:8000/retry/until-200'
 curl -k https://localhost:8001/hello
+curl --header 'Empty-Header;' http://localhost:8000/hello
 

--- a/integration/hurlfmt/tests_ok/import_curl.out
+++ b/integration/hurlfmt/tests_ok/import_curl.out
@@ -43,3 +43,6 @@ GET https://localhost:8001/hello
 [Options]
 insecure: true
 
+GET http://localhost:8000/hello
+Empty-Header:
+

--- a/packages/hurlfmt/src/curl/mod.rs
+++ b/packages/hurlfmt/src/curl/mod.rs
@@ -96,7 +96,11 @@ fn format(
 ) -> String {
     let mut s = format!("{method} {url}");
     for header in headers {
-        s.push_str(format!("\n{header}").as_str());
+        if let Some(stripped) = header.strip_suffix(";") {
+            s.push_str(format!("\n{}:", stripped).as_str());
+        } else {
+            s.push_str(format!("\n{header}").as_str());
+        }
     }
     if !options.is_empty() {
         s.push_str("\n[Options]");
@@ -183,6 +187,17 @@ Test: '
         );
         assert_eq!(
             parse_line("curl http://localhost:8000/custom-headers   --header Fruit:Raspberry -H 'Fruit: Banana' -H $'Test: \\''  ").unwrap(),
+            hurl_str
+        );
+    }
+
+    #[test]
+    fn test_empty_headers() {
+        let hurl_str = r#"GET http://localhost:8000/empty-headers
+Empty-Header:
+"#;
+        assert_eq!(
+            parse_line("curl http://localhost:8000/empty-headers -H 'Empty-Header;'").unwrap(),
             hurl_str
         );
     }


### PR DESCRIPTION
### Description
This PR enables `hurlfmt` to handle empty headers during the conversion from curl commands to hurl file. It also comes with the corresponding unit test/integration test.