### PR TITLE
Add each predicate

### DIFF
--- a/packages/hurl_core/src/ast/section.rs
+++ b/packages/hurl_core/src/ast/section.rs
@@ -402,6 +402,10 @@ pub enum PredicateFuncValue {
         space0: Whitespace,
         value: PredicateValue,
     },
+    Each {
+        space0: Whitespace,
+        predicate: Box<Predicate>,
+    },
     IsInteger,
     IsFloat,
     IsBoolean,
@@ -443,6 +447,7 @@ impl PredicateFuncValue {
             PredicateFuncValue::IsNumber => "isNumber",
             PredicateFuncValue::IsIpv4 => "isIpv4",
             PredicateFuncValue::IsIpv6 => "isIpv6",
+            PredicateFuncValue::Each { .. } => "each",
         }
     }
 }

--- a/packages/hurl_core/src/ast/visit.rs
+++ b/packages/hurl_core/src/ast/visit.rs
@@ -664,6 +664,10 @@ pub fn walk_predicate<V: Visitor>(visitor: &mut V, pred: &Predicate) {
             visitor.visit_whitespace(space0);
             visitor.visit_predicate_value(value);
         }
+        PredicateFuncValue::Each { space0, predicate } => {
+            visitor.visit_whitespace(space0);
+            visitor.visit_predicate(predicate);
+        }
         PredicateFuncValue::IsInteger
         | PredicateFuncValue::IsFloat
         | PredicateFuncValue::IsBoolean

--- a/packages/hurl_core/src/parser/predicate.rs
+++ b/packages/hurl_core/src/parser/predicate.rs
@@ -94,6 +94,7 @@ fn predicate_func_value(reader: &mut Reader) -> ParseResult<PredicateFuncValue> 
             is_number_predicate,
             is_ipv4_predicate,
             is_ipv6_predicate,
+            each_predicate,
         ],
         reader,
     ) {
@@ -316,6 +317,16 @@ fn is_ipv4_predicate(reader: &mut Reader) -> ParseResult<PredicateFuncValue> {
 fn is_ipv6_predicate(reader: &mut Reader) -> ParseResult<PredicateFuncValue> {
     try_literal("isIpv6", reader)?;
     Ok(PredicateFuncValue::IsIpv6)
+}
+
+fn each_predicate(reader: &mut Reader) -> ParseResult<PredicateFuncValue> {
+    try_literal("each", reader)?;
+    let space0 = one_or_more_spaces(reader)?;
+    let pred = predicate(reader)?;
+    Ok(PredicateFuncValue::Each {
+        space0,
+        predicate: Box::new(pred),
+    })
 }
 
 #[cfg(test)]

--- a/packages/hurlfmt/src/format/json.rs
+++ b/packages/hurlfmt/src/format/json.rs
@@ -557,6 +557,9 @@ impl ToJson for Predicate {
             PredicateFuncValue::Match { value, .. } => {
                 add_predicate_value(&mut attributes, value);
             }
+            PredicateFuncValue::Each { predicate, .. } => {
+                attributes.push(("predicate".to_string(), predicate.to_json()));
+            }
             PredicateFuncValue::IsInteger
             | PredicateFuncValue::IsFloat
             | PredicateFuncValue::IsBoolean

--- a/packages/hurlfmt/src/linter/rules.rs
+++ b/packages/hurlfmt/src/linter/rules.rs
@@ -356,6 +356,10 @@ fn lint_predicate_func_value(predicate_func_value: &PredicateFuncValue) -> Predi
             space0: one_whitespace(),
             value: lint_predicate_value(value),
         },
+        PredicateFuncValue::Each { predicate, .. } => PredicateFuncValue::Each {
+            space0: one_whitespace(),
+            predicate: Box::new(lint_predicate(predicate)),
+        },
         PredicateFuncValue::IsInteger => PredicateFuncValue::IsInteger,
         PredicateFuncValue::IsFloat => PredicateFuncValue::IsFloat,
         PredicateFuncValue::IsBoolean => PredicateFuncValue::IsBoolean,


### PR DESCRIPTION
# Description
- Add `each` predicate which takes another predicate as input and checks each element of a collection 

# Issue
#2212 

# Discussion
Hey @jcamiel, I needed you advice on a few things how to best go about making this predicate
1. As `each` can take another predicate, it should be able to take itself as an input too right? For example, the below should be a valid line in a `.hurl` file
```
// ...  
jsonpath "$.list" each each isNumber
{
    "list": [ [1], [2], [2] ]
}
```
2. What would be the best to show the error? We would have to consider nesting as it should be clear which element failed the predicate right? Do we show the whole list or just the failed element? This is how it shows right now (not ideal)
```
error: Assert failure
  --> filter.hurl:14:0
   |
   | GET http://localhost:8000/filter
   | ...
14 | jsonpath "$.list" each contains "a"
   |   actual:   list <[1,2,3]>, element at index 0 fails
   |   expected: each element contains string <a>
   |

error: Assert failure
  --> filter.hurl:15:0
   |
   | GET http://localhost:8000/filter
   | ...
15 | jsonpath "$.listA" each each == 1
   |   actual:   list <[[1,1,1],[4,5,6]]>, element at index 1 fails
   |   expected: each element each element integer <1>
   |

error: Assert failure
  --> filter.hurl:38:0
   |
   | GET http://localhost:8000/filter
   | ...
38 | jsonpath "$.ips" split ", " each not contains "."
   |   actual:   list <[192.168.2.1,10.0.0.20,10.0.0.10]>, element at index 0 fails
   |   expected: each element not contains string <.>
   |
```
3. Do we need to support `not` for `each` as well? Assuming `any` is added too, then isn't `not each` the same as `any`?