### PR TITLE
Parse `--user`, `--negotiate`, and `--ntlm` options in hurlfmt

### DIFF
--- a/integration/hurlfmt/tests_ok/import_curl.in
+++ b/integration/hurlfmt/tests_ok/import_curl.in
@@ -11,5 +11,6 @@ curl -k https://localhost:8001/hello
 curl -v https://localhost:8001/hello
 curl --verbose https://localhost:8001/hello
 curl --ntlm https://localhost:8001/hello
+curl --negotiate https://localhost:8001/hello
 curl --header 'Empty-Header;' http://localhost:8000/hello
 

--- a/integration/hurlfmt/tests_ok/import_curl.out
+++ b/integration/hurlfmt/tests_ok/import_curl.out
@@ -63,6 +63,10 @@ GET https://localhost:8001/hello
 [Options]
 ntlm: true
 
+GET https://localhost:8001/hello
+[Options]
+negotiate: true
+
 GET http://localhost:8000/hello
 Empty-Header:
 

--- a/packages/hurlfmt/src/curl/commands.rs
+++ b/packages/hurlfmt/src/curl/commands.rs
@@ -112,6 +112,10 @@ pub fn method() -> clap::Arg {
         .num_args(1)
 }
 
+pub fn negotiate() -> clap::Arg {
+    clap::Arg::new("negotiate").long("negotiate").num_args(0)
+}
+
 pub fn ntlm() -> clap::Arg {
     clap::Arg::new("ntlm").long("ntlm").num_args(0)
 }

--- a/packages/hurlfmt/src/curl/matches.rs
+++ b/packages/hurlfmt/src/curl/matches.rs
@@ -89,6 +89,9 @@ pub fn options(arg_matches: &ArgMatches) -> Vec<HurlOption> {
     if let Some(value) = get::<i32>(arg_matches, "max_redirects") {
         options.push(HurlOption::new("max-redirs", value.to_string().as_str()));
     }
+    if has_flag(arg_matches, "negotiate") {
+        options.push(HurlOption::new("negotiate", "true"));
+    }
     if has_flag(arg_matches, "ntlm") {
         options.push(HurlOption::new("ntlm", "true"));
     }

--- a/packages/hurlfmt/src/curl/mod.rs
+++ b/packages/hurlfmt/src/curl/mod.rs
@@ -69,6 +69,7 @@ fn parse_line(s: &str) -> Result<String, String> {
         .arg(commands::cookies())
         .arg(commands::insecure())
         .arg(commands::verbose())
+        .arg(commands::negotiate())
         .arg(commands::ntlm())
         .arg(commands::location())
         .arg(commands::max_redirects())
@@ -430,6 +431,18 @@ ntlm: true
 "#;
         assert_eq!(
             parse_line("curl --ntlm http://localhost:8000/hello").unwrap(),
+            hurl_str
+        );
+    }
+
+    #[test]
+    fn test_negotiate_flag() {
+        let hurl_str = r#"GET http://localhost:8000/hello
+[Options]
+negotiate: true
+"#;
+        assert_eq!(
+            parse_line("curl --negotiate http://localhost:8000/hello").unwrap(),
             hurl_str
         );
     }


### PR DESCRIPTION
Add support for parsing:

- `-u`, `--user` option
- `--ntlm`  flag
- `--negotiate` flag

in hurlfmt

closes #4213