### PR TITLE
Add "url" filter for Value variant HttpResponse

### DIFF
--- a/integration/hurl/tests_ok/assert_redirects.hurl
+++ b/integration/hurl/tests_ok/assert_redirects.hurl
@@ -4,3 +4,11 @@ location: true
 HTTP 200
 [Asserts]
 redirects count == 3
+redirects nth 0 url == "http://localhost:8000/redirect-3"
+redirects nth 1 url == "http://localhost:8000/redirect-2"
+redirects nth 2 url == "http://localhost:8000/redirect-1"
+redirects nth 0 url contains "redirect-3"
+redirects nth 1 url endsWith "2"
+redirects nth 2 url matches /^http:\/\/.*redirect-1$/
+url == "http://localhost:8000/redirected"
+`Redirected`

--- a/integration/hurl/tests_ok/follow_redirect.hurl
+++ b/integration/hurl/tests_ok/follow_redirect.hurl
@@ -13,6 +13,8 @@ Accept: text/plain
 HTTP 200
 [Asserts]
 redirects count == 2
+redirects nth 0 url == "http://localhost:8000/follow-redirect"
+redirects nth 1 url == "http://localhost:8000/following-redirect"
 url == "http://localhost:8000/followed-redirect"
 `Followed redirect!`
 
@@ -24,6 +26,8 @@ Accept: text/plain
 HTTP 200
 [Asserts]
 redirects count == 2
+redirects nth 0 url == "http://localhost:8000/follow-redirect"
+redirects nth 1 url == "http://localhost:8000/following-redirect"
 url == "http://localhost:8000/followed-redirect"
 `Followed redirect!`
 
@@ -33,6 +37,7 @@ Accept: text/plain
 HTTP 200
 [Asserts]
 redirects count == 1
+redirects nth 0 url == "http://localhost:8000/follow-redirect/relative/foo"
 url == "http://localhost:8000/follow-redirect/bar"
 `Followed relative redirect!`
 
@@ -43,6 +48,7 @@ Authorization: Basic Ym9iQGVtYWlsLmNvbTpzZWNyZXQ=
 HTTP 200
 [Asserts]
 redirects count == 1
+redirects nth 0 url == "http://localhost:8000/follow-redirect-basic-auth?change_host=true"
 header "Location" not exists
 `Followed redirect without Authorization header!`
 
@@ -54,6 +60,7 @@ Authorization: Basic Ym9iQGVtYWlsLmNvbTpzZWNyZXQ=
 HTTP 200
 [Asserts]
 redirects count == 1
+redirects nth 0 url == "http://localhost:8000/follow-redirect-basic-auth?change_host=false"
 header "Location" not exists
 `Followed redirect with Authorization header!`
 
@@ -65,6 +72,7 @@ user: bob@email.com:secret
 HTTP 200
 [Asserts]
 redirects count == 1
+redirects nth 0 url == "http://localhost:8000/follow-redirect-basic-auth?change_host=true"
 header "Location" not exists
 `Followed redirect without Authorization header!`
 
@@ -75,6 +83,7 @@ user: bob@email.com:secret
 HTTP 200
 [Asserts]
 redirects count == 1
+redirects nth 0 url == "http://localhost:8000/follow-redirect-basic-auth?change_host=false"
 header "Location" not exists
 `Followed redirect with Authorization header!`
 
@@ -86,6 +95,7 @@ bob@email.com: secret
 HTTP 200
 [Asserts]
 redirects count == 1
+redirects nth 0 url == "http://localhost:8000/follow-redirect-basic-auth?change_host=true"
 header "Location" not exists
 `Followed redirect without Authorization header!`
 
@@ -96,6 +106,7 @@ bob@email.com: secret
 HTTP 200
 [Asserts]
 redirects count == 1
+redirects nth 0 url == "http://localhost:8000/follow-redirect-basic-auth?change_host=false"
 header "Location" not exists
 `Followed redirect with Authorization header!`
 
@@ -105,5 +116,6 @@ Accept: text/plain
 HTTP 200
 [Asserts]
 redirects count == 1
+redirects nth 0 url == "http://localhost:8000/follow-redirect-308"
 url == "http://localhost:8000/followed-redirect-post"
 `Followed redirect POST!`

--- a/packages/hurl/src/runner/filter/eval.rs
+++ b/packages/hurl/src/runner/filter/eval.rs
@@ -37,6 +37,7 @@ use crate::runner::filter::to_date::eval_to_date;
 use crate::runner::filter::to_float::eval_to_float;
 use crate::runner::filter::to_int::eval_to_int;
 use crate::runner::filter::to_string::eval_to_string;
+use crate::runner::filter::url::eval_url;
 use crate::runner::filter::url_decode::eval_url_decode;
 use crate::runner::filter::url_encode::eval_url_encode;
 use crate::runner::filter::url_query_param::eval_url_query_param;
