### PR TITLE
Parse `--user`, `--negotiate`, and `--ntlm` options in hurlfmt

### DIFF
--- a/integration/hurlfmt/tests_ok/import_curl.in
+++ b/integration/hurlfmt/tests_ok/import_curl.in
@@ -10,5 +10,6 @@ curl -u "user:pass" https://localhost:8001/hello
 curl -k https://localhost:8001/hello
 curl -v https://localhost:8001/hello
 curl --verbose https://localhost:8001/hello
+curl --ntlm https://localhost:8001/hello
 curl --header 'Empty-Header;' http://localhost:8000/hello
 

--- a/integration/hurlfmt/tests_ok/import_curl.in
+++ b/integration/hurlfmt/tests_ok/import_curl.in
@@ -11,5 +11,6 @@ curl -k https://localhost:8001/hello
 curl -v https://localhost:8001/hello
 curl --verbose https://localhost:8001/hello
 curl --ntlm https://localhost:8001/hello
+curl --negotiate https://localhost:8001/hello
 curl --header 'Empty-Header;' http://localhost:8000/hello
 

--- a/integration/hurlfmt/tests_ok/import_curl.in
+++ b/integration/hurlfmt/tests_ok/import_curl.in
@@ -5,6 +5,8 @@ curl --header 'Content-Type: application/json' --data $'{\n    "name": "Bob",\n 
 curl --header 'Content-Type:' --data '@tests_ok/data.bin' 'http://localhost:8000/post-file'
 curl --location 'http://localhost:8000/redirect-absolute'
 curl --retry 4 'http://localhost:8000/retry/until-200'
+curl --user "user:pass" https://localhost:8001/hello
+curl -u "user:pass" https://localhost:8001/hello
 curl -k https://localhost:8001/hello
 curl -v https://localhost:8001/hello
 curl --verbose https://localhost:8001/hello

--- a/integration/hurlfmt/tests_ok/import_curl.out
+++ b/integration/hurlfmt/tests_ok/import_curl.out
@@ -63,6 +63,10 @@ GET https://localhost:8001/hello
 [Options]
 ntlm: true
 
+GET https://localhost:8001/hello
+[Options]
+negotiate: true
+
 GET http://localhost:8000/hello
 Empty-Header:
 

--- a/integration/hurlfmt/tests_ok/import_curl.out
+++ b/integration/hurlfmt/tests_ok/import_curl.out
@@ -41,6 +41,14 @@ status < 500
 
 GET https://localhost:8001/hello
 [Options]
+user: "user:pass"
+
+GET https://localhost:8001/hello
+[Options]
+user: "user:pass"
+
+GET https://localhost:8001/hello
+[Options]
 insecure: true
 
 GET https://localhost:8001/hello

--- a/integration/hurlfmt/tests_ok/import_curl.out
+++ b/integration/hurlfmt/tests_ok/import_curl.out
@@ -59,6 +59,10 @@ GET https://localhost:8001/hello
 [Options]
 verbose: true
 
+GET https://localhost:8001/hello
+[Options]
+ntlm: true
+
 GET http://localhost:8000/hello
 Empty-Header:
 

--- a/packages/hurlfmt/src/curl/commands.rs
+++ b/packages/hurlfmt/src/curl/commands.rs
@@ -140,3 +140,7 @@ pub fn verbose() -> clap::Arg {
         .short('v')
         .num_args(0)
 }
+
+pub fn user() -> clap::Arg {
+    clap::Arg::new("user").long("user").short('u').num_args(1)
+}

