### PR TITLE
Downgrade Arch Linux CI test to libxml 2.13.8 (2.14 can not be used wth generic Hurl)

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -186,10 +186,21 @@ jobs:
       with:
         image: archlinux
         options: --volume ${{ github.workspace }}:/work --workdir /work --privileged
+# Revert to libxml 2.13.8 that has a soname libxml2.so.2 required by our Ubuntu Hurl build.
+# Starting from libxml 2.14, <https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.14.0>:
+#
+# > Binary compatibility is restricted to versions 2.14 or newer. On ELF systems, the soname was bumped from
+# > libxml2.so.2 to libxml2.so.16.
+#
+# We downgrade when testing the Hurl generic package, not when we're building the Hurl package on Arch Linux as the soname
+# problem arise only with the generic package.
         run: |
           set -e
           echo "::group::Install system prerequisites"
             bin/install_prerequisites_archlinux.sh
+          echo "::endgroup::"
+          echo "::group::Downgrade libxml2"
+          pacman --upgrade --nodeps --noconfirm https://archive.archlinux.org/packages/l/libxml2/libxml2-2.13.8-1-x86_64.pkg.tar.zst
           echo "::endgroup::"
           echo "::group::Activate python3 venv"
             bin/activate_python3_venv.sh

--- a/bin/install_prerequisites_archlinux.sh
+++ b/bin/install_prerequisites_archlinux.sh
@@ -21,4 +21,3 @@ sudo rm -v /dev/shm/squid*.shm >/dev/null 2>&1 || true
 
 # Temporary install to patch a python3/pip crash
 pacman -Syu --noconfirm expat
-


### PR DESCRIPTION
## Downgrade Arch Linux CI test to libxml 2.13.8 (2.14 can not be used with generic Hurl).

@lepapareil @fabricereix 

Starting with libxml2 2.14.0 (27/04/2025), the soname of libxml2 has been updated (from `libxml2.so.2` to `libxml2.so.16`)

In <https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.14.0>:

> Binary compatibility is restricted to versions 2.14 or newer. On ELF systems, the soname was bumped from libxml2.so.2 to libxml2.so.16.

As a consquence, Hurl generic package can't be installed "as it" on distribution that have libxml2 >= 2.14.0 (the generic package depends on libxml2 whith soname `libxml2.so.2`)

For the moment, the issue is restricted to the CI package generic test with Arch Linux.

One way to go is to downgrade libxml2:

- note that we don't do it in `install_prerequisites_archlinux.sh`: if we rebuild Hurl on Archlinux, everything is fine (and linked to `libxml2.so.16`). The issue arises only when copying the generic Linux Hurl bianry.
- by downgrading libxml2, Hurl tests are OK but we've a broken distribution as pacman relies also and `libxml2` and cannot be launched (it needs `libxml2.so.16`which have been downgraded to `libxml.so.2`)