### PR TITLE
Plug comparison-expr into logical-expr

### DIFF
--- a/packages/hurl/src/jsonpath2/eval/expr.rs
+++ b/packages/hurl/src/jsonpath2/eval/expr.rs
@@ -22,7 +22,9 @@ impl LogicalExpr {
     #[allow(dead_code)]
     pub fn eval(&self, current_value: &serde_json::Value, root_value: &serde_json::Value) -> bool {
         match self {
-            LogicalExpr::Comparison(_comparison_expr) => todo!(),
+            LogicalExpr::Comparison(comparison_expr) => {
+                comparison_expr.eval(current_value, root_value)
+            }
             LogicalExpr::Test(test_expr) => test_expr.eval(current_value, root_value),
             LogicalExpr::And(_and_expr) => todo!(),
             LogicalExpr::Or(_or_expr) => todo!(),

--- a/packages/hurl/src/jsonpath2/parser/selectors.rs
+++ b/packages/hurl/src/jsonpath2/parser/selectors.rs
@@ -112,13 +112,15 @@ fn try_filter_selector(reader: &mut Reader) -> ParseResult<Option<FilterSelector
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use crate::jsonpath2::ast::{
+        comparison::{Comparable, ComparisonExpr, ComparisonOp},
         expr::{LogicalExpr, TestExpr, TestExprKind},
+        literal::Literal,
         query::{Query, RelativeQuery},
         segment::{ChildSegment, Segment},
+        singular_query::{RelativeSingularQuery, SingularQuery},
     };
-
-    use super::*;
     use hurl_core::reader::{CharPos, Reader};
 
     #[test]
@@ -258,5 +260,18 @@ mod tests {
             )))
         );
         assert_eq!(reader.cursor().index, CharPos(10));
+
+        let mut reader = Reader::new("?@>3]");
+        assert_eq!(
+            try_filter_selector(&mut reader).unwrap().unwrap(),
+            FilterSelector::new(LogicalExpr::Comparison(ComparisonExpr::new(
+                Comparable::SingularQuery(SingularQuery::Relative(RelativeSingularQuery::new(
+                    vec![]
+                ))),
+                Comparable::Literal(Literal::Integer(3)),
+                ComparisonOp::Greater
+            )))
+        );
+        assert_eq!(reader.cursor().index, CharPos(4));
     }
 }

--- a/packages/hurl/src/jsonpath2/tests/cts.rs
+++ b/packages/hurl/src/jsonpath2/tests/cts.rs
@@ -259,7 +259,7 @@ fn load_testcases() -> Vec<TestCase> {
 fn run() {
     let testcases = load_testcases();
     // TODO: Remove Limit when spec is fully implemented
-    let testcases = testcases.iter().take(47);
+    let testcases = testcases.iter().take(97);
     let count_total = testcases.len();
 
     let errors = testcases


### PR DESCRIPTION
Parsing comparison expression is tried before the test expression.
It must not fail for example if query segments are not singular.
The segments can indeed be non singular if the expression to be parsed is a test expression.
