### PR TITLE
Parse ` --user`, `--negotiate`, and `--ntlm` options in hurlfmt

### DIFF
--- a/integration/hurlfmt/tests_ok/import_curl.in
+++ b/integration/hurlfmt/tests_ok/import_curl.in
@@ -8,5 +8,6 @@ curl --retry 4 'http://localhost:8000/retry/until-200'
 curl -k https://localhost:8001/hello
 curl -v https://localhost:8001/hello
 curl --verbose https://localhost:8001/hello
+curl --ntlm https://localhost:8001/hello
 curl --header 'Empty-Header;' http://localhost:8000/hello
 

--- a/integration/hurlfmt/tests_ok/import_curl.in
+++ b/integration/hurlfmt/tests_ok/import_curl.in
@@ -9,5 +9,6 @@ curl -k https://localhost:8001/hello
 curl -v https://localhost:8001/hello
 curl --verbose https://localhost:8001/hello
 curl --ntlm https://localhost:8001/hello
+curl --negotiate https://localhost:8001/hello
 curl --header 'Empty-Header;' http://localhost:8000/hello
 

--- a/integration/hurlfmt/tests_ok/import_curl.in
+++ b/integration/hurlfmt/tests_ok/import_curl.in
@@ -5,6 +5,8 @@ curl --header 'Content-Type: application/json' --data $'{\n    "name": "Bob",\n 
 curl --header 'Content-Type:' --data '@tests_ok/data.bin' 'http://localhost:8000/post-file'
 curl --location 'http://localhost:8000/redirect-absolute'
 curl --retry 4 'http://localhost:8000/retry/until-200'
+curl --user "user:pass" https://localhost:8001/hello
+curl -u "user:pass" https://localhost:8001/hello
 curl -k https://localhost:8001/hello
 curl -v https://localhost:8001/hello
 curl --verbose https://localhost:8001/hello

--- a/integration/hurlfmt/tests_ok/import_curl.out
+++ b/integration/hurlfmt/tests_ok/import_curl.out
@@ -41,6 +41,14 @@ status < 500
 
 GET https://localhost:8001/hello
 [Options]
+user: "user:pass"
+
+GET https://localhost:8001/hello
+[Options]
+user: "user:pass"
+
+GET https://localhost:8001/hello
+[Options]
 insecure: true
 
 GET https://localhost:8001/hello

--- a/integration/hurlfmt/tests_ok/import_curl.out
+++ b/integration/hurlfmt/tests_ok/import_curl.out
@@ -51,6 +51,10 @@ GET https://localhost:8001/hello
 [Options]
 verbose: true
 
+GET https://localhost:8001/hello
+[Options]
+ntlm: true
+
 GET http://localhost:8000/hello
 Empty-Header:
 

--- a/integration/hurlfmt/tests_ok/import_curl.out
+++ b/integration/hurlfmt/tests_ok/import_curl.out
@@ -55,6 +55,10 @@ GET https://localhost:8001/hello
 [Options]
 ntlm: true
 
+GET https://localhost:8001/hello
+[Options]
+negotiate: true
+
 GET http://localhost:8000/hello
 Empty-Header:
 

--- a/packages/hurl/src/runner/options.rs
+++ b/packages/hurl/src/runner/options.rs
@@ -273,6 +273,9 @@ pub fn get_entry_options(
             OptionKind::Ntlm(value) => {
                 eval_boolean_option(value, variables)?;
             }
+            OptionKind::Negotiate(value) => {
+                eval_boolean_option(value, variables)?;
+            }
         }
         logger.debug(&option.kind.to_string());
     }

--- a/packages/hurl/src/runner/options.rs
+++ b/packages/hurl/src/runner/options.rs
@@ -270,6 +270,9 @@ pub fn get_entry_options(
             OptionKind::VeryVerbose(value) => {
                 eval_boolean_option(value, variables)?;
             }
+            OptionKind::Ntlm(value) => {
+                eval_boolean_option(value, variables)?;
+            }
         }
         logger.debug(&option.kind.to_string());
     }

--- a/packages/hurl_core/src/ast/option.rs
+++ b/packages/hurl_core/src/ast/option.rs
@@ -72,6 +72,7 @@ pub enum OptionKind {
     Variable(VariableDefinition),
     Verbose(BooleanOption),
     VeryVerbose(BooleanOption),
+    Ntlm(BooleanOption),
 }
 
 impl OptionKind {
@@ -116,6 +117,7 @@ impl OptionKind {
             OptionKind::Variable(_) => "variable",
             OptionKind::Verbose(_) => "verbose",
             OptionKind::VeryVerbose(_) => "very-verbose",
+            OptionKind::Ntlm(_) => "ntlm",
         }
     }
 }
