### PR TITLE
Add new PTY integration tests.

### DIFF
--- a/integration/README.md
+++ b/integration/README.md
@@ -60,6 +60,8 @@ raised by the test is a runtime error.
 - [`hurl/tests_error_parser`]: every test is not a syntactically correct Hurl file. We test here the parsing error message.
 - [`hurl/tests_ssl`]: tests SSL features (server, client certificates and test files)
 - [`hurl/tests_unix_socket`]: tests Unix Socket (server and test files)
+- [`hurl/tests_pty`]: tests that need a "terminal" env, contrary to other tests where standard output and error output 
+are captured. These tests use a PTY only available on *Nix platform (Windows WSL included, but not "standard" Windows).
 
 
 Integration tests to test `hurlfmt` binary are grouped in `integration/hurlfmt` directory:

--- a/integration/hurl/integration.py
+++ b/integration/hurl/integration.py
@@ -13,7 +13,8 @@ def get_files(glob_expr: str) -> list[str]:
 
 def main():
     # Run test scripts
-    extension = "ps1" if platform.system() == "Windows" else "sh"
+    is_windows = platform.system() == "Windows"
+    extension = "ps1" if is_windows else "sh"
     script_files = (
         get_files("tests_ok/**/*." + extension)
         + get_files("tests_ok_not_linted/*." + extension)
@@ -23,7 +24,14 @@ def main():
         + get_files("tests_ssl/*." + extension)
     )
     for f in sorted(script_files):
-        test_script.test(f)
+        test_script.test(script_file=f, use_tty=True)
+
+    # Some tests need a "terminal" env, contrary to previous tests where standard output and error output are captured.
+    # These tests use a PTY only available on *Nix platform (Windows WSL included, but not "standard" Windows).
+    if not is_windows:
+        script_files = get_files("tests_pty/**/*.sh")
+        for f in sorted(script_files):
+            test_script.test(script_file=f, use_tty=False)
 
     print("Test integration hurl ok!")
 

