### PR TITLE
Allow asserts on ip versions

### DIFF
--- a/packages/hurl/src/runner/error.rs
+++ b/packages/hurl/src/runner/error.rs
@@ -90,6 +90,9 @@ pub enum RunnerErrorKind {
     FilterInvalidFormatSpecifier(String),
     FilterMissingInput,
     Http(HttpError),
+    InvalidIpAddr {
+        value: String,
+    },
     InvalidJson {
         value: String,
     },
@@ -147,6 +150,7 @@ impl DisplaySourceError for RunnerError {
             RunnerErrorKind::FilterInvalidFormatSpecifier { .. } => "Filter error".to_string(),
             RunnerErrorKind::FilterMissingInput => "Filter error".to_string(),
             RunnerErrorKind::Http(http_error) => http_error.description(),
+            RunnerErrorKind::InvalidIpAddr { .. } => "Invalid IP address".to_string(),
             RunnerErrorKind::InvalidJson { .. } => "Invalid JSON".to_string(),
             RunnerErrorKind::InvalidUrl { .. } => "Invalid URL".to_string(),
             RunnerErrorKind::InvalidRegex => "Invalid regex".to_string(),
@@ -259,6 +263,11 @@ impl DisplaySourceError for RunnerError {
             RunnerErrorKind::Http(http_error) => {
                 let message = http_error.message();
                 let message = error::add_carets(&message, self.source_info, content);
+                color_red_multiline_string(&message)
+            }
+            RunnerErrorKind::InvalidIpAddr { value } => {
+                let message = &format!("Invalid IP address <{value}>");
+                let message = error::add_carets(message, self.source_info, content);
                 color_red_multiline_string(&message)
             }
             RunnerErrorKind::InvalidJson { value } => {

--- a/packages/hurl/src/runner/predicate.rs
+++ b/packages/hurl/src/runner/predicate.rs
@@ -15,16 +15,17 @@
  * limitations under the License.
  *
  */
-use hurl_core::ast::{Predicate, PredicateFunc, PredicateFuncValue, PredicateValue, SourceInfo};
-use hurl_core::reader::Pos;
-use std::cmp::Ordering;
-
 use crate::runner::error::RunnerError;
 use crate::runner::predicate_value::{eval_predicate_value, eval_predicate_value_template};
 use crate::runner::result::PredicateResult;
 use crate::runner::value::{EvalError, Value};
 use crate::runner::{Number, RunnerErrorKind, VariableSet};
 use crate::util::path::ContextDir;
+use hurl_core::ast::{Predicate, PredicateFunc, PredicateFuncValue, PredicateValue, SourceInfo};
+use hurl_core::reader::Pos;
+use std::cmp::Ordering;
+use std::net::IpAddr;
+use std::str::FromStr;
 
 /// Evaluates a `predicate` against an actual `value`.
 ///
@@ -201,6 +202,8 @@ fn expected_no_value(
         PredicateFuncValue::Exist => Ok("something".to_string()),
         PredicateFuncValue::IsEmpty => Ok("empty".to_string()),
         PredicateFuncValue::IsNumber => Ok("number".to_string()),
+        PredicateFuncValue::IsIpv4 => Ok("ipv4".to_string()),
+        PredicateFuncValue::IsIpv6 => Ok("ipv6".to_string()),
     }
 }
 
@@ -276,6 +279,8 @@ fn eval_predicate_func(
         PredicateFuncValue::Exist => eval_exist(value),
         PredicateFuncValue::IsEmpty => eval_is_empty(value),
         PredicateFuncValue::IsNumber => eval_is_number(value),
+        PredicateFuncValue::IsIpv4 => eval_is_ipv4(predicate_func.source_info, value),
+        PredicateFuncValue::IsIpv6 => eval_is_ipv6(predicate_func.source_info, value),
     }
 }
 
@@ -599,6 +604,50 @@ fn eval_is_number(actual: &Value) -> Result<AssertResult, RunnerError> {
         success: actual.is_number(),
         actual: actual.repr(),
         expected: "number".to_string(),
+        type_mismatch: false,
+    })
+}
+
+/// Evaluates if an `actual` value is an IPv4 address.
+fn eval_is_ipv4(source_info: SourceInfo, actual: &Value) -> Result<AssertResult, RunnerError> {
+    let ip = actual.to_string();
+    let parsed = match IpAddr::from_str(&ip) {
+        Ok(ip) => ip,
+        Err(_) => {
+            return Err(RunnerError::new(
+                source_info,
+                RunnerErrorKind::InvalidIpAddr { value: ip },
+                false,
+            ))
+        }
+    };
+
+    Ok(AssertResult {
+        success: parsed.is_ipv4(),
+        actual: actual.repr(),
+        expected: "ipv4".to_string(),
+        type_mismatch: false,
+    })
+}
+
+/// Evaluates if an `actual` value is an IPv6 address.
+fn eval_is_ipv6(source_info: SourceInfo, actual: &Value) -> Result<AssertResult, RunnerError> {
+    let ip = actual.to_string();
+    let parsed = match IpAddr::from_str(&ip) {
+        Ok(ip) => ip,
+        Err(_) => {
+            return Err(RunnerError::new(
+                source_info,
+                RunnerErrorKind::InvalidIpAddr { value: ip },
+                false,
+            ))
+        }
+    };
+
+    Ok(AssertResult {
+        success: parsed.is_ipv6(),
+        actual: actual.repr(),
+        expected: "ipv6".to_string(),
         type_mismatch: false,
     })
 }

