### PR TITLE
Add Subject Alt Name (SAN) attribute for certificate assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -780,6 +780,8 @@ certificate "Subject" == "CN=example.org"
 certificate "Issuer" == "C=US, O=Let's Encrypt, CN=R3"
 certificate "Expire-Date" daysAfterNow > 15
 certificate "Serial-Number" matches /[\da-f]+/
+certificate "Subject-Alt-Name" contains "DNS:example.org"
+certificate "Subject-Alt-Name" split "," count == 2
 ```
 
 [Doc](https://hurl.dev/docs/asserting-response.html#ssl-certificate-assert)

--- a/docs/asserting-response.md
+++ b/docs/asserting-response.md
@@ -960,7 +960,7 @@ duration < 1000   # Check that response time is less than one second
 Check the SSL certificate properties. Certificate assert consists of the keyword `certificate`, followed by the 
 certificate attribute value.
 
-The following attributes are supported: `Subject`, `Issuer`, `Start-Date`, `Expire-Date` and `Serial-Number`.
+The following attributes are supported: `Subject`, `Issuer`, `Start-Date`, `Expire-Date`, `Serial-Number`, and `Subject-Alt-Name`.
 
 ```hurl
 GET https://example.org
@@ -970,6 +970,8 @@ certificate "Subject" == "CN=example.org"
 certificate "Issuer" == "C=US, O=Let's Encrypt, CN=R3"
 certificate "Expire-Date" daysAfterNow > 15
 certificate "Serial-Number" matches "[0-9af]+"
