### PR TITLE
Handle option default explictly w/o clap

### DIFF
--- a/bin/spec/options/generate_source.py
+++ b/bin/spec/options/generate_source.py
@@ -57,13 +57,14 @@ def generate_source_option(option: Option) -> str:
         s += f"\n        .short('{option.short}')"
     if option.value is not None:
         s += f'\n        .value_name("{option.value}")'
-    if option.value_default is not None:
-        s += f'\n        .default_value("{option.value_default}")'
     if option.value_parser is not None:
         s += f"\n        .value_parser({option.value_parser})"
         if "-1" in option.value_parser:
             s += "\n        .allow_hyphen_values(true)"
-    s += f'\n        .help("{option.help}")'
+    help = option.help
+    if option.value_default is not None:
+        help += " [default: " + option.value_default + "]"
+    s += f'\n        .help("{help}")'
     if option.help_heading is not None:
         s += f'\n        .help_heading("{option.help_heading}")'
     if option.conflict is not None:

--- a/packages/hurl/src/cli/options/commands.rs
+++ b/packages/hurl/src/cli/options/commands.rs
@@ -84,8 +84,7 @@ pub fn connect_timeout() -> clap::Arg {
     clap::Arg::new("connect_timeout")
         .long("connect-timeout")
         .value_name("SECONDS")
-        .default_value("300")
-        .help("Maximum time allowed for connection")
+        .help("Maximum time allowed for connection [default: 300]")
         .help_heading("HTTP options")
         .num_args(1)
 }
@@ -141,8 +140,7 @@ pub fn delay() -> clap::Arg {
     clap::Arg::new("delay")
         .long("delay")
         .value_name("MILLISECONDS")
-        .default_value("0")
-        .help("Sets delay before each request (aka sleep)")
+        .help("Sets delay before each request (aka sleep) [default: 0]")
         .help_heading("Run options")
         .num_args(1)
 }
@@ -151,9 +149,8 @@ pub fn error_format() -> clap::Arg {
     clap::Arg::new("error_format")
         .long("error-format")
         .value_name("FORMAT")
-        .default_value("short")
         .value_parser(["short", "long"])
-        .help("Control the format of error messages")
+        .help("Control the format of error messages [default: short]")
         .help_heading("Output options")
         .num_args(1)
 }
@@ -345,10 +342,9 @@ pub fn max_redirects() -> clap::Arg {
     clap::Arg::new("max_redirects")
         .long("max-redirs")
         .value_name("NUM")
-        .default_value("50")
         .value_parser(clap::value_parser!(i32).range(-1..))
         .allow_hyphen_values(true)
-        .help("Maximum number of redirects allowed, -1 for unlimited redirects")
+        .help("Maximum number of redirects allowed, -1 for unlimited redirects [default: 50]")
         .help_heading("HTTP options")
         .num_args(1)
 }
@@ -358,8 +354,7 @@ pub fn max_time() -> clap::Arg {
         .long("max-time")
         .short('m')
         .value_name("SECONDS")
-        .default_value("300")
-        .help("Maximum time allowed for the transfer")
+        .help("Maximum time allowed for the transfer [default: 300]")
         .help_heading("HTTP options")
         .num_args(1)
 }
@@ -546,8 +541,7 @@ pub fn retry_interval() -> clap::Arg {
     clap::Arg::new("retry_interval")
         .long("retry-interval")
         .value_name("MILLISECONDS")
-        .default_value("1000")
-        .help("Interval in milliseconds before a retry")
+        .help("Interval in milliseconds before a retry [default: 1000]")
         .help_heading("Run options")
         .num_args(1)
 }

--- a/packages/hurl/src/cli/options/matches.rs
+++ b/packages/hurl/src/cli/options/matches.rs
@@ -100,7 +100,7 @@ pub fn compressed(arg_matches: &ArgMatches) -> bool {
 }
 
 pub fn connect_timeout(arg_matches: &ArgMatches) -> Result<Duration, CliOptionsError> {
-    let s = get::<String>(arg_matches, "connect_timeout").unwrap_or_default();
+    let s = get::<String>(arg_matches, "connect_timeout").unwrap_or("300".to_string());
     get_duration(&s, DurationUnit::Second)
 }
 