--- a/packages/hurl_core/src/ast/core.rs
+++ b/packages/hurl_core/src/ast/core.rs
@@ -497,6 +497,8 @@ pub enum PredicateFuncValue {
     Exist,
     IsEmpty,
     IsNumber,
+    IsIpv4,
+    IsIpv6,
 }
 
 //

--- a/packages/hurl_core/src/ast/display.rs
+++ b/packages/hurl_core/src/ast/display.rs
@@ -333,6 +333,8 @@ impl PredicateFuncValue {
             PredicateFuncValue::Exist => "exists",
             PredicateFuncValue::IsEmpty => "isEmpty",
             PredicateFuncValue::IsNumber => "isNumber",
+            PredicateFuncValue::IsIpv4 => "isIpv4",
+            PredicateFuncValue::IsIpv6 => "isIpv6",
         }
     }
 }

--- a/packages/hurl_core/src/format/html.rs
+++ b/packages/hurl_core/src/format/html.rs
@@ -540,6 +540,8 @@ impl HtmlFormatter {
             PredicateFuncValue::Exist => {}
             PredicateFuncValue::IsEmpty => {}
             PredicateFuncValue::IsNumber => {}
+            PredicateFuncValue::IsIpv4 => {}
+            PredicateFuncValue::IsIpv6 => {}
         }
     }
 

--- a/packages/hurl_core/src/parser/predicate.rs
+++ b/packages/hurl_core/src/parser/predicate.rs
@@ -92,6 +92,8 @@ fn predicate_func_value(reader: &mut Reader) -> ParseResult<PredicateFuncValue> 
             exist_predicate,
             is_empty_predicate,
             is_number_predicate,
+            is_ipv4_predicate,
+            is_ipv6_predicate,
         ],
         reader,
     ) {
@@ -304,6 +306,16 @@ fn is_empty_predicate(reader: &mut Reader) -> ParseResult<PredicateFuncValue> {
 fn is_number_predicate(reader: &mut Reader) -> ParseResult<PredicateFuncValue> {
     try_literal("isNumber", reader)?;
     Ok(PredicateFuncValue::IsNumber)
+}
+
+fn is_ipv4_predicate(reader: &mut Reader) -> ParseResult<PredicateFuncValue> {
+    try_literal("isIPv4", reader)?;
+    Ok(PredicateFuncValue::IsIpv4)
+}
+
+fn is_ipv6_predicate(reader: &mut Reader) -> ParseResult<PredicateFuncValue> {
+    try_literal("isIPv6", reader)?;
+    Ok(PredicateFuncValue::IsIpv6)
 }
 
 #[cfg(test)]

--- a/packages/hurlfmt/src/format/json.rs
+++ b/packages/hurlfmt/src/format/json.rs
@@ -561,7 +561,9 @@ impl ToJson for Predicate {
             | PredicateFuncValue::IsIsoDate
             | PredicateFuncValue::Exist
             | PredicateFuncValue::IsEmpty
-            | PredicateFuncValue::IsNumber => {}
+            | PredicateFuncValue::IsNumber
+            | PredicateFuncValue::IsIpv4
+            | PredicateFuncValue::IsIpv6 => {}
         }
         JValue::Object(attributes)
     }

--- a/packages/hurlfmt/src/format/token.rs
+++ b/packages/hurlfmt/src/format/token.rs
@@ -610,6 +610,12 @@ impl Tokenizable for PredicateFuncValue {
             PredicateFuncValue::IsNumber => {
                 tokens.push(Token::PredicateType(name));
             }
+            PredicateFuncValue::IsIpv4 => {
+                tokens.push(Token::PredicateType(name));
+            }
+            PredicateFuncValue::IsIpv6 => {
+                tokens.push(Token::PredicateType(name));
+            }
         }
         tokens
     }

--- a/packages/hurlfmt/src/linter/rules.rs
+++ b/packages/hurlfmt/src/linter/rules.rs
@@ -427,6 +427,8 @@ fn lint_predicate_func_value(predicate_func_value: &PredicateFuncValue) -> Predi
         PredicateFuncValue::Exist => PredicateFuncValue::Exist,
         PredicateFuncValue::IsEmpty => PredicateFuncValue::IsEmpty,
         PredicateFuncValue::IsNumber => PredicateFuncValue::IsNumber,
+        PredicateFuncValue::IsIpv4 => PredicateFuncValue::IsIpv4,
+        PredicateFuncValue::IsIpv6 => PredicateFuncValue::IsIpv6,
     }
 }
 


### PR DESCRIPTION
Part 3 of #3106.

### Description
This PR adds the feature to assert IP version on a request using the following syntax:
```
[Asserts]
ip isIPv4
```
or
```
[Asserts]
ip isIPv6
```