### PR TITLE
Align parser on grammar for redacted captures.

### DIFF
--- a/packages/hurl/src/runner/capture.rs
+++ b/packages/hurl/src/runner/capture.rs
@@ -107,7 +107,7 @@ pub mod tests {
             // xpath count(//user)
             query: query::tests::xpath_count_user_query(),
             filters: vec![],
-            space3: whitespace.clone(),
+            space3: None,
             redacted: false,
             line_terminator0: LineTerminator {
                 space0: whitespace.clone(),
@@ -140,7 +140,7 @@ pub mod tests {
             // xpath count(//user)
             query: query::tests::jsonpath_duration(),
             filters: vec![],
-            space3: whitespace.clone(),
+            space3: None,
             redacted: false,
             line_terminator0: LineTerminator {
                 space0: whitespace.clone(),
@@ -174,7 +174,7 @@ pub mod tests {
             space2: whitespace.clone(),
 
             query: query::tests::xpath_invalid_query(),
-            space3: whitespace.clone(),
+            space3: None,
             redacted: false,
             line_terminator0: LineTerminator {
                 space0: whitespace.clone(),
@@ -232,7 +232,7 @@ pub mod tests {
                 },
             },
             filters: vec![],
-            space3: whitespace.clone(),
+            space3: None,
             redacted: false,
             line_terminator0: LineTerminator {
                 space0: whitespace.clone(),

--- a/packages/hurl_core/src/ast/section.rs
+++ b/packages/hurl_core/src/ast/section.rs
@@ -113,7 +113,7 @@ pub struct Capture {
     pub space2: Whitespace,
     pub query: Query,
     pub filters: Vec<(Whitespace, Filter)>,
-    pub space3: Whitespace,
+    pub space3: Option<Whitespace>,
     pub redacted: bool,
     pub line_terminator0: LineTerminator,
 }

--- a/packages/hurl_core/src/ast/visit.rs
+++ b/packages/hurl_core/src/ast/visit.rs
@@ -283,7 +283,9 @@ pub fn walk_capture<V: Visitor>(visitor: &mut V, capture: &Capture) {
         visitor.visit_whitespace(space);
         visitor.visit_filter(filter);
     }
-    visitor.visit_whitespace(&capture.space3);
+    if let Some(ws) = &capture.space3 {
+        visitor.visit_whitespace(ws);
+    }
     if capture.redacted {
         // The next node should have been literal to be more correct
         // we visit a string instead to be comptaible with <= 6.1.1 HTML export

--- a/packages/hurl_core/src/parser/sections.rs
+++ b/packages/hurl_core/src/parser/sections.rs
@@ -270,8 +270,18 @@ fn capture(reader: &mut Reader) -> ParseResult<Capture> {
     let space2 = zero_or_more_spaces(reader)?;
     let q = query(reader)?;
     let filters = filters(reader)?;
+
+    let save = reader.cursor();
     let space3 = zero_or_more_spaces(reader)?;
     let redacted = try_literal("redact", reader).is_ok();
+    let space3 = if redacted {
+        Some(space3)
+    } else {
+        // When we don't have a `redacted` keyword, we rewind the reader so the whitespaces will
+        // be consumed by line terminator.
+        reader.seek(save);
+        None
+    };
     let line_terminator0 = line_terminator(reader)?;
     Ok(Capture {
         line_terminators,
@@ -593,40 +603,143 @@ mod tests {
         let capture0 = capture(&mut reader).unwrap();
 
         assert_eq!(
-            capture0.name,
-            Template::new(
-                None,
-                vec![TemplateElement::String {
-                    value: "url".to_string(),
-                    source: "url".to_source(),
-                }],
-                SourceInfo::new(Pos::new(1, 1), Pos::new(1, 4))
-            ),
-        );
-        assert_eq!(
-            capture0.query,
-            Query {
-                source_info: SourceInfo::new(Pos::new(1, 6), Pos::new(1, 23)),
-                value: QueryValue::Header {
-                    space0: Whitespace {
-                        value: String::from(" "),
-                        source_info: SourceInfo::new(Pos::new(1, 12), Pos::new(1, 13)),
+            capture0,
+            Capture {
+                line_terminators: vec![],
+                space0: Whitespace {
+                    value: String::new(),
+                    source_info: SourceInfo {
+                        start: Pos::new(1, 1),
+                        end: Pos::new(1, 1),
                     },
-                    name: Template::new(
-                        Some('"'),
-                        vec![TemplateElement::String {
-                            value: "Location".to_string(),
-                            source: "Location".to_source(),
-                        }],
-                        SourceInfo::new(Pos::new(1, 13), Pos::new(1, 23))
-                    )
-                }
+                },
+                name: Template::new(
+                    None,
+                    vec![TemplateElement::String {
+                        value: "url".to_string(),
+                        source: "url".to_source(),
+                    }],
+                    SourceInfo::new(Pos::new(1, 1), Pos::new(1, 4))
+                ),
+                space1: Whitespace {
+                    value: String::new(),
+                    source_info: SourceInfo {
+                        start: Pos::new(1, 4),
+                        end: Pos::new(1, 4),
+                    }
+                },
+                space2: Whitespace {
+                    value: " ".to_string(),
+                    source_info: SourceInfo {
+                        start: Pos::new(1, 5),
+                        end: Pos::new(1, 6),
+                    }
+                },
+                query: Query {
+                    source_info: SourceInfo::new(Pos::new(1, 6), Pos::new(1, 23)),
+                    value: QueryValue::Header {
+                        space0: Whitespace {
+                            value: String::from(" "),
+                            source_info: SourceInfo::new(Pos::new(1, 12), Pos::new(1, 13)),
+                        },
+                        name: Template::new(
+                            Some('"'),
+                            vec![TemplateElement::String {
+                                value: "Location".to_string(),
+                                source: "Location".to_source(),
+                            }],
+                            SourceInfo::new(Pos::new(1, 13), Pos::new(1, 23))
+                        )
+                    }
+                },
+                filters: vec![],
+                space3: None,
+                redacted: false,
+                line_terminator0: LineTerminator {
+                    space0: Whitespace {
+                        value: String::new(),
+                        source_info: SourceInfo::new(Pos::new(1, 23), Pos::new(1, 23)),
+                    },
+                    comment: None,
+                    newline: Whitespace {
+                        value: String::new(),
+                        source_info: SourceInfo::new(Pos::new(1, 23), Pos::new(1, 23)),
+                    },
+                },
             }
         );
 
-        let mut reader = Reader::new("url: header \"Token\" redact");
+        let mut reader = Reader::new("url: header \"Token\"    redact");
         let capture0 = capture(&mut reader).unwrap();
-        assert!(capture0.redacted);
+        assert_eq!(
+            capture0,
+            Capture {
+                line_terminators: vec![],
+                space0: Whitespace {
+                    value: String::new(),
+                    source_info: SourceInfo {
+                        start: Pos::new(1, 1),
+                        end: Pos::new(1, 1),
+                    },
+                },
+                name: Template::new(
+                    None,
+                    vec![TemplateElement::String {
+                        value: "url".to_string(),
+                        source: "url".to_source(),
+                    }],
+                    SourceInfo::new(Pos::new(1, 1), Pos::new(1, 4))
+                ),
+                space1: Whitespace {
+                    value: String::new(),
+                    source_info: SourceInfo {
+                        start: Pos::new(1, 4),
+                        end: Pos::new(1, 4),
+                    }
+                },
+                space2: Whitespace {
+                    value: " ".to_string(),
+                    source_info: SourceInfo {
+                        start: Pos::new(1, 5),
+                        end: Pos::new(1, 6),
+                    }
+                },
+                query: Query {
+                    source_info: SourceInfo::new(Pos::new(1, 6), Pos::new(1, 20)),
+                    value: QueryValue::Header {
+                        space0: Whitespace {
+                            value: String::from(" "),
+                            source_info: SourceInfo::new(Pos::new(1, 12), Pos::new(1, 13)),
+                        },
+                        name: Template::new(
+                            Some('"'),
+                            vec![TemplateElement::String {
+                                value: "Token".to_string(),
+                                source: "Token".to_source(),
+                            }],
+                            SourceInfo::new(Pos::new(1, 13), Pos::new(1, 20))
+                        )
+                    }
+                },
+                filters: vec![],
+                space3: Some(Whitespace {
+                    value: "    ".to_string(),
+                    source_info: SourceInfo::new(Pos::new(1, 20), Pos::new(1, 24)),
+                }),
+                redacted: true,
+                line_terminator0: LineTerminator {
+                    space0: Whitespace {
+                        value: String::new(),
+                        source_info: SourceInfo::new(Pos::new(1, 30), Pos::new(1, 30)),
+                    },
+                    comment: None,
+                    newline: Whitespace {
+                        value: String::new(),
+                        source_info: SourceInfo::new(Pos::new(1, 30), Pos::new(1, 30)),
+                    },
+                },
+            }
+        );
     }
 
     #[test]
@@ -699,8 +812,8 @@ mod tests {
         let mut reader = Reader::new("name: jsonpath \"$.name\"          # name");
         let capture0 = capture(&mut reader).unwrap();
         assert!(capture0.filters.is_empty());
-        assert_eq!(capture0.space3.as_str(), "          ");
-        assert_eq!(capture0.line_terminator0.space0.as_str(), "");
+        assert!(capture0.space3.is_none());
+        assert_eq!(capture0.line_terminator0.space0.as_str(), "          ");
     }
 
     #[test]

--- a/packages/hurlfmt/src/format/json.rs
+++ b/packages/hurlfmt/src/format/json.rs
@@ -897,7 +897,7 @@ pub mod tests {
             space2: whitespace(),
             query: header_query(),
             filters: vec![],
-            space3: whitespace(),
+            space3: None,
             redacted: false,
             line_terminator0: line_terminator(),
         }

--- a/packages/hurlfmt/src/linter/rules.rs
+++ b/packages/hurlfmt/src/linter/rules.rs
@@ -176,9 +176,9 @@ fn lint_capture(capture: &Capture) -> Capture {
         .map(|(_, f)| (one_whitespace(), lint_filter(f)))
         .collect();
     let space3 = if capture.redacted {
-        one_whitespace()
+        Some(one_whitespace())
     } else {
-        capture.space3.clone()
+        None
     };
     Capture {
         line_terminators: capture.line_terminators.clone(),


### PR DESCRIPTION
@fabricereix happy to have your feedback on i: curently, the captre grammar is

```
capture:
  lt*
  key-string ":" query (sp filter)* (sp "redact")? lt
```

Our AST is:

```rust
#[derive(Clone, Debug, PartialEq, Eq)]
pub struct Capture {
    pub line_terminators: Vec<LineTerminator>,
    pub space0: Whitespace,
    pub name: Template,
    pub space1: Whitespace,
    pub space2: Whitespace,
    pub query: Query,
    pub filters: Vec<(Whitespace, Filter)>,
    pub space3: Whitespace,
    pub redacted: bool,
    pub line_terminator0: LineTerminator,
}
```

Actually, there is a misalignment with `space3`: given the grammar, when there is no `redact` keyword, `space3` should always be empty. Today, `space3` is always consuming space instead of line terminator.

With this capture:

```
toto: header "tata"      # comment
```

We should not have space3, only space consumed by the line terminator.

I'm not sure what is the best parsing solution, what do you think?



