### PR TITLE
Update crates without libxml.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,9 +159,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "7.0.0"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
+checksum = "9991eea70ea4f293524138648e41ee89b0b2b12ddef3b255effa43c8056e0e0d"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -170,9 +170,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "4.0.2"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74fa05ad7d803d413eb8380983b092cbbaf9a85f151b871360e7b00cd7060b37"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -186,9 +186,9 @@ checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "cc"
-version = "1.2.18"
+version = "1.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525046617d8376e3db1deffb079e91cef90a89fc3ca5c185bbf8c9ecdd15cd5c"
+checksum = "8691782945451c1c383942c4874dbe63814f61cb57ef773cda2972682b7bb3c0"
 dependencies = [
  "shlex",
 ]
@@ -201,9 +201,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -213,18 +213,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.36"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2df961d8c8a0d08aa9945718ccf584145eee3f3aa06cddbeac12933781102e04"
+checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.36"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "132dbda40fb6753878316a489d5a1242a8ef2f0d9e47ba01c951ea8aa7d013a5"
+checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1153,9 +1153,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/packages/hurl/Cargo.toml
+++ b/packages/hurl/Cargo.toml
@@ -20,9 +20,9 @@ static-openssl = ["curl/static-ssl", "curl-sys/static-ssl"]
 
 [dependencies]
 base64 = "0.22.1"
-brotli = "7.0.0"
-chrono = { version = "0.4.40", default-features = false, features = ["clock"] }
-clap = { version = "4.5.36", features = ["string", "wrap_help"] }
+brotli = "8.0.1"
+chrono = { version = "0.4.41", default-features = false, features = ["clock"] }
+clap = { version = "4.5.37", features = ["string", "wrap_help"] }
 curl = "0.4.47"
 curl-sys = "0.4.80"
 encoding = "0.2.33"
@@ -35,7 +35,7 @@ percent-encoding = "2.3.1"
 regex = "1.11.1"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = { version = "1.0.140", features = ["arbitrary_precision"] }
-sha2 = "0.10.8"
+sha2 = "0.10.9"
 url = "2.5.4"
 xml-rs = { version = "0.8.26" }
 # uuid features: lets you generate random UUIDs and use a faster (but still sufficiently random) RNG
@@ -50,7 +50,7 @@ termion = "4.0.5"
 winres = "0.1.12"
 
 [build-dependencies]
-cc = "1.2.18"
+cc = "1.2.21"
 
 [lints]
 workspace = true

--- a/packages/hurlfmt/Cargo.toml
+++ b/packages/hurlfmt/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.86.0"
 
 [dependencies]
 base64 = "0.22.1"
-clap = { version = "4.5.36", features = ["cargo", "wrap_help"] }
+clap = { version = "4.5.37", features = ["cargo", "wrap_help"] }
 hurl_core = { version = "7.0.0-SNAPSHOT", path = "../hurl_core" }
 regex = "1.11.1"
 

--- a/packages/hurlfmt/src/curl/mod.rs
+++ b/packages/hurlfmt/src/curl/mod.rs
@@ -15,7 +15,7 @@
  * limitations under the License.
  *
  */
-
+use regex;
 use std::fmt;
 
 mod args;


### PR DESCRIPTION
libxml crate 0.3.5 has build issues => see <https://github.com/KWARC/rust-libxml/issues/168>