+certificate "Subject-Alt-Name" contains "DNS:example.org"
+certificate "Subject-Alt-Name" split "," count == 2
 ```
 
 [predicates]: #predicates

--- a/docs/manual/hurl.1
+++ b/docs/manual/hurl.1
@@ -1,4 +1,4 @@
-.TH hurl 1 "20 Nov 2025" "hurl 7.2.0-SNAPSHOT" " Hurl Manual"
+.TH hurl 1 "07 Dec 2025" "hurl 7.2.0-SNAPSHOT" " Hurl Manual"
 .SH NAME
 
 hurl - run and test HTTP requests.

--- a/docs/manual/hurlfmt.1
+++ b/docs/manual/hurlfmt.1
@@ -1,4 +1,4 @@
-.TH hurl 1 "20 Nov 2025" "hurl 7.2.0-SNAPSHOT" " Hurl Manual"
+.TH hurl 1 "07 Dec 2025" "hurl 7.2.0-SNAPSHOT" " Hurl Manual"
 .SH NAME
 
 hurlfmt - format Hurl files

--- a/docs/samples.md
+++ b/docs/samples.md
@@ -505,6 +505,8 @@ certificate "Subject" == "CN=example.org"
 certificate "Issuer" == "C=US, O=Let's Encrypt, CN=R3"
 certificate "Expire-Date" daysAfterNow > 15
 certificate "Serial-Number" matches /[\da-f]+/
+certificate "Subject-Alt-Name" contains "DNS:example.org"
+certificate "Subject-Alt-Name" split "," count == 2
 ```
 
 [Doc](/docs/asserting-response.md#ssl-certificate-assert)

--- a/packages/hurl/README.md
+++ b/packages/hurl/README.md
@@ -780,6 +780,8 @@ certificate "Subject" == "CN=example.org"
 certificate "Issuer" == "C=US, O=Let's Encrypt, CN=R3"
 certificate "Expire-Date" daysAfterNow > 15
 certificate "Serial-Number" matches /[\da-f]+/
+certificate "Subject-Alt-Name" contains "DNS:example.org"
+certificate "Subject-Alt-Name" split "," count == 2
 ```
 
 [Doc](https://hurl.dev/docs/asserting-response.html#ssl-certificate-assert)

--- a/packages/hurl/src/json/result.rs
+++ b/packages/hurl/src/json/result.rs
@@ -194,6 +194,8 @@ struct CertificateJson {
     start_date: String,
     expire_date: String,
     serial_number: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    subject_alt_name: Option<String>,
 }
 
 impl HurlResultJson {
@@ -448,6 +450,7 @@ impl CertificateJson {
             start_date: c.start_date.to_string(),
             expire_date: c.expire_date.to_string(),
             serial_number: c.serial_number.to_string(),
+            subject_alt_name: c.subject_alt_name.clone(),
         }
     }
 }

--- a/packages/hurl/src/report/html/run.rs
+++ b/packages/hurl/src/report/html/run.rs
@@ -133,13 +133,17 @@ fn get_call_html(
     if let Some(certificate) = &call.response.certificate {
         let start_date = certificate.start_date.to_string();
         let end_date = certificate.expire_date.to_string();
-        let values = vec![
+        let mut values = vec![
             ("Subject", certificate.subject.as_str()),
             ("Issuer", certificate.issuer.as_str()),
             ("Start Date", start_date.as_str()),
             ("Expire Date", end_date.as_str()),
             ("Serial Number", certificate.serial_number.as_str()),
         ];
+        if let Some(subject_alt_name) = certificate.subject_alt_name.as_ref() {
+            values.push(("Subject Alt Name", subject_alt_name.as_str()));
+        }
+
         let table = new_table("Certificate", &values);
         text.push_str(&table);
     }

--- a/packages/hurl/src/runner/query.rs
+++ b/packages/hurl/src/runner/query.rs
@@ -391,6 +391,12 @@ fn eval_query_certificate(
             CertificateAttributeName::SerialNumber => {
                 Value::String(certificate.serial_number.clone())
             }
+            CertificateAttributeName::SubjectAltName => {
+                match certificate.subject_alt_name.as_ref() {
+                    Some(s) => Value::String(s.clone()),
+                    None => return Ok(None),
+                }
+            }
         };
         Ok(Some(value))
     } else {
@@ -1484,7 +1490,8 @@ pub mod tests {
                         issuer: String::new(),
                         start_date: Default::default(),
                         expire_date: Default::default(),
-                        serial_number: String::new()
+                        serial_number: String::new(),
+                        subject_alt_name: Some(String::new())
                     }),
                     ..default_response()
                 },

--- a/packages/hurl_core/src/ast/section.rs
+++ b/packages/hurl_core/src/ast/section.rs
@@ -296,6 +296,7 @@ pub enum CertificateAttributeName {
     StartDate,
     ExpireDate,
     SerialNumber,
+    SubjectAltName,
 }
 
 impl CertificateAttributeName {
@@ -307,6 +308,7 @@ impl CertificateAttributeName {
             CertificateAttributeName::StartDate => "Start-Date",
             CertificateAttributeName::ExpireDate => "Expire-Date",
             CertificateAttributeName::SerialNumber => "Serial-Number",
+            CertificateAttributeName::SubjectAltName => "Subject-Alt-Name",
         }
     }
 }

--- a/packages/hurl_core/src/parser/query.rs
+++ b/packages/hurl_core/src/parser/query.rs
@@ -219,9 +219,11 @@ fn certificate_field(reader: &mut Reader) -> ParseResult<CertificateAttributeNam
         Ok(CertificateAttributeName::ExpireDate)
     } else if try_literal(r#"Serial-Number""#, reader).is_ok() {
         Ok(CertificateAttributeName::SerialNumber)
+    } else if try_literal(r#"Subject-Alt-Name""#, reader).is_ok() {
+        Ok(CertificateAttributeName::SubjectAltName)
     } else {
         let value =
-            "Field <Subject>, <Issuer>, <Start-Date>, <Expire-Date> or <Serial-Number>".to_string();
+            "Field <Subject>, <Issuer>, <Start-Date>, <Expire-Date>, <Serial-Number>, or <Subject-Alt-Name>".to_string();
         let kind = ParseErrorKind::Expecting { value };
         let cur = reader.cursor();
         Err(ParseError::new(cur.pos, false, kind))


### PR DESCRIPTION
Enhance the `certificate` assertion to expose the Subject Alternative Name x509v3 extension as an attribute for queries. You can now write comparisons such as:
```
certificate "Subject-Alt-Name" contains "DNS:example.org"
certificate "Subject-Alt-Name" split "," count == 2
```

Closes #4617. 
