### PR TITLE
Add SingularQuery type

### DIFF
--- a/packages/hurl/src/jsonpath2/ast/comparison.rs
+++ b/packages/hurl/src/jsonpath2/ast/comparison.rs
@@ -16,7 +16,7 @@
  *
  */
 
-use crate::jsonpath2::ast::{expr::Literal, query::Query};
+use crate::jsonpath2::ast::{expr::Literal, singular_query::SingularQuery};
 
 #[derive(Clone, Debug, PartialEq)]
 #[allow(dead_code)]
@@ -50,7 +50,7 @@ impl ComparisonExpr {
 #[allow(dead_code)]
 pub enum Comparable {
     Literal(Literal),
-    SingularQuery(Query),
+    SingularQuery(SingularQuery),
 }
 
 #[allow(dead_code)]

--- a/packages/hurl/src/jsonpath2/ast/mod.rs
+++ b/packages/hurl/src/jsonpath2/ast/mod.rs
@@ -21,6 +21,7 @@ pub(crate) mod expr;
 pub(crate) mod query;
 pub(crate) mod segment;
 pub(crate) mod selector;
+pub(crate) mod singular_query;
 
 /// JSONPath Query
 /// https://www.rfc-editor.org/rfc/rfc9535.html#name-overview-of-jsonpath-expres

--- a/packages/hurl/src/jsonpath2/ast/singular_query.rs
+++ b/packages/hurl/src/jsonpath2/ast/singular_query.rs
@@ -1,0 +1,63 @@
+/*
+ * Hurl (https://hurl.dev)
+ * Copyright (C) 2025 Orange
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+use crate::jsonpath2::ast::selector::{IndexSelector, NameSelector};
+
+#[allow(dead_code)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SingularQuery {
+    Absolute(AbsoluteSingularQuery),
+    Relative(RelativeSingularQuery),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AbsoluteSingularQuery {
+    segments: Vec<SingularQuerySegment>,
+}
+
+impl AbsoluteSingularQuery {
+    pub fn new(segments: Vec<SingularQuerySegment>) -> AbsoluteSingularQuery {
+        AbsoluteSingularQuery { segments }
+    }
+
+    pub fn segments(&self) -> &[SingularQuerySegment] {
+        &self.segments
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RelativeSingularQuery {
+    segments: Vec<SingularQuerySegment>,
+}
+
+impl RelativeSingularQuery {
+    pub fn new(segments: Vec<SingularQuerySegment>) -> RelativeSingularQuery {
+        RelativeSingularQuery { segments }
+    }
+
+    pub fn segments(&self) -> &[SingularQuerySegment] {
+        &self.segments
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[allow(dead_code)]
+pub enum SingularQuerySegment {
+    Name(NameSelector),
+    Index(IndexSelector),
+}

--- a/packages/hurl/src/jsonpath2/eval/comparison.rs
+++ b/packages/hurl/src/jsonpath2/eval/comparison.rs
@@ -62,16 +62,8 @@ impl Comparable {
     ) -> Option<serde_json::Value> {
         match self {
             Comparable::Literal(literal) => Some(literal.eval()),
-            Comparable::SingularQuery(query) => {
-                let values = query.eval(current_value, root_value);
-                if values.is_empty() {
-                    None
-                } else if values.len() == 1 {
-                    Some(values[0].clone())
-                } else {
-                    // TODO: Create specific type for Singular Query with eval returning Option<Value>
-                    panic!("Should not happen for SingularQuery")
-                }
+            Comparable::SingularQuery(singular_query) => {
+                singular_query.eval(current_value, root_value)
             }
         }
     }
@@ -96,18 +88,17 @@ mod tests {
 
     use serde_json::json;
 
+    use super::*;
+    use crate::jsonpath2::ast::singular_query::SingularQuerySegment;
     use crate::jsonpath2::ast::{
-        query::{AbsoluteQuery, Query},
-        segment::{ChildSegment, Segment},
-        selector::{NameSelector, Selector},
+        selector::NameSelector,
+        singular_query::{AbsoluteSingularQuery, SingularQuery},
     };
 
-    use super::*;
-
-    fn name_query(name: &str) -> Query {
-        Query::AbsoluteQuery(AbsoluteQuery::new(vec![Segment::Child(ChildSegment::new(
-            vec![Selector::Name(NameSelector::new(name.to_string()))],
-        ))]))
+    fn name_query(name: &str) -> SingularQuery {
+        SingularQuery::Absolute(AbsoluteSingularQuery::new(vec![
+            SingularQuerySegment::Name(NameSelector::new(name.to_string())),
+        ]))
     }
 
     #[test]

--- a/packages/hurl/src/jsonpath2/eval/mod.rs
+++ b/packages/hurl/src/jsonpath2/eval/mod.rs
@@ -20,6 +20,7 @@ mod comparison;
 mod query;
 mod segment;
 mod selector;
+mod singular_query;
 
 #[allow(dead_code)]
 pub type NodeList = Vec<serde_json::Value>;

--- a/packages/hurl/src/jsonpath2/eval/query.rs
+++ b/packages/hurl/src/jsonpath2/eval/query.rs
@@ -20,6 +20,7 @@ use crate::jsonpath2::ast::query::{AbsoluteQuery, Query, RelativeQuery};
 use crate::jsonpath2::eval::NodeList;
 
 impl Query {
+    #[allow(dead_code)]
     pub fn eval(
         &self,
         current_value: &serde_json::Value,

--- a/packages/hurl/src/jsonpath2/eval/singular_query.rs
+++ b/packages/hurl/src/jsonpath2/eval/singular_query.rs
@@ -1,0 +1,78 @@
+/*
+ * Hurl (https://hurl.dev)
+ * Copyright (C) 2025 Orange
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+use crate::jsonpath2::ast::singular_query::{
+    AbsoluteSingularQuery, RelativeSingularQuery, SingularQuery, SingularQuerySegment,
+};
+
+impl SingularQuery {
+    #[allow(dead_code)]
+    pub fn eval(
+        &self,
+        current_value: &serde_json::Value,
+        root_value: &serde_json::Value,
+    ) -> Option<serde_json::Value> {
+        match self {
+            SingularQuery::Absolute(absolute_singular_query) => {
+                absolute_singular_query.eval(root_value)
+            }
+            SingularQuery::Relative(relative_singular_query) => {
+                relative_singular_query.eval(current_value)
+            }
+        }
+    }
+}
+
+impl AbsoluteSingularQuery {
+    pub fn eval(&self, value: &serde_json::Value) -> Option<serde_json::Value> {
+        let mut result = value.clone();
+        for segment in self.segments() {
+            if let Some(value) = segment.eval(&result) {
+                result = value;
+            } else {
+                return None;
+            }
+        }
+        Some(result.clone())
+    }
+}
+
+impl RelativeSingularQuery {
+    pub fn eval(&self, value: &serde_json::Value) -> Option<serde_json::Value> {
+        let mut result = value.clone();
+        for segment in self.segments() {
+            if let Some(value) = segment.eval(&result) {
+                result = value;
+            } else {
+                return None;
+            }
+        }
+        Some(result.clone())
+    }
+}
+
+impl SingularQuerySegment {
+    pub fn eval(&self, value: &serde_json::Value) -> Option<serde_json::Value> {
+        match self {
+            SingularQuerySegment::Name(name_selector) => name_selector.eval(value),
+            SingularQuerySegment::Index(index_selector) => index_selector.eval(value),
+        }
+    }
+}
+#[cfg(test)]
+mod tests {}

--- a/packages/hurl/src/jsonpath2/parser/mod.rs
+++ b/packages/hurl/src/jsonpath2/parser/mod.rs
@@ -23,6 +23,7 @@ mod primitives;
 mod query;
 mod segments;
 mod selectors;
+mod singular_query;
 
 use crate::jsonpath2::ast::JsonPathQuery;
 pub use error::{ParseError, ParseErrorKind};

--- a/packages/hurl/src/jsonpath2/parser/query.rs
+++ b/packages/hurl/src/jsonpath2/parser/query.rs
@@ -18,36 +18,19 @@
 
 use hurl_core::reader::Reader;
 
-use crate::jsonpath2::ast::query::{AbsoluteQuery, Query, RelativeQuery};
+use crate::jsonpath2::ast::query::{AbsoluteQuery, RelativeQuery};
 use crate::jsonpath2::parser::primitives::{expect_str, match_str};
-use crate::jsonpath2::parser::{segments, ParseError, ParseErrorKind, ParseResult};
+use crate::jsonpath2::parser::{segments, ParseResult};
 
 pub fn parse(reader: &mut Reader) -> ParseResult<AbsoluteQuery> {
     expect_str("$", reader)?;
-    let segments = segments::parse(reader, false)?;
+    let segments = segments::parse(reader)?;
     Ok(AbsoluteQuery::new(segments))
-}
-
-/// Parse a singular query.
-/// Regardless of the input value, the expression produces a nodelist containing at most one node
-#[allow(dead_code)]
-pub fn singular_query(reader: &mut Reader) -> ParseResult<Query> {
-    if match_str("$", reader) {
-        let segments = segments::parse(reader, true)?;
-        Ok(Query::AbsoluteQuery(AbsoluteQuery::new(segments)))
-    } else if match_str("@", reader) {
-        let segments = segments::parse(reader, true)?;
-        Ok(Query::RelativeQuery(RelativeQuery::new(segments)))
-    } else {
-        let pos = reader.cursor().pos;
-        let kind = ParseErrorKind::Expecting("a singular query".to_string());
-        Err(ParseError::new(pos, kind))
-    }
 }
 
 pub fn try_relative_query(reader: &mut Reader) -> ParseResult<Option<RelativeQuery>> {
     if match_str("@", reader) {
-        let segments = segments::parse(reader, false)?;
+        let segments = segments::parse(reader)?;
         Ok(Some(RelativeQuery::new(segments)))
     } else {
         Ok(None)

--- a/packages/hurl/src/jsonpath2/parser/selectors.rs
+++ b/packages/hurl/src/jsonpath2/parser/selectors.rs
@@ -61,7 +61,7 @@ pub fn selector(reader: &mut Reader) -> ParseResult<Selector> {
 }
 
 /// Try to parse a name selector
-fn try_name_selector(reader: &mut Reader) -> ParseResult<Option<NameSelector>> {
+pub fn try_name_selector(reader: &mut Reader) -> ParseResult<Option<NameSelector>> {
     let value = try_string_literal(reader)?;
     Ok(value.map(NameSelector::new))
 }

--- a/packages/hurl/src/jsonpath2/parser/singular_query.rs
+++ b/packages/hurl/src/jsonpath2/parser/singular_query.rs
@@ -1,0 +1,170 @@
+/*
+ * Hurl (https://hurl.dev)
+ * Copyright (C) 2025 Orange
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+use crate::jsonpath2::ast::selector::{IndexSelector, NameSelector};
+use crate::jsonpath2::ast::singular_query::{
+    AbsoluteSingularQuery, RelativeSingularQuery, SingularQuery, SingularQuerySegment,
+};
+use crate::jsonpath2::parser::literal::try_integer;
+use crate::jsonpath2::parser::primitives::expect_str;
+use crate::jsonpath2::parser::primitives::match_str;
+use crate::jsonpath2::parser::selectors::try_name_selector;
+use crate::jsonpath2::parser::ParseResult;
+use crate::jsonpath2::parser::{ParseError, ParseErrorKind};
+use hurl_core::reader::Reader;
+
+/// Parse a singular query.
+/// It differs from a regular query in that it only matches a single node.
+#[allow(dead_code)]
+pub fn parse(reader: &mut Reader) -> ParseResult<SingularQuery> {
+    if match_str("$", reader) {
+        let segments = singular_query_segments(reader)?;
+        Ok(SingularQuery::Absolute(AbsoluteSingularQuery::new(
+            segments,
+        )))
+    } else if match_str("@", reader) {
+        let segments = singular_query_segments(reader)?;
+        Ok(SingularQuery::Relative(RelativeSingularQuery::new(
+            segments,
+        )))
+    } else {
+        let pos = reader.cursor().pos;
+        let kind = ParseErrorKind::Expecting("a singular query".to_string());
+        Err(ParseError::new(pos, kind))
+    }
+}
+
+/// Parse singular segments
+fn singular_query_segments(reader: &mut Reader) -> ParseResult<Vec<SingularQuerySegment>> {
+    let mut segments = vec![];
+    while let Some(segment) = try_singular_query_segment(reader)? {
+        segments.push(segment);
+    }
+    Ok(segments)
+}
+
+fn try_singular_query_segment(reader: &mut Reader) -> ParseResult<Option<SingularQuerySegment>> {
+    let save = reader.cursor();
+    if match_str("[", reader) {
+        if let Some(name) = try_name_selector(reader)? {
+            expect_str("]", reader)?;
+            Ok(Some(SingularQuerySegment::Name(name)))
+        } else if let Some(value) = try_integer(reader)? {
+            expect_str("]", reader)?;
+            Ok(Some(SingularQuerySegment::Index(IndexSelector::new(value))))
+        } else {
+            Err(ParseError::new(
+                save.pos,
+                ParseErrorKind::Expecting("singular query segment".to_string()),
+            ))
+        }
+    } else if match_str(".", reader) {
+        match member_name_shorthand(reader) {
+            Ok(name) => Ok(Some(SingularQuerySegment::Name(NameSelector::new(name)))),
+            Err(_) => Err(ParseError::new(
+                save.pos,
+                ParseErrorKind::Expecting("singular query segment".to_string()),
+            )),
+        }
+    } else {
+        Ok(None)
+    }
+}
+
+fn member_name_shorthand(reader: &mut Reader) -> ParseResult<String> {
+    let mut name = alpha(reader)?.to_string();
+    name.push_str(&reader.read_while(|c| c.is_alphanumeric()));
+    Ok(name)
+}
+
+fn alpha(reader: &mut Reader) -> ParseResult<char> {
+    let pos = reader.cursor().pos;
+    if let Some(c) = reader.read() {
+        if c.is_alphabetic() {
+            Ok(c)
+        } else {
+            let kind = ParseErrorKind::Expecting("a character".to_string());
+            Err(ParseError::new(pos, kind))
+        }
+    } else {
+        let kind = ParseErrorKind::Expecting("a character".to_string());
+        Err(ParseError::new(pos, kind))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{ParseError, ParseErrorKind};
+    use super::*;
+    use crate::jsonpath2::ast::singular_query::{
+        AbsoluteSingularQuery, SingularQuery, SingularQuerySegment,
+    };
+    use hurl_core::reader::{CharPos, Pos, Reader};
+
+    #[test]
+    pub fn test_singular_query() {
+        let mut reader = Reader::new("$.store");
+
+        assert_eq!(
+            parse(&mut reader).unwrap(),
+            SingularQuery::Absolute(AbsoluteSingularQuery::new(vec![
+                SingularQuerySegment::Name(NameSelector::new("store".to_string()))
+            ]))
+        );
+        assert_eq!(reader.cursor().index, CharPos(7));
+    }
+
+    #[test]
+    pub fn test_singular_query_error() {
+        let mut reader = Reader::new("$.*");
+
+        assert_eq!(
+            parse(&mut reader).unwrap_err(),
+            ParseError::new(
+                Pos::new(1, 2),
+                ParseErrorKind::Expecting("singular query segment".to_string())
+            )
+        );
+    }
+
+    #[test]
+    pub fn test_singular_query_segment() {
+        let mut reader = Reader::new(".store");
+        assert_eq!(
+            try_singular_query_segment(&mut reader).unwrap().unwrap(),
+            SingularQuerySegment::Name(NameSelector::new("store".to_string()))
+        );
+        assert_eq!(reader.cursor().index, CharPos(6));
+
+        let mut reader = Reader::new("]");
+        assert!(try_singular_query_segment(&mut reader).unwrap().is_none(),);
+        assert_eq!(reader.cursor().index, CharPos(0));
+    }
+
+    #[test]
+    pub fn test_singular_query_segment_error() {
+        let mut reader = Reader::new(".*");
+        assert_eq!(
+            try_singular_query_segment(&mut reader).unwrap_err(),
+            ParseError::new(
+                Pos::new(1, 1),
+                ParseErrorKind::Expecting("singular query segment".to_string())
+            )
+        );
+    }
+}


### PR DESCRIPTION
A singular query differs from a regular query as it can only return a single node.