@@ -121,6 +122,7 @@ pub fn eval_filter(
         FilterValue::ToFloat => eval_to_float(value, filter.source_info, in_assert),
         FilterValue::ToInt => eval_to_int(value, filter.source_info, in_assert),
         FilterValue::ToString => eval_to_string(value, filter.source_info, in_assert),
+        FilterValue::Url => eval_url(value, filter.source_info, in_assert),
         FilterValue::UrlDecode => eval_url_decode(value, filter.source_info, in_assert),
         FilterValue::UrlEncode => eval_url_encode(value, filter.source_info, in_assert),
         FilterValue::UrlQueryParam { param, .. } => {

--- a/packages/hurl/src/runner/filter/url.rs
+++ b/packages/hurl/src/runner/filter/url.rs
@@ -15,34 +15,21 @@
  * limitations under the License.
  *
  */
+use hurl_core::ast::SourceInfo;
 
-pub use eval::eval_filters;
-pub use jsonpath::eval_jsonpath_json;
-pub use xpath::eval_xpath_doc;
+use crate::runner::{RunnerError, RunnerErrorKind, Value};
 
-mod base64_decode;
-mod base64_encode;
-mod base64_url_safe_decode;
-mod base64_url_safe_encode;
-mod count;
-mod days_after_now;
-mod days_before_now;
-mod decode;
-mod eval;
-mod format;
-mod html_escape;
-mod html_unescape;
-mod jsonpath;
-mod nth;
-mod regex;
-mod replace;
-mod split;
-mod to_date;
-mod to_float;
-mod to_int;
-mod to_string;
-mod url;
-mod url_decode;
-mod url_encode;
-mod url_query_param;
-mod xpath;
+/// Evaluates the URL of an HTTP response, if `value` is of type `HttpResponse`
+pub fn eval_url(
+    value: &Value,
+    source_info: SourceInfo,
+    assert: bool,
+) -> Result<Option<Value>, RunnerError> {
+    match value {
+        Value::HttpResponse(value) => Ok(Some(Value::String(value.url().raw()))),
+        v => {
+            let kind = RunnerErrorKind::FilterInvalidInput(v.kind().to_string());
+            Err(RunnerError::new(source_info, kind, assert))
+        }
+    }
+}

--- a/packages/hurl_core/src/ast/core.rs
+++ b/packages/hurl_core/src/ast/core.rs
@@ -325,6 +325,7 @@ pub enum FilterValue {
     ToFloat,
     ToInt,
     ToString,
+    Url,
     UrlDecode,
     UrlEncode,
     UrlQueryParam {
@@ -361,6 +362,7 @@ impl FilterValue {
             FilterValue::ToFloat => "toFloat",
             FilterValue::ToInt => "toInt",
             FilterValue::ToString => "toString",
+            FilterValue::Url => "url",
             FilterValue::UrlDecode => "urlDecode",
             FilterValue::UrlEncode => "urlEncode",
             FilterValue::UrlQueryParam { .. } => "urlQueryParam",

--- a/packages/hurl_core/src/format/html.rs
+++ b/packages/hurl_core/src/format/html.rs
@@ -802,6 +802,7 @@ impl HtmlFormatter {
             | FilterValue::ToFloat
             | FilterValue::ToInt
             | FilterValue::ToString
+            | FilterValue::Url
             | FilterValue::UrlDecode
             | FilterValue::UrlEncode => {}
         };

--- a/packages/hurl_core/src/parser/filter.rs
+++ b/packages/hurl_core/src/parser/filter.rs
@@ -73,6 +73,7 @@ pub fn filter(reader: &mut Reader) -> ParseResult<Filter> {
             to_float_filter,
             to_int_filter,
             to_string_filter,
+            url_filter,
             url_decode_filter,
             url_encode_filter,
             url_query_param_filter,
@@ -219,6 +220,11 @@ fn to_int_filter(reader: &mut Reader) -> ParseResult<FilterValue> {
 fn to_string_filter(reader: &mut Reader) -> ParseResult<FilterValue> {
     try_literal("toString", reader)?;
     Ok(FilterValue::ToString)
+}
+
+fn url_filter(reader: &mut Reader) -> ParseResult<FilterValue> {
+    try_literal("url", reader)?;
+    Ok(FilterValue::Url)
 }
 
 fn url_encode_filter(reader: &mut Reader) -> ParseResult<FilterValue> {


### PR DESCRIPTION
Follow-up of #922.

### Description
This PR implements a new filter `url` for the value variant `Value::HttpResponse`, which extracts the URL from such HTTP response. 

### Usage
```
[Asserts]
redirects nth 0 url == "http://bar.com"
redirects nth 1 url contains "foo.com"
redirects nth 2 url endsWith ".com"
```