### PR TITLE
Fix Request retaining `request_spec` after Redirect

### DIFF
--- a/packages/hurl/src/http/client.rs
+++ b/packages/hurl/src/http/client.rs
@@ -131,7 +131,7 @@ impl Client {
                 method: redirect_method,
                 url: redirect_url,
                 headers,
-                ..Default::default()
+                ..request_spec
             };
         }
         Ok(calls)


### PR DESCRIPTION
## Overview

This PR fixes the issue #4073, which causes `hurl` to drop any body within the request after a redirect. This PR adjusts this behavior by constructing the redirected request directly from the previous request instead of using `Default::default()`.