--- a/integration/hurl/tests_pty/help/help.out.pattern
+++ b/integration/hurl/tests_pty/help/help.out.pattern
@@ -1,0 +1,139 @@
+Hurl, run and test HTTP requests with plain text
+
+Usage: hurl<<<(\.exe)?>>> [OPTIONS] [FILES]...
+
+Arguments:
+  [FILES]...  Set the input file to use
+
+Options:
+  -h, --help     Print help
+  -V, --version  Print version
+
+HTTP options:
+      --aws-sigv4 <PROVIDER1[:PROVIDER2[:REGION[:SERVICE]]]>
+          Use AWS V4 signature authentication in the transfer
+      --cacert <FILE>
+          CA certificate to verify peer against (PEM format)
+  -E, --cert <CERTIFICATE[:PASSWORD]>
+          Client certificate file and password
+      --compressed
+          Request compressed response (using deflate or gzip)
+      --connect-timeout <SECONDS>
+          Maximum time allowed for connection [default: 300]
+      --connect-to <HOST1:PORT1:HOST2:PORT2>
+          For a request to the given HOST1:PORT1 pair, connect to HOST2:PORT2 instead
+      --digest
+          Tell Hurl to use HTTP Digest authentication
+  -H, --header <HEADER>
+          Pass custom header(s) to server
+  -0, --http1.0
+          Tell Hurl to use HTTP version 1.0
+      --http1.1
+          Tell Hurl to use HTTP version 1.1
+      --http2
+          Tell Hurl to use HTTP version 2
+      --http3
+          Tell Hurl to use HTTP version 3
+  -k, --insecure
+          Allow insecure SSL connections
+  -4, --ipv4
+          Tell Hurl to use IPv4 addresses only when resolving host names, and not for example try
+          IPv6
+  -6, --ipv6
+          Tell Hurl to use IPv6 addresses only when resolving host names, and not for example try
+          IPv4
+      --key <KEY>
+          Private key file name
+      --limit-rate <SPEED>
+          Specify the maximum transfer rate in bytes/second, for both downloads and uploads
+  -L, --location
+          Follow redirects
+      --location-trusted
+          Follow redirects but allows sending the name + password to all hosts that the site may
+          redirect to
+      --max-filesize <BYTES>
+          Specify the maximum size in bytes of a file to download
+      --max-redirs <NUM>
+          Maximum number of redirects allowed, -1 for unlimited redirects [default: 50]
+  -m, --max-time <SECONDS>
+          Maximum time allowed for the transfer [default: 300]
+      --negotiate
+          Tell Hurl to use Negotiate (SPNEGO) authentication
+      --no-cookie-store
+          Do not use cookie store between requests
+      --no-proxy <HOST(S)>
+          List of hosts which do not use proxy
+      --ntlm
+          Tell Hurl to use NTLM authentication
+      --path-as-is
+          Tell Hurl to not handle sequences of /../ or /./ in the given URL path
+      --pinnedpubkey <HASHES>
+          Public key to verify peer against
+  -x, --proxy <[PROTOCOL://]HOST[:PORT]>
+          Use proxy on given PROTOCOL/HOST/PORT
+      --resolve <HOST:PORT:ADDR>
+          Provide a custom address for a specific HOST and PORT pair
+      --ssl-no-revoke
+          (Windows) Tell Hurl to disable certificate revocation checks
+      --unix-socket <PATH>
+          (HTTP) Connect through this Unix domain socket, instead of using the network
+  -u, --user <USER:PASSWORD>
+          Add basic Authentication header to each request
+  -A, --user-agent <NAME>
+          Specify the User-Agent string to send to the HTTP server
+
+Output options:
+      --color                  Colorize output
+      --curl <FILE>            Export each request to a list of curl commands
+      --error-format <FORMAT>  Control the format of error messages [default: short] [possible
+                               values: short, long]
+  -i, --include                Include the HTTP headers in the output
+      --json                   Output each Hurl file result to JSON
+      --no-color               Do not colorize output
+      --no-output              Suppress output. By default, Hurl outputs the body of the last
+                               response
+      --no-pretty              Do not prettify response output
+  -o, --output <FILE>          Write to FILE instead of stdout
+      --pretty                 Prettify JSON response output
+      --progress-bar           Display a progress bar in test mode
+  -v, --verbose                Turn on verbose (alias to --verbosity verbose)
+      --very-verbose           Turn on very verbose output, including HTTP response and libcurl logs
+                               (alias to --verbosity debug)
+      --verbosity <LEVEL>      Set verbosity level for debug log [possible values: brief, verbose,
+                               debug]
+
+Run options:
+      --continue-on-error              Continue executing requests even if an error occurs
+      --delay <MILLISECONDS>           Sets delay before each request (aka sleep) [default: 0]
+      --from-entry <ENTRY_NUMBER>      Execute Hurl file from ENTRY_NUMBER (starting at 1)
+      --ignore-asserts                 Ignore asserts defined in the Hurl file
+      --jobs <NUM>                     Maximum number of parallel jobs, 0 to disable parallel
+                                       execution
+      --parallel                       Run files in parallel (default in test mode)
+      --repeat <NUM>                   Repeat the input files sequence NUM times, -1 for infinite
+                                       loop
+      --retry <NUM>                    Maximum number of retries, 0 for no retries, -1 for unlimited
+                                       retries
+      --retry-interval <MILLISECONDS>  Interval in milliseconds before a retry [default: 1000]
+      --secret <NAME=VALUE>            Define a variable which value is secret
+      --secrets-file <FILE>            Define a secrets file in which you define your secrets
+      --test                           Activate test mode (use parallel execution)
+      --to-entry <ENTRY_NUMBER>        Execute Hurl file to ENTRY_NUMBER (starting at 1)
+      --variable <NAME=VALUE>          Define a variable
+      --variables-file <FILE>          Define a properties file in which you define your variables
+
+Report options:
+      --report-html <DIR>    Generate HTML report to DIR
+      --report-json <DIR>    Generate JSON report to DIR
+      --report-junit <FILE>  Write a JUnit XML report to FILE
+      --report-tap <FILE>    Write a TAP report to FILE
+
+Other options:
+  -b, --cookie <FILE>      Read cookies from FILE
+  -c, --cookie-jar <FILE>  Write cookies to FILE after running the session
+      --file-root <DIR>    Set root directory to import files [default: input file directory]
+      --glob <GLOB>        Specify input files that match the given GLOB. Multiple glob flags may be
+                           used
+  -n, --netrc              Must read .netrc for username and password
+      --netrc-file <FILE>  Specify FILE for .netrc
+      --netrc-optional     Use either .netrc or the URL

--- a/integration/hurl/tests_pty/help/help.ps1
+++ b/integration/hurl/tests_pty/help/help.ps1
@@ -1,0 +1,6 @@
+Set-StrictMode -Version latest
+$ErrorActionPreference = 'Stop'
+
+# In pty tests, --help is wrapped on a 100 columns wide terminal.
+export NO_COLOR=1
+hurl --help

--- a/integration/hurl/tests_pty/help/help.sh
+++ b/integration/hurl/tests_pty/help/help.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+# In pty tests, --help is wrapped on a 100 columns wide terminal.
+export NO_COLOR=1
+hurl --help

--- a/integration/hurlfmt/integration.py
+++ b/integration/hurlfmt/integration.py
@@ -29,7 +29,7 @@ def main():
         "tests_failed/*." + extension
     )
     for f in sorted(script_files):