@@ -161,6 +163,7 @@ impl fmt::Display for OptionKind {
             OptionKind::Variable(value) => value.to_string(),
             OptionKind::Verbose(value) => value.to_string(),
             OptionKind::VeryVerbose(value) => value.to_string(),
+            OptionKind::Ntlm(value) => value.to_string(),
         };
         write!(f, "{}: {}", self.identifier(), value)
     }

--- a/packages/hurl_core/src/ast/option.rs
+++ b/packages/hurl_core/src/ast/option.rs
@@ -73,6 +73,7 @@ pub enum OptionKind {
     Verbose(BooleanOption),
     VeryVerbose(BooleanOption),
     Ntlm(BooleanOption),
+    Negotiate(BooleanOption),
 }
 
 impl OptionKind {
@@ -118,6 +119,7 @@ impl OptionKind {
             OptionKind::Verbose(_) => "verbose",
             OptionKind::VeryVerbose(_) => "very-verbose",
             OptionKind::Ntlm(_) => "ntlm",
+            OptionKind::Negotiate(_) => "negotiate",
         }
     }
 }
@@ -164,6 +166,7 @@ impl fmt::Display for OptionKind {
             OptionKind::Verbose(value) => value.to_string(),
             OptionKind::VeryVerbose(value) => value.to_string(),
             OptionKind::Ntlm(value) => value.to_string(),
+            OptionKind::Negotiate(value) => value.to_string(),
         };
         write!(f, "{}: {}", self.identifier(), value)
     }

--- a/packages/hurl_core/src/ast/visit.rs
+++ b/packages/hurl_core/src/ast/visit.rs
@@ -394,6 +394,7 @@ pub fn walk_entry_option<V: Visitor>(visitor: &mut V, option: &EntryOption) {
         OptionKind::Verbose(value) => visitor.visit_bool_option(value),
         OptionKind::VeryVerbose(value) => visitor.visit_bool_option(value),
         OptionKind::Ntlm(value) => visitor.visit_bool_option(value),
+        OptionKind::Negotiate(value) => visitor.visit_bool_option(value),
     };
     visitor.visit_lt(&option.line_terminator0);
 }

--- a/packages/hurl_core/src/ast/visit.rs
+++ b/packages/hurl_core/src/ast/visit.rs
@@ -393,6 +393,7 @@ pub fn walk_entry_option<V: Visitor>(visitor: &mut V, option: &EntryOption) {
         OptionKind::Variable(value) => visitor.visit_variable_def(value),
         OptionKind::Verbose(value) => visitor.visit_bool_option(value),
         OptionKind::VeryVerbose(value) => visitor.visit_bool_option(value),
+        OptionKind::Ntlm(value) => visitor.visit_bool_option(value),
     };
     visitor.visit_lt(&option.line_terminator0);
 }