@@ -125,15 +125,15 @@ pub fn curl_file(arg_matches: &ArgMatches) -> Option<PathBuf> {
 }
 
 pub fn delay(arg_matches: &ArgMatches) -> Result<Duration, CliOptionsError> {
-    let s = get::<String>(arg_matches, "delay").unwrap_or_default();
+    let s = get::<String>(arg_matches, "delay").unwrap_or("0".to_string());
     get_duration(&s, DurationUnit::MilliSecond)
 }
 
 pub fn error_format(arg_matches: &ArgMatches) -> ErrorFormat {
-    let error_format = get::<String>(arg_matches, "error_format");
-    match error_format.as_deref() {
-        Some("long") => ErrorFormat::Long,
-        Some("short") => ErrorFormat::Short,
+    let error_format = get::<String>(arg_matches, "error_format").unwrap_or("short".to_string());
+    match error_format.as_str() {
+        "long" => ErrorFormat::Long,
+        "short" => ErrorFormat::Short,
         _ => ErrorFormat::Short,
     }
 }
@@ -291,7 +291,7 @@ pub fn max_filesize(arg_matches: &ArgMatches) -> Option<u64> {
 }
 
 pub fn max_redirect(arg_matches: &ArgMatches) -> Count {
-    match get::<i32>(arg_matches, "max_redirects").unwrap() {
+    match get::<i32>(arg_matches, "max_redirects").unwrap_or(50) {
         -1 => Count::Infinite,
         m => Count::Finite(m as usize),
     }
@@ -414,7 +414,7 @@ pub fn retry(arg_matches: &ArgMatches) -> Option<Count> {
 }
 
 pub fn retry_interval(arg_matches: &ArgMatches) -> Result<Duration, CliOptionsError> {
-    let s = get::<String>(arg_matches, "retry_interval").unwrap_or_default();
+    let s = get::<String>(arg_matches, "retry_interval").unwrap_or("1000".to_string());
     get_duration(&s, DurationUnit::MilliSecond)
 }
 
@@ -453,7 +453,7 @@ pub fn test(arg_matches: &ArgMatches) -> bool {
 }
 
 pub fn timeout(arg_matches: &ArgMatches) -> Result<Duration, CliOptionsError> {
-    let s = get::<String>(arg_matches, "max_time").unwrap_or_default();
+    let s = get::<String>(arg_matches, "max_time").unwrap_or("300".to_string());
     get_duration(&s, DurationUnit::Second)
 }
 

--- a/packages/hurlfmt/src/cli/options/commands.rs
+++ b/packages/hurlfmt/src/cli/options/commands.rs
@@ -56,8 +56,7 @@ pub fn input_format() -> clap::Arg {
     clap::Arg::new("input_format")
         .long("in")
         .value_name("FORMAT")
-        .default_value("hurl")
-        .help("Specify input format: hurl or curl")
+        .help("Specify input format: hurl or curl [default: hurl]")
         .num_args(1)
 }
 
@@ -82,8 +81,7 @@ pub fn output_format() -> clap::Arg {
     clap::Arg::new("output_format")
         .long("out")
         .value_name("FORMAT")
-        .default_value("hurl")
-        .help("Specify output format: hurl, json or html")
+        .help("Specify output format: hurl, json or html [default: hurl]")
         .conflicts_with("check")
         .num_args(1)
 }

--- a/packages/hurlfmt/src/cli/options/matches.rs
+++ b/packages/hurlfmt/src/cli/options/matches.rs
@@ -40,7 +40,10 @@ pub fn color(arg_matches: &ArgMatches) -> bool {
 }
 
 pub fn input_format(arg_matches: &ArgMatches) -> Result<InputFormat, OptionsError> {
-    match get_string(arg_matches, "input_format").unwrap().as_str() {
+    match get_string(arg_matches, "input_format")
+        .unwrap_or("hurl".to_string())
+        .as_str()
+    {
         "hurl" => Ok(InputFormat::Hurl),
         "curl" => Ok(InputFormat::Curl),
         v => Err(OptionsError::Error(format!("Invalid input format {v}"))),
@@ -48,7 +51,10 @@ pub fn input_format(arg_matches: &ArgMatches) -> Result<InputFormat, OptionsErro
 }
 
 pub fn output_format(arg_matches: &ArgMatches) -> Result<OutputFormat, OptionsError> {
-    match get_string(arg_matches, "output_format").unwrap().as_str() {
+    match get_string(arg_matches, "output_format")
+        .unwrap_or("hurl".to_string())
+        .as_str()
+    {
         "hurl" => Ok(OutputFormat::Hurl),
         "json" => Ok(OutputFormat::Json),
         "html" => Ok(OutputFormat::Html),
@@ -58,7 +64,7 @@ pub fn output_format(arg_matches: &ArgMatches) -> Result<OutputFormat, OptionsEr
 
 pub fn in_place(arg_matches: &ArgMatches) -> Result<bool, OptionsError> {
     if has_flag(arg_matches, "in_place") {
-        if get_string(arg_matches, "input_format") != Some("hurl".to_string()) {
+        if input_format(arg_matches)? != InputFormat::Hurl {
             Err(OptionsError::Error(
                 "You can use --in-place only hurl format!".to_string(),
             ))


### PR DESCRIPTION
This is the first step for refactoring option defaults.
The final objective is to be able to override defaults options from a config file.
