### PR TITLE
Use `std::process::ExitCode` in main instead of `std::process:exit` to fix valgrind errror

### DIFF
--- a/bin/check/valgrind.sh
+++ b/bin/check/valgrind.sh
@@ -4,8 +4,7 @@ set -Eeuo pipefail
 valgrind --version
 cargo-valgrind --help
 
-# Disable valgrind for the moment, see <https://github.com/jfrimmel/cargo-valgrind/issues/131>
-#cat <<END | cargo valgrind run -p hurl -- --test
-#GET https://unpkg.com/vue@3.4.27/dist/vue.global.prod.js
-#HTTP 200
-#END
+cat <<END | cargo valgrind run -p hurl -- --test
+GET https://unpkg.com/vue@3.4.27/dist/vue.global.prod.js
+HTTP 200
+END

--- a/packages/hurl/src/cli/logger.rs
+++ b/packages/hurl/src/cli/logger.rs
@@ -52,6 +52,9 @@ impl BaseLogger {
 
     /// Prints an error `message` on standard error.
     pub fn error(&self, message: &str) {
+        if message.is_empty() {
+            return;
+        }
         let mut s = StyledString::new();
         s.push_with("error", Style::new().red().bold());
         s.push(": ");


### PR DESCRIPTION
See <https://github.com/jfrimmel/cargo-valgrind/issues/131>