### PR TITLE
fix hurlfmt html export loosing some whitespaces

### DIFF
--- a/packages/hurl_core/src/format/html.rs
+++ b/packages/hurl_core/src/format/html.rs
@@ -876,7 +876,13 @@ impl Template {
         for element in self.elements.iter() {
             let elem_str = match element {
                 TemplateElement::String { source, .. } => source.to_string(),
-                TemplateElement::Placeholder(expr) => format!("{{{{{expr}}}}}"),
+                TemplateElement::Placeholder(Placeholder {
+                    space0,
+                    expr,
+                    space1,
+                }) => {
+                    format!("{{{}{}{}}}", space0.value, expr, space1.value)
+                }
             };
             s.push_str(elem_str.as_str());
         }


### PR DESCRIPTION
This should fix #3675 

After the fix:

test.hurl
```
GET https://google.fr
HTTP 200
[Asserts]
jsonpath "toto" == "{{    x }}"
```

```
$ hurlfmt --out html test.hurl
```

```
<pre><code class="language-hurl"><span class="hurl-entry"><span class="request"><span class="line"><span class="method">GET</span> <span class="url">https://google.fr</span></span>
</span><span class="response"><span class="line"><span class="version">HTTP</span> <span class="number">200</span></span>
<span class="line"><span class="section-header">[Asserts]</span></span>
<span class="line"><span class="query-type">jsonpath</span> <span class="string">"toto"</span> <span class="predicate-type">==</span> <span class="string">"{    x }"</span></span></span></span></code></pre>
```