### PR TITLE
[WIP] Add query for HTTP redirects

### DIFF
--- a/packages/hurl/src/json/value.rs
+++ b/packages/hurl/src/json/value.rs
@@ -81,6 +81,15 @@ impl Value {
                 );
                 serde_json::Value::Object(map)
             }
+            Value::HttpResponse(v) => {
+                let mut map = serde_json::Map::new();
+                map.insert("url".to_string(), serde_json::Value::String(v.url().raw()));
+                map.insert(
+                    "status".to_string(),
+                    serde_json::Value::Number(serde_json::Number::from(v.status())),
+                );
+                serde_json::Value::Object(map)
+            }
         }
     }
 }

--- a/packages/hurl/src/runner/http_response.rs
+++ b/packages/hurl/src/runner/http_response.rs
@@ -1,0 +1,46 @@
+/*
+ * Hurl (https://hurl.dev)
+ * Copyright (C) 2025 Orange
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+use crate::http::Url;
+use std::fmt::Display;
+
+/// Represents an HTTP request for `Value::HttpResponse`
+#[derive(Clone, Debug)]
+pub struct HttpResponse {
+    url: Url,
+    status: u32,
+}
+
+impl HttpResponse {
+    pub fn new(url: Url, status: u32) -> Self {
+        HttpResponse { url, status }
+    }
+
+    pub fn url(&self) -> &Url {
+        &self.url
+    }
+
+    pub fn status(&self) -> u32 {
+        self.status
+    }
+}
+
+impl Display for HttpResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}

--- a/packages/hurl/src/runner/mod.rs
+++ b/packages/hurl/src/runner/mod.rs
@@ -21,6 +21,7 @@
 pub use self::error::{RunnerError, RunnerErrorKind};
 #[doc(hidden)]
 pub use self::event::EventListener;
+pub use self::http_response::HttpResponse;
 pub use self::hurl_file::run;
 #[doc(hidden)]
 pub use self::hurl_file::run_entries;
@@ -42,6 +43,7 @@ mod event;
 mod expr;
 mod filter;
 mod function;
+mod http_response;
 mod hurl_file;
 mod json;
 mod multiline;

--- a/packages/hurl/src/runner/predicate.rs
+++ b/packages/hurl/src/runner/predicate.rs
@@ -110,6 +110,7 @@ impl Value {
                 if values.len() > 1 { "s" } else { "" }
             ),
             Value::Date(value) => format!("date <{value}>"),
+            Value::HttpResponse(value) => format!("HTTP response <{value}>"),
             Value::List(value) => format!("list of size {}", value.len()),
             Value::Nodeset(size) => format!("list of size {size}"),
             Value::Null => "null".to_string(),

--- a/packages/hurl/src/runner/query.rs
+++ b/packages/hurl/src/runner/query.rs
@@ -27,7 +27,7 @@ use crate::runner::cache::BodyCache;
 use crate::runner::error::{RunnerError, RunnerErrorKind};
 use crate::runner::template::eval_template;
 use crate::runner::xpath::{Document, Format};
-use crate::runner::{filter, Number, Value, VariableSet};
+use crate::runner::{filter, HttpResponse, Number, Value, VariableSet};
 
 pub type QueryResult = Result<Option<Value>, RunnerError>;
 
@@ -68,6 +68,7 @@ pub fn eval_query(
             ..
         } => eval_query_certificate(last_response, *field),
         QueryValue::Ip => eval_ip(last_response),
+        QueryValue::Redirects => eval_redirects(responses),
     }
 }
 
@@ -397,6 +398,16 @@ fn eval_query_certificate(
 /// Evaluates the ip address of the HTTP `response`.
 fn eval_ip(response: &http::Response) -> QueryResult {
     Ok(Some(Value::String(response.ip_addr.to_string())))
+}
+
+/// Evaluates the redirects within a list of HTTP `responses`
+fn eval_redirects(responses: &[&http::Response]) -> QueryResult {
+    let mut values: Vec<Value> = responses
+        .iter()
+        .map(|r| Value::HttpResponse(HttpResponse::new(r.url.clone(), r.status)))
+        .collect();
+    values.pop();
+    Ok(Some(Value::List(values)))
 }
 
 fn eval_cookie_attribute_name(

--- a/packages/hurl/src/runner/value.rs
+++ b/packages/hurl/src/runner/value.rs
@@ -18,6 +18,7 @@
 use std::cmp::Ordering;
 use std::fmt;
 
+use crate::runner::HttpResponse;
 use crate::runner::Number;
 
 /// System types used in Hurl.
@@ -31,6 +32,8 @@ pub enum Value {
     Bytes(Vec<u8>),
     /// A date.
     Date(chrono::DateTime<chrono::Utc>),
+    /// A structure to represent an HTTP redirection.
+    HttpResponse(HttpResponse),
     /// A list of [`Value`].
     List(Vec<Value>),
     /// A structure to represents node of object (returned from XPath queries).
@@ -55,6 +58,7 @@ pub enum ValueKind {
     Bytes,
     Date,
     Float,
+    HttpResponse,
     Integer,
     List,
     Nodeset,
@@ -102,6 +106,7 @@ impl fmt::Display for Value {
             Value::Bool(x) => x.to_string(),
             Value::Bytes(v) => hex::encode(v).to_string(),
             Value::Date(v) => v.to_string(),
+            Value::HttpResponse(v) => format!("HttpResponse(status={})", v.status()),
             Value::Number(v) => v.to_string(),
             Value::List(values) => {
                 let values: Vec<String> = values.iter().map(|e| e.to_string()).collect();
@@ -129,6 +134,7 @@ impl Value {
             Value::Bool(_) => ValueKind::Bool,
             Value::Bytes(_) => ValueKind::Bytes,
             Value::Date(_) => ValueKind::Date,
+            Value::HttpResponse(_) => ValueKind::HttpResponse,
             Value::Number(Number::Float(_)) => ValueKind::Float,
             Value::Number(Number::Integer(_)) | Value::Number(Number::BigInteger(_)) => {
                 ValueKind::Integer
@@ -174,6 +180,7 @@ impl fmt::Display for ValueKind {
             ValueKind::Bytes => write!(f, "bytes"),
             ValueKind::Date => write!(f, "date"),
             ValueKind::Float => write!(f, "float"),
+            ValueKind::HttpResponse => write!(f, "http_response"),
             ValueKind::Integer => write!(f, "integer"),
             ValueKind::List => write!(f, "list"),
             ValueKind::Nodeset => write!(f, "nodeset"),

--- a/packages/hurl_core/src/ast/section.rs
+++ b/packages/hurl_core/src/ast/section.rs
@@ -174,6 +174,7 @@ pub enum QueryValue {
         attribute_name: CertificateAttributeName,
     },
     Ip,
+    Redirects,
 }
 
 impl QueryValue {
@@ -196,6 +197,7 @@ impl QueryValue {
             QueryValue::Md5 => "md5",
             QueryValue::Certificate { .. } => "certificate",
             QueryValue::Ip => "ip",
+            QueryValue::Redirects => "redirects",
         }
     }
 }

--- a/packages/hurl_core/src/format/html.rs
+++ b/packages/hurl_core/src/format/html.rs
@@ -415,7 +415,8 @@ impl HtmlFormatter {
             | QueryValue::Bytes
             | QueryValue::Sha256
             | QueryValue::Md5
-            | QueryValue::Ip => {}
+            | QueryValue::Ip
+            | QueryValue::Redirects => {}
         }
     }
 

--- a/packages/hurl_core/src/parser/error.rs
+++ b/packages/hurl_core/src/parser/error.rs
@@ -176,6 +176,7 @@ impl DisplaySourceError for ParseError {
                     "output",
                     "path-as-is",
                     "proxy",
+                    "redirects",
                     "resolve",
                     "retry",
                     "retry-interval",

--- a/packages/hurl_core/src/parser/query.rs
+++ b/packages/hurl_core/src/parser/query.rs
@@ -52,6 +52,7 @@ fn query_value(reader: &mut Reader) -> ParseResult<QueryValue> {
             md5_query,
             certificate_query,
             ip_query,
+            redirects_query,
         ],
         reader,
     )
@@ -199,6 +200,11 @@ fn certificate_query(reader: &mut Reader) -> ParseResult<QueryValue> {
 fn ip_query(reader: &mut Reader) -> ParseResult<QueryValue> {
     try_literal("ip", reader)?;
     Ok(QueryValue::Ip)
+}
+
+fn redirects_query(reader: &mut Reader) -> ParseResult<QueryValue> {
+    try_literal("redirects", reader)?;
+    Ok(QueryValue::Redirects)
 }
 
 fn certificate_field(reader: &mut Reader) -> ParseResult<CertificateAttributeName> {

--- a/packages/hurlfmt/src/linter/rules.rs
+++ b/packages/hurlfmt/src/linter/rules.rs
@@ -252,6 +252,7 @@ fn lint_query_value(query_value: &QueryValue) -> QueryValue {
             space0: one_whitespace(),
         },
         QueryValue::Ip => QueryValue::Ip,
+        QueryValue::Redirects => QueryValue::Redirects,
     }
 }
 


### PR DESCRIPTION
Closes #922.

### Description
This PR adds the query for `redirects`, allowing Hurl to look up a list of HTTP redirects evaluated as `runner::HttpResponse`.

(Marked as draft because it's still missing integration tests)