### PR TITLE
Feat: Document recursive files

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -55,6 +55,11 @@ To have a test oriented output, you can use [`--test`](#test) option:
 $ hurl --test *.hurl
 ```
 
+Wildcard `*.hurl` does not work recursively. If you need to search all nested folders, you can combine Hurl with `find` command:
+
+```shell
+find . -type f -name \"*.hurl\" | xargs hurl --test
+```
 
 ## Hurl File Format
 


### PR DESCRIPTION
In a setup where each path is separate file, for example `src/modules/storage/files/create.js`, where test file will be in same path, `src/modules/storage/files/create.hurl`, current command with `*.hurl` won't work. Neither would `**/*.hurl` (that would only work 1 layer deep).

Addition to docs give ability to do wildcard search for files, nested in folders recursively.

Sample repository: https://github.com/Meldiron/almost-vault/blob/40e6825b1912f25e84a7974be2a6f262ea6aad3b/function/package.json#L11