--- a/packages/hurl_core/src/parser/option.rs
+++ b/packages/hurl_core/src/parser/option.rs
@@ -85,6 +85,7 @@ pub fn parse(reader: &mut Reader) -> ParseResult<EntryOption> {
         "verbose" => option_verbose(reader)?,
         "very-verbose" => option_very_verbose(reader)?,
         "ntlm" => option_ntlm(reader)?,
+        "negotiate" => option_negotiate(reader)?,
         _ => {
             return Err(ParseError::new(
                 start.pos,
@@ -298,6 +299,11 @@ fn option_very_verbose(reader: &mut Reader) -> ParseResult<OptionKind> {
 fn option_ntlm(reader: &mut Reader) -> ParseResult<OptionKind> {
     let value = non_recover(boolean_option, reader)?;
     Ok(OptionKind::Ntlm(value))
+}
+
+fn option_negotiate(reader: &mut Reader) -> ParseResult<OptionKind> {
+    let value = non_recover(boolean_option, reader)?;
+    Ok(OptionKind::Negotiate(value))
 }
 
 fn count(reader: &mut Reader) -> ParseResult<Count> {

--- a/packages/hurl_core/src/parser/option.rs
+++ b/packages/hurl_core/src/parser/option.rs
@@ -84,6 +84,7 @@ pub fn parse(reader: &mut Reader) -> ParseResult<EntryOption> {
         "variable" => option_variable(reader)?,
         "verbose" => option_verbose(reader)?,
         "very-verbose" => option_very_verbose(reader)?,
+        "ntlm" => option_ntlm(reader)?,
         _ => {
             return Err(ParseError::new(
                 start.pos,
@@ -292,6 +293,11 @@ fn option_verbose(reader: &mut Reader) -> ParseResult<OptionKind> {
 fn option_very_verbose(reader: &mut Reader) -> ParseResult<OptionKind> {
     let value = non_recover(boolean_option, reader)?;
     Ok(OptionKind::VeryVerbose(value))
+}
+
+fn option_ntlm(reader: &mut Reader) -> ParseResult<OptionKind> {
+    let value = non_recover(boolean_option, reader)?;
+    Ok(OptionKind::Ntlm(value))
 }
 
 fn count(reader: &mut Reader) -> ParseResult<Count> {

--- a/packages/hurlfmt/src/curl/commands.rs
+++ b/packages/hurlfmt/src/curl/commands.rs
@@ -140,3 +140,7 @@ pub fn verbose() -> clap::Arg {
         .short('v')
         .num_args(0)
 }
+
+pub fn ntlm() -> clap::Arg {
+    clap::Arg::new("ntlm").long("ntlm").num_args(0)
+}

--- a/packages/hurlfmt/src/curl/commands.rs
+++ b/packages/hurlfmt/src/curl/commands.rs
@@ -144,3 +144,7 @@ pub fn verbose() -> clap::Arg {
 pub fn ntlm() -> clap::Arg {
     clap::Arg::new("ntlm").long("ntlm").num_args(0)
 }
+
+pub fn negotiate() -> clap::Arg {
+    clap::Arg::new("negotiate").long("negotiate").num_args(0)
+}

--- a/packages/hurlfmt/src/curl/commands.rs
+++ b/packages/hurlfmt/src/curl/commands.rs
@@ -148,3 +148,7 @@ pub fn ntlm() -> clap::Arg {
 pub fn negotiate() -> clap::Arg {
     clap::Arg::new("negotiate").long("negotiate").num_args(0)
 }
+
+pub fn user() -> clap::Arg {
+    clap::Arg::new("user").long("user").short('u').num_args(1)
+}

--- a/packages/hurlfmt/src/curl/matches.rs
+++ b/packages/hurlfmt/src/curl/matches.rs
@@ -95,6 +95,9 @@ pub fn options(arg_matches: &ArgMatches) -> Vec<HurlOption> {
     if has_flag(arg_matches, "verbose") {
         options.push(HurlOption::new("verbose", "true"));
     }
+    if has_flag(arg_matches, "ntlm") {
+        options.push(HurlOption::new("ntlm", "true"));
+    }
     options
 }
 

--- a/packages/hurlfmt/src/curl/matches.rs
+++ b/packages/hurlfmt/src/curl/matches.rs
@@ -101,6 +101,10 @@ pub fn options(arg_matches: &ArgMatches) -> Vec<HurlOption> {
     if has_flag(arg_matches, "negotiate") {
         options.push(HurlOption::new("negotiate", "true"));
     }
+    if let Some(value) = get::<String>(arg_matches, "user") {
+        options.push(HurlOption::new("user", value.to_string().as_str()));
+    }
+
     options
 }
 

--- a/packages/hurlfmt/src/curl/matches.rs
+++ b/packages/hurlfmt/src/curl/matches.rs
@@ -98,6 +98,9 @@ pub fn options(arg_matches: &ArgMatches) -> Vec<HurlOption> {
     if has_flag(arg_matches, "ntlm") {
         options.push(HurlOption::new("ntlm", "true"));
     }
+    if has_flag(arg_matches, "negotiate") {
+        options.push(HurlOption::new("negotiate", "true"));
+    }
     options
 }
 

--- a/packages/hurlfmt/src/curl/mod.rs
+++ b/packages/hurlfmt/src/curl/mod.rs
@@ -76,7 +76,8 @@ fn parse_line(s: &str) -> Result<String, String> {
         .arg(commands::url())
         .arg(commands::url_param())
         .arg(commands::ntlm())
-        .arg(commands::negotiate());
+        .arg(commands::negotiate())
+        .arg(commands::user());
 
     let params = args::split(s)?;
     let arg_matches = match command.try_get_matches_from_mut(params) {
@@ -414,7 +415,7 @@ verbose: true
 ntlm: true
 "#;
         assert_eq!(
-            parse_line(format!("curl --ntlm http://localhost:8000/hello").as_str()).unwrap(),
+            parse_line("curl --ntlm http://localhost:8000/hello").unwrap(),
             hurl_str
         );
     }
@@ -426,8 +427,21 @@ ntlm: true
 negotiate: true
 "#;
         assert_eq!(
-            parse_line(format!("curl --negotiate http://localhost:8000/hello").as_str()).unwrap(),
+            parse_line("curl --negotiate http://localhost:8000/hello").unwrap(),
             hurl_str
         );
+    }
+    #[test]
+    fn test_user_option() {
+        let user = "test_user:test_pass";
+        let hurl_str = format!("GET http://localhost:8000/hello\n[Options]\nuser: {user}\n");
+
+        let flags = vec!["-u", "--user"];
+        for flag in flags {
+            assert_eq!(
+                parse_line(&format!("curl {flag} '{user}' http://localhost:8000/hello")).unwrap(),
+                hurl_str
+            );
+        }
     }
 }

--- a/packages/hurlfmt/src/curl/mod.rs
+++ b/packages/hurlfmt/src/curl/mod.rs
@@ -75,7 +75,8 @@ fn parse_line(s: &str) -> Result<String, String> {
         .arg(commands::retry())
         .arg(commands::url())
         .arg(commands::url_param())
-        .arg(commands::ntlm());
+        .arg(commands::ntlm())
+        .arg(commands::negotiate());
 
     let params = args::split(s)?;
     let arg_matches = match command.try_get_matches_from_mut(params) {
@@ -414,6 +415,18 @@ ntlm: true
 "#;
         assert_eq!(
             parse_line(format!("curl --ntlm http://localhost:8000/hello").as_str()).unwrap(),
+            hurl_str
+        );
+    }
+
+    #[test]
+    fn test_negotiate_flag() {
+        let hurl_str = r#"GET http://localhost:8000/hello
+[Options]
+negotiate: true
+"#;
+        assert_eq!(
+            parse_line(format!("curl --negotiate http://localhost:8000/hello").as_str()).unwrap(),
             hurl_str
         );
     }

--- a/packages/hurlfmt/src/curl/mod.rs
+++ b/packages/hurlfmt/src/curl/mod.rs
@@ -74,7 +74,8 @@ fn parse_line(s: &str) -> Result<String, String> {
         .arg(commands::method())
         .arg(commands::retry())
         .arg(commands::url())
-        .arg(commands::url_param());
+        .arg(commands::url_param())
+        .arg(commands::ntlm());
 
     let params = args::split(s)?;
     let arg_matches = match command.try_get_matches_from_mut(params) {
@@ -404,5 +405,16 @@ verbose: true
                 hurl_str
             );
         }
+    }
+    #[test]
+    fn test_ntlm_flag() {
+        let hurl_str = r#"GET http://localhost:8000/hello
+[Options]
+ntlm: true
+"#;
+        assert_eq!(
+            parse_line(format!("curl --ntlm http://localhost:8000/hello").as_str()).unwrap(),
+            hurl_str
+        );
     }
 }

--- a/packages/hurlfmt/src/format/json.rs
+++ b/packages/hurlfmt/src/format/json.rs
@@ -347,6 +347,7 @@ impl ToJson for EntryOption {
             }
             OptionKind::Verbose(value) => value.to_json(),
             OptionKind::VeryVerbose(value) => value.to_json(),
+            OptionKind::Ntlm(value) => value.to_json(),
         };
 
         // If the value contains the unit such as `{ "value": 10, "unit": "second" }`

--- a/packages/hurlfmt/src/format/json.rs
+++ b/packages/hurlfmt/src/format/json.rs
@@ -348,6 +348,7 @@ impl ToJson for EntryOption {
             OptionKind::Verbose(value) => value.to_json(),
             OptionKind::VeryVerbose(value) => value.to_json(),
             OptionKind::Ntlm(value) => value.to_json(),
+            OptionKind::Negotiate(value) => value.to_json(),
         };
 
         // If the value contains the unit such as `{ "value": 10, "unit": "second" }`

--- a/packages/hurlfmt/src/linter/rewrite.rs
+++ b/packages/hurlfmt/src/linter/rewrite.rs
@@ -491,6 +491,7 @@ impl Lint for OptionKind {
             OptionKind::Variable(value) => value.lint(),
             OptionKind::Verbose(value) => value.lint(),
             OptionKind::VeryVerbose(value) => value.lint(),
+            OptionKind::Ntlm(value) => value.lint(),
         };
         s.push_str(&value);
         s

--- a/packages/hurlfmt/src/linter/rewrite.rs
+++ b/packages/hurlfmt/src/linter/rewrite.rs
@@ -492,6 +492,7 @@ impl Lint for OptionKind {
             OptionKind::Verbose(value) => value.lint(),
             OptionKind::VeryVerbose(value) => value.lint(),
             OptionKind::Ntlm(value) => value.lint(),
+            OptionKind::Negotiate(value) => value.lint(),
         };
         s.push_str(&value);
         s


### PR DESCRIPTION
Add support for parsing:

- `-u`, `--user` option
- `--ntlm` flag
- `--negotiate` flag

in hurlfmt

closes #4213