### PR TITLE
Add date comparison predicates

### DIFF
--- a/integration/hurl/tests_ok/assert_json.hurl
+++ b/integration/hurl/tests_ok/assert_json.hurl
@@ -10,6 +10,8 @@ insecure: false
 HTTP 200
 [Captures]
 count: jsonpath "$.count"
+date0: jsonpath "$.dates[0]" toDate "%+"
+date1: jsonpath "$.dates[1]" toDate "%+"
 [Asserts]
 jsonpath "$.count" == 5
 jsonpath "$.count" == 5.0
@@ -71,6 +73,12 @@ jsonpath "$.dates[0]" isIsoDate
 jsonpath "$.dates[1]" isIsoDate
 jsonpath "$.tags[0]" not isIsoDate
 jsonpath "$.tags[0]" not isNumber
+jsonpath "$.dates[0]" toDate "%+" == {{ date0 }}
+jsonpath "$.dates[0]" toDate "%+" <= {{ date1 }}
+jsonpath "$.dates[0]" toDate "%+" < {{ date1 }}
+jsonpath "$.dates[1]" toDate "%+" != {{ date0 }}
+jsonpath "$.dates[1]" toDate "%+" >= {{ date0 }}
+jsonpath "$.dates[1]" toDate "%+" > {{ date0 }}
 
 
 # FIXME do we accept count filter on object?

--- a/packages/hurl/src/runner/value_impl.rs
+++ b/packages/hurl/src/runner/value_impl.rs
@@ -30,6 +30,7 @@ impl Value {
         match (self, other) {
             (Value::String(s1), Value::String(s2)) => Ok(s1.cmp(s2)),
             (Value::Number(n1), Value::Number(n2)) => Ok(n1.cmp_value(n2)),
+            (Value::Date(d1), Value::Date(d2)) => Ok(d1.cmp(d2)),
             _ => Err(EvalError::Type),
         }
     }


### PR DESCRIPTION
# Description
Add date comparison predicates

# Related Issue 
#3840 

# Other
Hey @jcamiel, I had a few questions
1. I wasn't quite sure how to update the `hurl.grammar` file, I couldn't find a `date` key. How do I go about updating the grammar file
2. There's an `sp` in the grammar description for `greater-or-equal-predicate`, just wanted to check with you if that is intentional.
https://github.com/Orange-OpenSource/hurl/blob/e33c01e8fd79fb5307bbb01c2cc5215eb3ef9eee/docs/spec/grammar/hurl.grammar#L334

