### PR TITLE
Remove hex crate dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,12 +499,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
 name = "hurl"
 version = "7.0.0-SNAPSHOT"
 dependencies = [
@@ -517,7 +511,6 @@ dependencies = [
  "curl-sys",
  "encoding",
  "glob",
- "hex",
  "hurl_core",
  "libflate",
  "libxml",

--- a/packages/hurl/Cargo.toml
+++ b/packages/hurl/Cargo.toml
@@ -27,7 +27,6 @@ curl = "0.4.47"
 curl-sys = "0.4.80"
 encoding = "0.2.33"
 glob = "0.3.2"
-hex = "0.4.3"
 hurl_core = { version = "7.0.0-SNAPSHOT", path = "../hurl_core" }
 libflate = "2.1.0"
 libxml = "0.3.3"

--- a/packages/hurl/src/http/debug.rs
+++ b/packages/hurl/src/http/debug.rs
@@ -18,6 +18,7 @@
 use encoding::DecoderTrap;
 
 use crate::http::{mimetype, HeaderVec};
+use crate::runner::hex;
 use crate::util::logger::Logger;
 
 /// Logs a buffer of bytes representing an HTTP request or response `body`.

--- a/packages/hurl/src/runner/filter/to_hex.rs
+++ b/packages/hurl/src/runner/filter/to_hex.rs
@@ -15,10 +15,9 @@
  * limitations under the License.
  *
  */
-use hex;
 use hurl_core::ast::SourceInfo;
 
-use crate::runner::{RunnerError, RunnerErrorKind, Value};
+use crate::runner::{hex, RunnerError, RunnerErrorKind, Value};
 
 /// Converts bytes `value` to hexadecimal string.
 pub fn eval_to_hex(

--- a/packages/hurl/src/runner/hex.rs
+++ b/packages/hurl/src/runner/hex.rs
@@ -1,0 +1,80 @@
+/*
+ * Hurl (https://hurl.dev)
+ * Copyright (C) 2025 Orange
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+use std::iter;
+
+const HEX_CHARS_LOWER: &[u8; 16] = b"0123456789abcdef";
+
+pub fn encode(bytes: &[u8]) -> String {
+    BytesToHexChars::new(bytes).collect()
+}
+
+struct BytesToHexChars<'a> {
+    inner: ::core::slice::Iter<'a, u8>,
+    next: Option<char>,
+}
+
+impl<'a> BytesToHexChars<'a> {
+    fn new(inner: &'a [u8]) -> BytesToHexChars<'a> {
+        BytesToHexChars {
+            inner: inner.iter(),
+            next: None,
+        }
+    }
+}
+
+impl Iterator for BytesToHexChars<'_> {
+    type Item = char;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.next.take() {
+            Some(current) => Some(current),
+            None => self.inner.next().map(|byte| {
+                let current = HEX_CHARS_LOWER[(byte >> 4) as usize] as char;
+                self.next = Some(HEX_CHARS_LOWER[(byte & 0x0F) as usize] as char);
+                current
+            }),
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let length = self.len();
+        (length, Some(length))
+    }
+}
+
+impl iter::ExactSizeIterator for BytesToHexChars<'_> {
+    fn len(&self) -> usize {
+        let mut length = self.inner.len() * 2;
+        if self.next.is_some() {
+            length += 1;
+        }
+        length
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_encode() {
+        let bytes = vec![0xc4, 0xe3, 0xba, 0xc3, 0xca, 0xc0, 0xbd, 0xe7];
+        let expected = "c4e3bac3cac0bde7";
+        assert_eq!(encode(&bytes), expected);
+    }
+}

--- a/packages/hurl/src/runner/mod.rs
+++ b/packages/hurl/src/runner/mod.rs
@@ -43,6 +43,7 @@ mod event;
 mod expr;
 mod filter;
 mod function;
+pub mod hex;
 mod http_response;
 mod hurl_file;
 mod json;

--- a/packages/hurl/src/runner/value.rs
+++ b/packages/hurl/src/runner/value.rs
@@ -18,6 +18,7 @@
 use std::cmp::Ordering;
 use std::fmt;
 
+use crate::runner::hex;
 use crate::runner::HttpResponse;
 use crate::runner::Number;
 


### PR DESCRIPTION
# Description
- Create `encode` to convert bytes to hexadecimal string
- Modify all `encode` to use custom implementation from `runner::hex`
- Remove `hex` crate as a dependency

# Related Issue
#4011 

# Discussion
Hey @jcamiel, let me know if this implementation of encode works or I need to make any changes

I had originally written the function as
```rust
pub fn encode(bytes: &[u8]) -> String {
    bytes.iter().map(|byte| format!("{:02x}", byte)).collect()
}
```
But I learnt this would be really inefficient so I changed it to new version (similar to how the `hex` crate does it)

Here's how the `hex` crate does `encode`

```rust
pub fn encode<T: AsRef<[u8]>>(data: T) -> String {
    data.encode_hex()
}

pub trait ToHex {
    /// Encode the hex strict representing `self` into the result. Lower case
    /// letters are used (e.g. `f9b4ca`)
    fn encode_hex<T: iter::FromIterator<char>>(&self) -> T;

    /// Encode the hex strict representing `self` into the result. Upper case
    /// letters are used (e.g. `F9B4CA`)
    fn encode_hex_upper<T: iter::FromIterator<char>>(&self) -> T;
}

const HEX_CHARS_LOWER: &[u8; 16] = b"0123456789abcdef";
const HEX_CHARS_UPPER: &[u8; 16] = b"0123456789ABCDEF";

struct BytesToHexChars<'a> {
    inner: ::core::slice::Iter<'a, u8>,
    table: &'static [u8; 16],
    next: Option<char>,
}

impl<'a> BytesToHexChars<'a> {
    fn new(inner: &'a [u8], table: &'static [u8; 16]) -> BytesToHexChars<'a> {
        BytesToHexChars {
            inner: inner.iter(),
            table,
            next: None,
        }
    }
}

impl<'a> Iterator for BytesToHexChars<'a> {
    type Item = char;

    fn next(&mut self) -> Option<Self::Item> {
        match self.next.take() {
            Some(current) => Some(current),
            None => self.inner.next().map(|byte| {
                let current = self.table[(byte >> 4) as usize] as char;
                self.next = Some(self.table[(byte & 0x0F) as usize] as char);
                current
            }),
        }
    }

    fn size_hint(&self) -> (usize, Option<usize>) {
        let length = self.len();
        (length, Some(length))
    }
}

impl<'a> iter::ExactSizeIterator for BytesToHexChars<'a> {
    fn len(&self) -> usize {
        let mut length = self.inner.len() * 2;
        if self.next.is_some() {
            length += 1;
        }
        length
    }
}

#[inline]
fn encode_to_iter<T: iter::FromIterator<char>>(table: &'static [u8; 16], source: &[u8]) -> T {
    BytesToHexChars::new(source, table).collect()
}

impl<T: AsRef<[u8]>> ToHex for T {
    fn encode_hex<U: iter::FromIterator<char>>(&self) -> U {
        encode_to_iter(HEX_CHARS_LOWER, self.as_ref())
    }

    fn encode_hex_upper<U: iter::FromIterator<char>>(&self) -> U {
        encode_to_iter(HEX_CHARS_UPPER, self.as_ref())
    }
}
```

If this looks good I'll replace the already existing references to `encode` to ours