-        test_script.test(f)
+        test_script.test(script_file=f, use_tty=True)
 
     print("Test integration hurlfmt ok!")
 

--- a/integration/term.py
+++ b/integration/term.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+# TTY and PTY runners for executing commands in terminal and pseudo-terminal environment.
+#
+import subprocess
+from typing import List
+
+
+class Term:
+    def run(self, cmd: List[str]) -> subprocess.CompletedProcess:
+        result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        return result
+
+
+class PseudoTerm:
+    """Pseudo-terminal wrapper for running commands with TTY simulation.
+
+    This PTY isn't available on Windows platform.
+    """
+
+    def __init__(self, row: int = 24, col: int = 80, read_chunk_size: int = 4096):
+        """Initialize Term with terminal dimensions.
+
+        Args:
+            row: Terminal height in rows (default: 24)
+            col: Terminal width in columns (default: 80)
+        """
+        self.row = row
+        self.width = col
+        self.read_chunk_size = read_chunk_size
+
+    def run(self, cmd: List[str]) -> subprocess.CompletedProcess:
+        """Run command with pseudo-terminals to simulate real TTYs for both stdout and stderr.
+
+        Args:
+            cmd: Command and arguments as a list
+
+        Returns:
+            CompletedProcess with captured stdout and stderr
+        """
+        import fcntl
+        import os
+        import pty
+        import select
+        import struct
+        import termios
+        import tty
+
+        # Create separate PTY pairs for stdout and stderr
+        stdout_master, stdout_slave = pty.openpty()
+        stderr_master, stderr_slave = pty.openpty()
+
+        try:
+            # Set PTYs to raw mode to prevent newline translation
+            tty.setraw(stdout_slave)
+            tty.setraw(stderr_slave)
+
+            # Set terminal size (rows, cols, xpixel, ypixel)
+            winsize = struct.pack("HHHH", self.row, self.width, 0, 0)
+            fcntl.ioctl(stdout_slave, termios.TIOCSWINSZ, winsize)
+            fcntl.ioctl(stderr_slave, termios.TIOCSWINSZ, winsize)
+
+            # Run process with separate PTYs for stdout and stderr
+            process = subprocess.Popen(
+                cmd, stdout=stdout_slave, stderr=stderr_slave, close_fds=True
+            )
+
+            # Close slave fds in parent process
+            os.close(stdout_slave)
+            os.close(stderr_slave)
+
+            # Read from both masters concurrently using select
+            stdout_output = b""
+            stderr_output = b""
+            fds = {stdout_master: "stdout", stderr_master: "stderr"}
+
+            while fds:
+                # Wait for data on any of the file descriptors
+                ready_fds, _, _ = select.select(list(fds.keys()), [], [])
+
+                for fd in ready_fds:
+                    try:
+                        chunk = os.read(fd, self.read_chunk_size)
+                        if chunk:
+                            if fds[fd] == "stdout":
+                                stdout_output += chunk
+                            else:
+                                stderr_output += chunk
+                        else:
+                            # EOF reached, remove this fd
+                            del fds[fd]
+                    except OSError:
+                        # Error reading, remove this fd
+                        if fd in fds:
+                            del fds[fd]
+
+            # Wait for process to finish
+            return_code = process.wait()
+
+            return subprocess.CompletedProcess(
+                args=cmd,
+                returncode=return_code,
+                stdout=stdout_output,
+                stderr=stderr_output,
+            )
+        finally:
+            os.close(stdout_master)
+            os.close(stderr_master)


### PR DESCRIPTION
Some tests need a "terminal" env, contrary to actual tests where standard output and error output are captured. These tests use a PTY only available on Windows.