--- a/packages/hurlfmt/src/curl/commands.rs
+++ b/packages/hurlfmt/src/curl/commands.rs
@@ -148,3 +148,7 @@ pub fn user() -> clap::Arg {
 pub fn ntlm() -> clap::Arg {
     clap::Arg::new("ntlm").long("ntlm").num_args(0)
 }
+
+pub fn negotiate() -> clap::Arg {
+    clap::Arg::new("negotiate").long("negotiate").num_args(0)
+}

--- a/packages/hurlfmt/src/curl/commands.rs
+++ b/packages/hurlfmt/src/curl/commands.rs
@@ -144,3 +144,7 @@ pub fn verbose() -> clap::Arg {
 pub fn user() -> clap::Arg {
     clap::Arg::new("user").long("user").short('u').num_args(1)
 }
+
+pub fn ntlm() -> clap::Arg {
+    clap::Arg::new("ntlm").long("ntlm").num_args(0)
+}

--- a/packages/hurlfmt/src/curl/matches.rs
+++ b/packages/hurlfmt/src/curl/matches.rs
@@ -89,8 +89,17 @@ pub fn options(arg_matches: &ArgMatches) -> Vec<HurlOption> {
     if let Some(value) = get::<i32>(arg_matches, "max_redirects") {
         options.push(HurlOption::new("max-redirs", value.to_string().as_str()));
     }
+    if has_flag(arg_matches, "negotiate") {
+        options.push(HurlOption::new("negotiate", "true"));
+    }
+    if has_flag(arg_matches, "ntlm") {
+        options.push(HurlOption::new("ntlm", "true"));
+    }
     if let Some(value) = get::<i32>(arg_matches, "retry") {
         options.push(HurlOption::new("retry", value.to_string().as_str()));
+    }
+    if let Some(value) = get::<String>(arg_matches, "user") {
+        options.push(HurlOption::new("user", value.to_string().as_str()));
     }
     if has_flag(arg_matches, "verbose") {
         options.push(HurlOption::new("verbose", "true"));

--- a/packages/hurlfmt/src/curl/matches.rs
+++ b/packages/hurlfmt/src/curl/matches.rs
@@ -104,9 +104,6 @@ pub fn options(arg_matches: &ArgMatches) -> Vec<HurlOption> {
     if has_flag(arg_matches, "verbose") {
         options.push(HurlOption::new("verbose", "true"));
     }
-    if has_flag(arg_matches, "ntlm") {
-        options.push(HurlOption::new("ntlm", "true"));
-    }
     options
 }
 

--- a/packages/hurlfmt/src/curl/matches.rs
+++ b/packages/hurlfmt/src/curl/matches.rs
@@ -104,6 +104,9 @@ pub fn options(arg_matches: &ArgMatches) -> Vec<HurlOption> {
     if has_flag(arg_matches, "verbose") {
         options.push(HurlOption::new("verbose", "true"));
     }
+    if has_flag(arg_matches, "ntlm") {
+        options.push(HurlOption::new("ntlm", "true"));
+    }
     options
 }
 

--- a/packages/hurlfmt/src/curl/mod.rs
+++ b/packages/hurlfmt/src/curl/mod.rs
@@ -70,6 +70,7 @@ fn parse_line(s: &str) -> Result<String, String> {
         .arg(commands::insecure())
         .arg(commands::verbose())
         .arg(commands::ntlm())
+        .arg(commands::negotiate())
         .arg(commands::location())
         .arg(commands::max_redirects())
         .arg(commands::method())
@@ -430,6 +431,18 @@ ntlm: true
 "#;
         assert_eq!(
             parse_line("curl --ntlm http://localhost:8000/hello").unwrap(),
+            hurl_str
+        );
+    }
+
+    #[test]
+    fn test_negotiate_flag() {
+        let hurl_str = r#"GET http://localhost:8000/hello
+[Options]
+negotiate: true
+"#;
+        assert_eq!(
+            parse_line("curl --negotiate http://localhost:8000/hello").unwrap(),
             hurl_str
         );
     }

--- a/packages/hurlfmt/src/curl/mod.rs
+++ b/packages/hurlfmt/src/curl/mod.rs
@@ -74,7 +74,8 @@ fn parse_line(s: &str) -> Result<String, String> {
         .arg(commands::method())
         .arg(commands::retry())
         .arg(commands::url())
-        .arg(commands::url_param());
+        .arg(commands::url_param())
+        .arg(commands::user());
 
     let params = args::split(s)?;
     let arg_matches = match command.try_get_matches_from_mut(params) {
@@ -401,6 +402,20 @@ verbose: true
         for flag in flags {
             assert_eq!(
                 parse_line(format!("curl {flag} http://localhost:8000/hello").as_str()).unwrap(),
+                hurl_str
+            );
+        }
+    }
+
+    #[test]
+    fn test_user_option() {
+        let user = "test_user:test_pass";
+        let hurl_str = format!("GET http://localhost:8000/hello\n[Options]\nuser: {user}\n");
+
+        let flags = vec!["-u", "--user"];
+        for flag in flags {
+            assert_eq!(
+                parse_line(&format!("curl {flag} '{user}' http://localhost:8000/hello")).unwrap(),
                 hurl_str
             );
         }

--- a/packages/hurlfmt/src/curl/mod.rs
+++ b/packages/hurlfmt/src/curl/mod.rs
@@ -69,13 +69,14 @@ fn parse_line(s: &str) -> Result<String, String> {
         .arg(commands::cookies())
         .arg(commands::insecure())
         .arg(commands::verbose())
+        .arg(commands::ntlm())
         .arg(commands::location())
         .arg(commands::max_redirects())
         .arg(commands::method())
         .arg(commands::retry())
+        .arg(commands::user())
         .arg(commands::url())
-        .arg(commands::url_param())
-        .arg(commands::user());
+        .arg(commands::url_param());
 
     let params = args::split(s)?;
     let arg_matches = match command.try_get_matches_from_mut(params) {
@@ -419,5 +420,17 @@ verbose: true
                 hurl_str
             );
         }
+    }
+
+    #[test]
+    fn test_ntlm_flag() {
+        let hurl_str = r#"GET http://localhost:8000/hello
+[Options]
+ntlm: true
+"#;
+        assert_eq!(
+            parse_line("curl --ntlm http://localhost:8000/hello").unwrap(),
+            hurl_str
+        );
     }
 }


### PR DESCRIPTION
Add support for parsing:

- `-u`, `--user` option
- `--ntlm`  flag
- `--negotiate` flag

in hurlfmt

closes #4213