### PR TITLE
Add support for UUIDv7 function

### DIFF
--- a/packages/hurl/Cargo.toml
+++ b/packages/hurl/Cargo.toml
@@ -39,7 +39,7 @@ sha2 = "0.10.9"
 url = "2.5.4"
 xml-rs = { version = "0.8.27" }
 # uuid features: lets you generate random UUIDs and use a faster (but still sufficiently random) RNG
-uuid = { version = "1.17.0", features = ["v4" , "fast-rng"] }
+uuid = { version = "1.17.0", features = ["v4", "v7", "fast-rng"] }
 similar = "2.7.0"
 terminal_size = "0.4.2"
 

--- a/packages/hurl/src/runner/function.rs
+++ b/packages/hurl/src/runner/function.rs
@@ -33,5 +33,9 @@ pub fn eval(function: &Function) -> Result<Value, RunnerError> {
             let uuid = Uuid::new_v4();
             Ok(Value::String(uuid.to_string()))
         }
+        Function::NewUuidV7 => {
+            let uuid = Uuid::now_v7();
+            Ok(Value::String(uuid.to_string()))
+        }
     }
 }

--- a/packages/hurl_core/src/ast/primitive.rs
+++ b/packages/hurl_core/src/ast/primitive.rs
@@ -571,6 +571,7 @@ impl fmt::Display for Variable {
 pub enum Function {
     NewDate,
     NewUuid,
+    NewUuidV7,
 }
 
 impl fmt::Display for Function {
@@ -578,6 +579,7 @@ impl fmt::Display for Function {
         match self {
             Function::NewDate => write!(f, "newDate"),
             Function::NewUuid => write!(f, "newUuid"),
+            Function::NewUuidV7 => write!(f, "newUuidV7"),
         }
     }
 }

--- a/packages/hurl_core/src/parser/function.rs
+++ b/packages/hurl_core/src/parser/function.rs
@@ -27,6 +27,7 @@ pub fn parse(reader: &mut Reader) -> ParseResult<Function> {
     match function_name.as_str() {
         "newDate" => Ok(Function::NewDate),
         "newUuid" => Ok(Function::NewUuid),
+        "newUuidV7" => Ok(Function::NewUuidV7),
         _ => Err(ParseError::new(
             start.pos,
             true,
@@ -46,6 +47,12 @@ mod tests {
     fn test_exist() {
         let mut reader = Reader::new("newUuid");
         assert_eq!(parse(&mut reader).unwrap(), Function::NewUuid);
+    }
+
+    #[test]
+    fn test_new_uuid_v7() {
+        let mut reader = Reader::new("newUuidV7");
+        assert_eq!(parse(&mut reader).unwrap(), Function::NewUuidV7);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds `newUuidV7()` function for generating RFC 9562 UUIDv7 identifiers
- UUIDv7 provides time-ordered UUIDs with better database performance than UUIDv4

## Changes
- Add `NewUuidV7` to Function enum and parser
- Implement UUIDv7 generation using `Uuid::now_v7()`
- Enable uuid crate "v7" feature
- Add test coverage

## Test plan
- [x] All existing tests pass
- [x] New parser test for `newUuidV7` function
- [x] Function generates valid UUIDv7 identifiers