### PR TITLE
Improve error message for invalid filter input

### DIFF
--- a/integration/hurl/tests_failed/filter/filter.err
+++ b/integration/hurl/tests_failed/filter/filter.err
@@ -5,7 +5,9 @@ error: Filter error
    | GET http://localhost:8000/error-filter
    | ...
  4 | jsonpath "$.file" base64Decode == hex,e4bda0e5a5bde4b896e7;
-   |                   ^^^^^^^^^^^^ invalid filter input: string is not base64
+   |                   ^^^^^^^^^^^^ invalid filter input:
+   |                                   actual: string is not base64
+   |                                   expected: base64
    |
 
 error: Filter error
@@ -14,7 +16,9 @@ error: Filter error
    | GET http://localhost:8000/error-filter
    | ...
  5 | jsonpath "$.number" base64Decode == 123
-   |                     ^^^^^^^^^^^^ invalid filter input: integer
+   |                     ^^^^^^^^^^^^ invalid filter input:
+   |                                     actual: integer
+   |                                     expected: string
    |
 
 error: Filter error
@@ -23,7 +27,9 @@ error: Filter error
    | GET http://localhost:8000/error-filter
    | ...
  6 | jsonpath "$.number" base64Encode == "MTIz"
-   |                     ^^^^^^^^^^^^ invalid filter input: integer
+   |                     ^^^^^^^^^^^^ invalid filter input:
+   |                                     actual: integer
+   |                                     expected: bytes
    |
 
 error: Filter error
@@ -32,7 +38,9 @@ error: Filter error
    | GET http://localhost:8000/error-filter
    | ...
  7 | jsonpath "$.file" base64UrlSafeDecode == hex,e4bda0e5a5bde4b896e7;
-   |                   ^^^^^^^^^^^^^^^^^^^ invalid filter input: string is not base64
+   |                   ^^^^^^^^^^^^^^^^^^^ invalid filter input:
+   |                                          actual: string is not base64
+   |                                          expected: base64
    |
 
 error: Filter error
@@ -41,7 +49,9 @@ error: Filter error
    | GET http://localhost:8000/error-filter
    | ...
  8 | jsonpath "$.base64_string" base64UrlSafeDecode == hex,e4bda0e5a5bde4b896e7;
-   |                            ^^^^^^^^^^^^^^^^^^^ invalid filter input: base64 string contains padding
+   |                            ^^^^^^^^^^^^^^^^^^^ invalid filter input:
+   |                                                   actual: base64 string contains padding
+   |                                                   expected: base64
    |
 
 error: Filter error
@@ -50,7 +60,9 @@ error: Filter error
    | GET http://localhost:8000/error-filter
    | ...
  9 | jsonpath "$.number" base64UrlSafeDecode == 123
-   |                     ^^^^^^^^^^^^^^^^^^^ invalid filter input: integer
+   |                     ^^^^^^^^^^^^^^^^^^^ invalid filter input:
+   |                                            actual: integer
+   |                                            expected: string
    |
 
 error: Filter error
@@ -59,7 +71,9 @@ error: Filter error
    | GET http://localhost:8000/error-filter
    | ...
 10 | jsonpath "$.number" base64UrlSafeEncode == "MTIz"
-   |                     ^^^^^^^^^^^^^^^^^^^ invalid filter input: integer
+   |                     ^^^^^^^^^^^^^^^^^^^ invalid filter input:
+   |                                            actual: integer
+   |                                            expected: bytes
    |
 
 error: Filter error
@@ -68,7 +82,9 @@ error: Filter error
    | GET http://localhost:8000/error-filter
    | ...
 11 | jsonpath "$.id" toHex == "d188d0b5d0bbd0bbd18b"
-   |                 ^^^^^ invalid filter input: string
+   |                 ^^^^^ invalid filter input:
+   |                          actual: string
+   |                          expected: bytes
    |
 
 error: Filter error
@@ -77,7 +93,9 @@ error: Filter error
    | GET http://localhost:8000/error-filter
    | ...
 12 | jsonpath "$.id" toInt == 123
-   |                 ^^^^^ invalid filter input: string <123x>
+   |                 ^^^^^ invalid filter input:
+   |                          actual: string <123x>
+   |                          expected: integer string
    |
 
 error: Filter error
@@ -86,7 +104,9 @@ error: Filter error
    | GET http://localhost:8000/error-filter
    | ...
 13 | jsonpath "$.id" first == 1
-   |                 ^^^^^ invalid filter input: string
+   |                 ^^^^^ invalid filter input:
+   |                          actual: string
+   |                          expected: list
    |
 
 error: Filter error
@@ -95,7 +115,9 @@ error: Filter error
    | GET http://localhost:8000/error-filter
    | ...
 14 | jsonpath "$.id" last == 3
-   |                 ^^^^ invalid filter input: string
+   |                 ^^^^ invalid filter input:
+   |                         actual: string
+   |                         expected: list
    |
 
 error: Filter error
@@ -104,7 +126,9 @@ error: Filter error
    | GET http://localhost:8000/error-filter
    | ...
 15 | jsonpath "$.empty_list" first == "1"
-   |                         ^^^^^ invalid filter input: list is empty
+   |                         ^^^^^ invalid filter input:
+   |                                  actual: list is empty
+   |                                  expected: non-empty list
    |
 
 error: Filter error
@@ -113,7 +137,9 @@ error: Filter error
    | GET http://localhost:8000/error-filter
    | ...
 16 | jsonpath "$.empty_list" last == "x"
-   |                         ^^^^ invalid filter input: list is empty
+   |                         ^^^^ invalid filter input:
+   |                                 actual: list is empty
+   |                                 expected: non-empty list
    |
 
 error: Filter error
@@ -122,7 +148,9 @@ error: Filter error
    | GET http://localhost:8000/error-filter
    | ...
 17 | jsonpath "$.status" toInt == 0
-   |                     ^^^^^ invalid filter input: boolean <true>
+   |                     ^^^^^ invalid filter input:
+   |                              actual: boolean <true>
+   |                              expected: integer, float, or string
    |
 
 error: Filter error
@@ -140,7 +168,9 @@ error: Filter error
    | GET http://localhost:8000/error-filter
    | ...
 19 | jsonpath "$.list" nth 5 == 3
-   |                   ^^^^^ invalid filter input: out of bound - size is 3
+   |                   ^^^^^ invalid filter input:
+   |                            actual: out of bound - size is 3
+   |                            expected: valid list index
    |
 
 error: Filter error
@@ -158,7 +188,9 @@ error: Filter error
    | GET http://localhost:8000/error-filter
    | ...
 21 | jsonpath "$.id" daysAfterNow == 1
-   |                 ^^^^^^^^^^^^ invalid filter input: string
+   |                 ^^^^^^^^^^^^ invalid filter input:
+   |                                 actual: string
+   |                                 expected: date
    |
 
 error: Filter error
@@ -167,7 +199,9 @@ error: Filter error
    | GET http://localhost:8000/error-filter
    | ...
 22 | jsonpath "$.id" daysBeforeNow == 1
-   |                 ^^^^^^^^^^^^^ invalid filter input: string
+   |                 ^^^^^^^^^^^^^ invalid filter input:
+   |                                  actual: string
+   |                                  expected: date
    |
 
 error: Filter error
@@ -176,7 +210,9 @@ error: Filter error
    | GET http://localhost:8000/error-filter
    | ...
 23 | jsonpath "$.id" charsetDecode "utf-8" == "help"
-   |                 ^^^^^^^^^^^^^^^^^^^^^ invalid filter input: string
+   |                 ^^^^^^^^^^^^^^^^^^^^^ invalid filter input:
+   |                                          actual: string
+   |                                          expected: bytes
    |
 
 error: Filter error
@@ -185,7 +221,9 @@ error: Filter error
    | GET http://localhost:8000/error-filter
    | ...
 24 | jsonpath "$.id" dateFormat "%a, %d %b %Y %H:%M:%S" == "Wed, 13 Jan 2021 22:23:01"
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid filter input: string
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid filter input:
+   |                                                       actual: string
+   |                                                       expected: date
    |
 
 error: Filter error
@@ -194,7 +232,9 @@ error: Filter error
    | GET http://localhost:8000/error-filter
    | ...
 25 | jsonpath "$.number" htmlEscape == "a &gt; b"
-   |                     ^^^^^^^^^^ invalid filter input: integer
+   |                     ^^^^^^^^^^ invalid filter input:
+   |                                   actual: integer
+   |                                   expected: string
    |
 
 error: Filter error
@@ -203,7 +243,9 @@ error: Filter error
    | GET http://localhost:8000/error-filter
    | ...
 26 | jsonpath "$.number" htmlUnescape == "a > b"
-   |                     ^^^^^^^^^^^^ invalid filter input: integer
+   |                     ^^^^^^^^^^^^ invalid filter input:
+   |                                     actual: integer
+   |                                     expected: string
    |
 
 error: Filter error
@@ -212,7 +254,9 @@ error: Filter error
    | GET http://localhost:8000/error-filter
    | ...
 27 | regex /(.*number.*)/ jsonpath "$.name" == "help"
-   |                      ^^^^^^^^^^^^^^^^^ invalid filter input: value is not a valid JSON
+   |                      ^^^^^^^^^^^^^^^^^ invalid filter input:
+   |                                           actual: value is not a valid JSON
+   |                                           expected: valid JSON string
    |
 
 error: Filter error
@@ -221,7 +265,9 @@ error: Filter error
    | GET http://localhost:8000/error-filter
    | ...
 28 | bytes jsonpath "$.name" == "help"
-   |       ^^^^^^^^^^^^^^^^^ invalid filter input: bytes
+   |       ^^^^^^^^^^^^^^^^^ invalid filter input:
+   |                            actual: bytes
+   |                            expected: string
    |
 
 error: Filter error
@@ -230,7 +276,9 @@ error: Filter error
    | GET http://localhost:8000/error-filter
    | ...
 29 | jsonpath "$.id" nth 0 == 123
-   |                 ^^^^^ invalid filter input: string <123x>
+   |                 ^^^^^ invalid filter input:
+   |                          actual: string <123x>
+   |                          expected: list
    |
 
 error: Filter error
@@ -239,7 +287,9 @@ error: Filter error
    | GET http://localhost:8000/error-filter
    | ...
 30 | jsonpath "$.list" nth -4 == 123
-   |                   ^^^^^^ invalid filter input: out of bound - size is 3
+   |                   ^^^^^^ invalid filter input:
+   |                             actual: out of bound - size is 3
+   |                             expected: valid list index
    |
 
 error: Filter error
@@ -248,7 +298,9 @@ error: Filter error
    | GET http://localhost:8000/error-filter
    | ...
 31 | jsonpath "$.number" regex /Hello (.*)!/ == "Bob"
-   |                     ^^^^^^^^^^^^^^^^^^^ invalid filter input: integer
+   |                     ^^^^^^^^^^^^^^^^^^^ invalid filter input:
+   |                                            actual: integer
+   |                                            expected: string
    |
 
 error: Filter error
@@ -257,7 +309,9 @@ error: Filter error
    | GET http://localhost:8000/error-filter
    | ...
 32 | jsonpath "$.number" replace ", " "|" == "192.168.2.1|10.0.0.20|10.0.0.10"
-   |                     ^^^^^^^^^^^^^^^^ invalid filter input: integer <42>
+   |                     ^^^^^^^^^^^^^^^^ invalid filter input:
+   |                                         actual: integer <42>
+   |                                         expected: string
    |
 
 error: Filter error
@@ -266,7 +320,9 @@ error: Filter error
    | GET http://localhost:8000/error-filter
    | ...
 33 | jsonpath "$.number" replaceRegex /\d/ "x" == "xxx.xxx.x.x,xx.x.x.xx|xx.x.x.xx"
-   |                     ^^^^^^^^^^^^^^^^^^^^^ invalid filter input: integer <42>
+   |                     ^^^^^^^^^^^^^^^^^^^^^ invalid filter input:
+   |                                              actual: integer <42>
+   |                                              expected: string
    |
 
 error: Filter error
@@ -275,7 +331,9 @@ error: Filter error
    | GET http://localhost:8000/error-filter
    | ...
 34 | jsonpath "$.number" split ", " count == 3
-   |                     ^^^^^^^^^^ invalid filter input: integer <42>
+   |                     ^^^^^^^^^^ invalid filter input:
+   |                                   actual: integer <42>
+   |                                   expected: string
    |
 
 error: Filter error
@@ -284,7 +342,9 @@ error: Filter error
    | GET http://localhost:8000/error-filter
    | ...
 35 | jsonpath "$.number" toDate "%Y-%m-%dT%H:%M:%S%.fZ" dateFormat "%A" == "Monday"
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid filter input: integer <42>
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid filter input:
+   |                                                       actual: integer
+   |                                                       expected: string
    |
 
 error: Filter error
@@ -293,7 +353,9 @@ error: Filter error
    | GET http://localhost:8000/error-filter
    | ...
 36 | jsonpath "$.number" urlDecode == "https://mozilla.org/?x=шеллы"
-   |                     ^^^^^^^^^ invalid filter input: integer
+   |                     ^^^^^^^^^ invalid filter input:
+   |                                  actual: integer
+   |                                  expected: string
    |
 
 error: Filter error
@@ -302,7 +364,9 @@ error: Filter error
    | GET http://localhost:8000/error-filter
    | ...
 37 | jsonpath "$.number" urlEncode == "https%3A//mozilla.org/%3Fx%3D%D1%88%D0%B5%D0%BB%D0%BB%D1%8B"
-   |                     ^^^^^^^^^ invalid filter input: integer
+   |                     ^^^^^^^^^ invalid filter input:
+   |                                  actual: integer
+   |                                  expected: string
    |
 
 error: Filter error
@@ -311,7 +375,9 @@ error: Filter error
    | GET http://localhost:8000/error-filter
    | ...
 38 | jsonpath "$.number" urlQueryParam "x" == "шеллы"
-   |                     ^^^^^^^^^^^^^^^^^ invalid filter input: integer
+   |                     ^^^^^^^^^^^^^^^^^ invalid filter input:
+   |                                          actual: integer
+   |                                          expected: string
    |
 
 error: Filter error
@@ -320,7 +386,9 @@ error: Filter error
    | GET http://localhost:8000/error-filter
    | ...
 39 | jsonpath "$.number" xpath "string(//body)" == "你好世界"
-   |                     ^^^^^^^^^^^^^^^^^^^^^^ invalid filter input: integer
+   |                     ^^^^^^^^^^^^^^^^^^^^^^ invalid filter input:
+   |                                               actual: integer
+   |                                               expected: string
    |
 
 error: Filter error
@@ -329,7 +397,9 @@ error: Filter error
    | GET http://localhost:8000/error-filter
    | ...
 40 | jsonpath "$.list" toString == "[]"
-   |                   ^^^^^^^^ invalid filter input: list <[1,2,3]> can not be converted to a string
+   |                   ^^^^^^^^ invalid filter input:
+   |                               actual: list <[1,2,3]>
+   |                               expected: a renderable value
    |
 
 error: Filter error
@@ -338,7 +408,9 @@ error: Filter error
    | GET http://localhost:8000/error-filter
    | ...
 41 | jsonpath "$.invalid_xml" xpath "normalize-space(//book)" == "foo"
-   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid filter input: value is not a valid XML
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid filter input:
+   |                                                             actual: value is not a valid XML
+   |                                                             expected: valid XML string
    |
 
 error: Invalid URL
@@ -365,7 +437,9 @@ error: Filter error
    | GET http://localhost:8000/error-filter
    | ...
 44 | jsonpath "$.big_int" toFloat == 10000000000000000365.0
-   |                      ^^^^^^^ invalid filter input: integer <10000000000000000365> is too big to be cast as a float
+   |                      ^^^^^^^ invalid filter input:
+   |                                 actual: integer <10000000000000000365> is too big to be cast as a float
+   |                                 expected: castable number
    |
 
 error: Filter error
@@ -374,7 +448,9 @@ error: Filter error
    | GET http://localhost:8000/error-filter
    | ...
 45 | jsonpath "$.id" toFloat == 1.23
-   |                 ^^^^^^^ invalid filter input: string <123x>
+   |                 ^^^^^^^ invalid filter input:
+   |                            actual: string <123x>
+   |                            expected: float string
    |
 
 error: Filter error
@@ -383,7 +459,9 @@ error: Filter error
    | GET http://localhost:8000/error-filter
    | ...
 46 | jsonpath "$.date" toDate "%+" toFloat == 3.14
-   |                               ^^^^^^^ invalid filter input: date <2023-01-23 18:25:43.511 UTC>
+   |                               ^^^^^^^ invalid filter input:
+   |                                          actual: date <2023-01-23 18:25:43.511 UTC>
+   |                                          expected: integer, float, or string
    |
 
 error: Filter error
@@ -401,6 +479,8 @@ error: Filter error
    | GET http://localhost:8000/error-filter
    | ...
 53 | foo: jsonpath "$.list" jsonpath "$.foo"
-   |                        ^^^^^^^^^^^^^^^^ invalid filter input: list
+   |                        ^^^^^^^^^^^^^^^^ invalid filter input:
+   |                                            actual: list
+   |                                            expected: string
    |
 

--- a/integration/hurl/tests_failed/filter/filter_in_capture.err
+++ b/integration/hurl/tests_failed/filter/filter_in_capture.err
@@ -4,6 +4,8 @@ error: Filter error
    | GET http://localhost:8000/error-filter-in-capture
    | ...
  4 | id: jsonpath "$.id" toInt
-   |                     ^^^^^ invalid filter input: string <123x>
+   |                     ^^^^^ invalid filter input:
+   |                              actual: string <123x>
+   |                              expected: integer string
    |
 

--- a/integration/hurl/tests_failed/predicate/predicate.err
+++ b/integration/hurl/tests_failed/predicate/predicate.err
@@ -212,7 +212,9 @@ error: Filter error
    | GET http://localhost:8000/predicate/error/type
    | ...
 24 | jsonpath "$.message" count == 1
-   |                      ^^^^^ invalid filter input: string
+   |                      ^^^^^ invalid filter input:
+   |                               actual: string
+   |                               expected: list, bytes, or nodeset
    |
 
 error: Assert failure

--- a/integration/hurl/tests_failed/runner_errors/runner_errors.err.pattern
+++ b/integration/hurl/tests_failed/runner_errors/runner_errors.err.pattern
@@ -92,7 +92,9 @@ error: Filter error
     | GET http://localhost:8000/runner_errors
     | ...
  58 | body toInt == 1
-    |      ^^^^^ invalid filter input: string <Hello World!>
+    |      ^^^^^ invalid filter input:
+    |               actual: string <Hello World!>
+    |               expected: integer string
     |
 
 error: Filter error

--- a/integration/hurl/tests_failed/runner_errors/runner_errors_color.err.pattern
+++ b/integration/hurl/tests_failed/runner_errors/runner_errors_color.err.pattern
@@ -92,7 +92,9 @@
 [1;34m    |[0m [90mGET http://localhost:8000/runner_errors[0m
 [1;34m    |[0m[90m ...[0m
 [1;34m 58 |[0m body toInt == 1
-[1;34m    |[0m[1;31m      ^^^^^ invalid filter input: string <Hello World!>[0m
+[1;34m    |[0m[1;31m      ^^^^^ invalid filter input:[0m
+[1;34m    |[0m[1;31m               actual: string <Hello World!>[0m
+[1;34m    |[0m[1;31m               expected: integer string[0m
 [1;34m    |[0m
 
 [1;31merror[0m: [1mFilter error[0m

--- a/packages/hurl/src/runner/error.rs
+++ b/packages/hurl/src/runner/error.rs
@@ -92,7 +92,10 @@ pub enum RunnerErrorKind {
     },
     FilterInvalidEncoding(String),
     /// Input of the filter is not valid, with a given reason.
-    FilterInvalidInput(String),
+    FilterInvalidInput {
+        actual: String,
+        expected: String,
+    },
     FilterInvalidFormatSpecifier(String),
     FilterMissingInput,
     Http(HttpError),
@@ -254,8 +257,10 @@ impl DisplaySourceError for RunnerError {
                 let message = error::add_carets(message, self.source_info, content);
                 color_red_multiline_string(&message)
             }
-            RunnerErrorKind::FilterInvalidInput(reason) => {
-                let message = &format!("invalid filter input: {reason}");
+            //work on this for better error message on filters
+            RunnerErrorKind::FilterInvalidInput { actual, expected } => {
+                let message =
+                    &format!("invalid filter input:\n   actual: {actual}\n   expected: {expected}");
                 let message = error::add_carets(message, self.source_info, content);
                 color_red_multiline_string(&message)
             }

--- a/packages/hurl/src/runner/filter/base64_decode.rs
+++ b/packages/hurl/src/runner/filter/base64_decode.rs
@@ -31,12 +31,18 @@ pub fn eval_base64_decode(
         Value::String(value) => match BASE64_STANDARD.decode(value) {
             Ok(decoded) => Ok(Some(Value::Bytes(decoded))),
             Err(_) => {
-                let kind = RunnerErrorKind::FilterInvalidInput("string is not base64".to_string());
+                let kind = RunnerErrorKind::FilterInvalidInput {
+                    actual: "string is not base64".to_string(),
+                    expected: "base64".to_string(),
+                };
                 Err(RunnerError::new(source_info, kind, assert))
             }
         },
         v => {
-            let kind = RunnerErrorKind::FilterInvalidInput(v.kind().to_string());
+            let kind = RunnerErrorKind::FilterInvalidInput {
+                actual: v.kind().to_string(),
+                expected: "string".to_string(),
+            };
             Err(RunnerError::new(source_info, kind, assert))
         }
     }
@@ -85,7 +91,10 @@ mod tests {
         );
         assert_eq!(
             ret.unwrap_err().kind,
-            RunnerErrorKind::FilterInvalidInput("string is not base64".to_string())
+            RunnerErrorKind::FilterInvalidInput {
+                actual: "string is not base64".to_string(),
+                expected: "base64".to_string()
+            }
         );
     }
 
@@ -105,7 +114,10 @@ mod tests {
         );
         assert_eq!(
             ret.unwrap_err().kind,
-            RunnerErrorKind::FilterInvalidInput("bytes".to_string())
+            RunnerErrorKind::FilterInvalidInput {
+                actual: "bytes".to_string(),
+                expected: "string".to_string()
+            }
         );
     }
 }

--- a/packages/hurl/src/runner/filter/base64_encode.rs
+++ b/packages/hurl/src/runner/filter/base64_encode.rs
@@ -30,7 +30,10 @@ pub fn eval_base64_encode(
     match value {
         Value::Bytes(value) => Ok(Some(Value::String(BASE64_STANDARD.encode(value)))),
         v => {
-            let kind = RunnerErrorKind::FilterInvalidInput(v.kind().to_string());
+            let kind = RunnerErrorKind::FilterInvalidInput {
+                actual: v.kind().to_string(),
+                expected: "bytes".to_string(),
+            };
             Err(RunnerError::new(source_info, kind, assert))
         }
     }
@@ -77,7 +80,10 @@ mod tests {
         );
         assert_eq!(
             ret.unwrap_err().kind,
-            RunnerErrorKind::FilterInvalidInput("string".to_string())
+            RunnerErrorKind::FilterInvalidInput {
+                actual: "string".to_string(),
+                expected: "bytes".to_string()
+            }
         );
     }
 }

--- a/packages/hurl/src/runner/filter/base64_url_safe_decode.rs
+++ b/packages/hurl/src/runner/filter/base64_url_safe_decode.rs
@@ -33,20 +33,26 @@ pub fn eval_base64_url_safe_decode(
             Ok(decoded) => Ok(Some(Value::Bytes(decoded))),
             Err(err) => match err {
                 InvalidPadding => {
-                    let kind = RunnerErrorKind::FilterInvalidInput(
-                        "base64 string contains padding".to_string(),
-                    );
+                    let kind = RunnerErrorKind::FilterInvalidInput {
+                        actual: "base64 string contains padding".to_string(),
+                        expected: "base64".to_string(),
+                    };
                     Err(RunnerError::new(source_info, kind, assert))
                 }
                 _ => {
-                    let kind =
-                        RunnerErrorKind::FilterInvalidInput("string is not base64".to_string());
+                    let kind = RunnerErrorKind::FilterInvalidInput {
+                        actual: "string is not base64".to_string(),
+                        expected: "base64".to_string(),
+                    };
                     Err(RunnerError::new(source_info, kind, assert))
                 }
             },
         },
         v => {
-            let kind = RunnerErrorKind::FilterInvalidInput(v.kind().to_string());
+            let kind = RunnerErrorKind::FilterInvalidInput {
+                actual: v.kind().to_string(),
+                expected: "string".to_string(),
+            };
             Err(RunnerError::new(source_info, kind, assert))
         }
     }
@@ -94,7 +100,10 @@ mod tests {
         );
         assert_eq!(
             ret.unwrap_err().kind,
-            RunnerErrorKind::FilterInvalidInput("string is not base64".to_string())
+            RunnerErrorKind::FilterInvalidInput {
+                actual: "string is not base64".to_string(),
+                expected: "base64".to_string()
+            }
         );
     }
 
@@ -114,7 +123,10 @@ mod tests {
         );
         assert_eq!(
             ret.unwrap_err().kind,
-            RunnerErrorKind::FilterInvalidInput("base64 string contains padding".to_string())
+            RunnerErrorKind::FilterInvalidInput {
+                actual: "base64 string contains padding".to_string(),
+                expected: "base64".to_string()
+            }
         );
     }
 
@@ -134,7 +146,10 @@ mod tests {
         );
         assert_eq!(
             ret.unwrap_err().kind,
-            RunnerErrorKind::FilterInvalidInput("bytes".to_string())
+            RunnerErrorKind::FilterInvalidInput {
+                actual: "bytes".to_string(),
+                expected: "string".to_string()
+            }
         );
     }
 }

--- a/packages/hurl/src/runner/filter/base64_url_safe_encode.rs
+++ b/packages/hurl/src/runner/filter/base64_url_safe_encode.rs
@@ -30,7 +30,10 @@ pub fn eval_base64_url_safe_encode(
     match value {
         Value::Bytes(value) => Ok(Some(Value::String(BASE64_URL_SAFE_NO_PAD.encode(value)))),
         v => {
-            let kind = RunnerErrorKind::FilterInvalidInput(v.kind().to_string());
+            let kind = RunnerErrorKind::FilterInvalidInput {
+                actual: v.kind().to_string(),
+                expected: "bytes".to_string(),
+            };
             Err(RunnerError::new(source_info, kind, assert))
         }
     }
@@ -77,7 +80,10 @@ mod tests {
         );
         assert_eq!(
             ret.unwrap_err().kind,
-            RunnerErrorKind::FilterInvalidInput("string".to_string())
+            RunnerErrorKind::FilterInvalidInput {
+                actual: "string".to_string(),
+                expected: "bytes".to_string()
+            }
         );
     }
 }

--- a/packages/hurl/src/runner/filter/count.rs
+++ b/packages/hurl/src/runner/filter/count.rs
@@ -30,7 +30,10 @@ pub fn eval_count(
         Value::Bytes(values) => Ok(Some(Value::Number(Number::Integer(values.len() as i64)))),
         Value::Nodeset(size) => Ok(Some(Value::Number(Number::Integer(*size as i64)))),
         v => {
-            let kind = RunnerErrorKind::FilterInvalidInput(v.kind().to_string());
+            let kind = RunnerErrorKind::FilterInvalidInput {
+                actual: v.kind().to_string(),
+                expected: "list, bytes, or nodeset".to_string(),
+            };
             Err(RunnerError::new(source_info, kind, assert))
         }
     }
@@ -78,7 +81,10 @@ mod tests {
         );
         assert_eq!(
             error.kind,
-            RunnerErrorKind::FilterInvalidInput("boolean".to_string())
+            RunnerErrorKind::FilterInvalidInput {
+                actual: "boolean".to_string(),
+                expected: "list, bytes, or nodeset".to_string()
+            }
         );
     }
 }

--- a/packages/hurl/src/runner/filter/days_after_now.rs
+++ b/packages/hurl/src/runner/filter/days_after_now.rs
@@ -32,7 +32,10 @@ pub fn eval_days_after_now(
             Ok(Some(Value::Number(Number::Integer(diff.num_days()))))
         }
         v => {
-            let kind = RunnerErrorKind::FilterInvalidInput(v.kind().to_string());
+            let kind = RunnerErrorKind::FilterInvalidInput {
+                actual: v.kind().to_string(),
+                expected: "date".to_string(),
+            };
             Err(RunnerError::new(source_info, kind, assert))
         }
     }

--- a/packages/hurl/src/runner/filter/days_before_now.rs
+++ b/packages/hurl/src/runner/filter/days_before_now.rs
@@ -32,7 +32,10 @@ pub fn eval_days_before_now(
             Ok(Some(Value::Number(Number::Integer(diff.num_days()))))
         }
         v => {
-            let kind = RunnerErrorKind::FilterInvalidInput(v.kind().to_string());
+            let kind = RunnerErrorKind::FilterInvalidInput {
+                actual: v.kind().to_string(),
+                expected: "date".to_string(),
+            };
             Err(RunnerError::new(source_info, kind, assert))
         }
     }

--- a/packages/hurl/src/runner/filter/decode.rs
+++ b/packages/hurl/src/runner/filter/decode.rs
@@ -45,7 +45,10 @@ pub fn eval_charset_decode(
             },
         },
         v => {
-            let kind = RunnerErrorKind::FilterInvalidInput(v.kind().to_string());
+            let kind = RunnerErrorKind::FilterInvalidInput {
+                actual: v.kind().to_string(),
+                expected: "bytes".to_string(),
+            };
             Err(RunnerError::new(source_info, kind, assert))
         }
     }
@@ -141,7 +144,10 @@ mod tests {
         );
         assert_eq!(
             ret.unwrap_err().kind,
-            RunnerErrorKind::FilterInvalidInput("string".to_string()),
+            RunnerErrorKind::FilterInvalidInput {
+                actual: "string".to_string(),
+                expected: "bytes".to_string()
+            },
         );
     }
 }

--- a/packages/hurl/src/runner/filter/first.rs
+++ b/packages/hurl/src/runner/filter/first.rs
@@ -29,12 +29,18 @@ pub fn eval_first(
         Value::List(values) => match values.first().cloned() {
             Some(first_value) => Ok(Some(first_value)),
             None => {
-                let kind = RunnerErrorKind::FilterInvalidInput("list is empty".to_string());
+                let kind = RunnerErrorKind::FilterInvalidInput {
+                    actual: "list is empty".to_string(),
+                    expected: "non-empty list".to_string(),
+                };
                 Err(RunnerError::new(source_info, kind, assert))
             }
         },
         v => {
-            let kind = RunnerErrorKind::FilterInvalidInput(v.kind().to_string());
+            let kind = RunnerErrorKind::FilterInvalidInput {
+                actual: v.kind().to_string(),
+                expected: "list".to_string(),
+            };
             Err(RunnerError::new(source_info, kind, assert))
         }
     }
@@ -86,7 +92,10 @@ mod tests {
 
         assert_eq!(
             ret.unwrap_err().kind,
-            RunnerErrorKind::FilterInvalidInput("list is empty".to_string())
+            RunnerErrorKind::FilterInvalidInput {
+                actual: "list is empty".to_string(),
+                expected: "non-empty list".to_string()
+            }
         );
     }
 
@@ -100,7 +109,10 @@ mod tests {
 
         assert_eq!(
             ret.unwrap_err().kind,
-            RunnerErrorKind::FilterInvalidInput("boolean".to_string())
+            RunnerErrorKind::FilterInvalidInput {
+                actual: "boolean".to_string(),
+                expected: "list".to_string()
+            }
         );
     }
 }

--- a/packages/hurl/src/runner/filter/format.rs
+++ b/packages/hurl/src/runner/filter/format.rs
@@ -45,7 +45,10 @@ pub fn eval_date_format(
             }
         }
         v => {
-            let kind = RunnerErrorKind::FilterInvalidInput(v.kind().to_string());
+            let kind = RunnerErrorKind::FilterInvalidInput {
+                actual: v.kind().to_string(),
+                expected: "date".to_string(),
+            };
             Err(RunnerError::new(source_info, kind, assert))
         }
     }
@@ -111,7 +114,10 @@ mod tests {
         );
         assert_eq!(
             ret.unwrap_err().kind,
-            RunnerErrorKind::FilterInvalidInput("string".to_string())
+            RunnerErrorKind::FilterInvalidInput {
+                actual: "string".to_string(),
+                expected: "date".to_string()
+            }
         );
     }
 

--- a/packages/hurl/src/runner/filter/html_escape.rs
+++ b/packages/hurl/src/runner/filter/html_escape.rs
@@ -32,7 +32,10 @@ pub fn eval_html_escape(
             Ok(Some(Value::String(encoded)))
         }
         v => {
-            let kind = RunnerErrorKind::FilterInvalidInput(v.kind().to_string());
+            let kind = RunnerErrorKind::FilterInvalidInput {
+                actual: v.kind().to_string(),
+                expected: "string".to_string(),
+            };
             Err(RunnerError::new(source_info, kind, assert))
         }
     }

--- a/packages/hurl/src/runner/filter/html_unescape.rs
+++ b/packages/hurl/src/runner/filter/html_unescape.rs
@@ -33,7 +33,10 @@ pub fn eval_html_unescape(
             Ok(Some(Value::String(decoded)))
         }
         v => {
-            let kind = RunnerErrorKind::FilterInvalidInput(v.kind().to_string());
+            let kind = RunnerErrorKind::FilterInvalidInput {
+                actual: v.kind().to_string(),
+                expected: "string".to_string(),
+            };
             Err(RunnerError::new(source_info, kind, assert))
         }
     }

--- a/packages/hurl/src/runner/filter/jsonpath.rs
+++ b/packages/hurl/src/runner/filter/jsonpath.rs
@@ -34,7 +34,10 @@ pub fn eval_jsonpath(
             Err(_) => {
                 return Err(RunnerError::new(
                     source_info,
-                    RunnerErrorKind::FilterInvalidInput("value is not a valid JSON".to_string()),
+                    RunnerErrorKind::FilterInvalidInput {
+                        actual: "value is not a valid JSON".to_string(),
+                        expected: "valid JSON string".to_string(),
+                    },
                     false,
                 ));
             }
@@ -52,7 +55,10 @@ pub fn eval_jsonpath(
         //     }
         // },
         v => {
-            let kind = RunnerErrorKind::FilterInvalidInput(v.kind().to_string());
+            let kind = RunnerErrorKind::FilterInvalidInput {
+                actual: v.kind().to_string(),
+                expected: "string".to_string(),
+            };
             return Err(RunnerError::new(source_info, kind, assert));
         }
     };

--- a/packages/hurl/src/runner/filter/last.rs
+++ b/packages/hurl/src/runner/filter/last.rs
@@ -29,12 +29,18 @@ pub fn eval_last(
         Value::List(values) => match values.last().cloned() {
             Some(last_value) => Ok(Some(last_value)),
             None => {
-                let kind = RunnerErrorKind::FilterInvalidInput("list is empty".to_string());
+                let kind = RunnerErrorKind::FilterInvalidInput {
+                    actual: "list is empty".to_string(),
+                    expected: "non-empty list".to_string(),
+                };
                 Err(RunnerError::new(source_info, kind, assert))
             }
         },
         v => {
-            let kind = RunnerErrorKind::FilterInvalidInput(v.kind().to_string());
+            let kind = RunnerErrorKind::FilterInvalidInput {
+                actual: v.kind().to_string(),
+                expected: "list".to_string(),
+            };
             Err(RunnerError::new(source_info, kind, assert))
         }
     }
@@ -86,7 +92,10 @@ mod tests {
 
         assert_eq!(
             ret.unwrap_err().kind,
-            RunnerErrorKind::FilterInvalidInput("list is empty".to_string())
+            RunnerErrorKind::FilterInvalidInput {
+                actual: "list is empty".to_string(),
+                expected: "non-empty list".to_string()
+            }
         );
     }
 
@@ -100,7 +109,10 @@ mod tests {
 
         assert_eq!(
             ret.unwrap_err().kind,
-            RunnerErrorKind::FilterInvalidInput("boolean".to_string())
+            RunnerErrorKind::FilterInvalidInput {
+                actual: "boolean".to_string(),
+                expected: "list".to_string()
+            }
         );
     }
 }

--- a/packages/hurl/src/runner/filter/location.rs
+++ b/packages/hurl/src/runner/filter/location.rs
@@ -28,7 +28,10 @@ pub fn eval_location(
     if let Value::HttpResponse(resp) = value {
         Ok(resp.location().map(|loc| Value::String(loc.raw())))
     } else {
-        let kind = RunnerErrorKind::FilterInvalidInput(value.kind().to_string());
+        let kind = RunnerErrorKind::FilterInvalidInput {
+            actual: value.kind().to_string(),
+            expected: "string".to_string(),
+        };
         Err(RunnerError::new(source_info, kind, assert))
     }
 }

--- a/packages/hurl/src/runner/filter/nth.rs
+++ b/packages/hurl/src/runner/filter/nth.rs
@@ -33,12 +33,18 @@ pub fn eval_nth(
         Value::List(values) => match try_nth(values, n) {
             Ok(value) => Ok(Some(value.clone())),
             Err(err) => {
-                let kind = RunnerErrorKind::FilterInvalidInput(err);
+                let kind = RunnerErrorKind::FilterInvalidInput {
+                    actual: err,
+                    expected: "valid list index".to_string(),
+                };
                 Err(RunnerError::new(source_info, kind, assert))
             }
         },
         v => {
-            let kind = RunnerErrorKind::FilterInvalidInput(v.repr());
+            let kind = RunnerErrorKind::FilterInvalidInput {
+                actual: v.repr(),
+                expected: "list".to_string(),
+            };
             Err(RunnerError::new(source_info, kind, assert))
         }
     }
@@ -130,7 +136,10 @@ mod tests {
             .unwrap(),
             RunnerError::new(
                 SourceInfo::new(Pos::new(1, 1), Pos::new(1, 1)),
-                RunnerErrorKind::FilterInvalidInput("out of bound - size is 2".to_string()),
+                RunnerErrorKind::FilterInvalidInput {
+                    actual: "out of bound - size is 2".to_string(),
+                    expected: "valid list index".to_string()
+                },
                 false
             )
         );
@@ -177,7 +186,10 @@ mod tests {
             .unwrap(),
             RunnerError::new(
                 SourceInfo::new(Pos::new(1, 1), Pos::new(1, 1)),
-                RunnerErrorKind::FilterInvalidInput("out of bound - size is 1".to_string()),
+                RunnerErrorKind::FilterInvalidInput {
+                    actual: "out of bound - size is 1".to_string(),
+                    expected: "valid list index".to_string()
+                },
                 false
             )
         );

--- a/packages/hurl/src/runner/filter/regex.rs
+++ b/packages/hurl/src/runner/filter/regex.rs
@@ -39,7 +39,10 @@ pub fn eval_regex(
             None => Ok(None),
         },
         v => {
-            let kind = RunnerErrorKind::FilterInvalidInput(v.kind().to_string());
+            let kind = RunnerErrorKind::FilterInvalidInput {
+                actual: v.kind().to_string(),
+                expected: "string".to_string(),
+            };
             Err(RunnerError::new(source_info, kind, assert))
         }
     }
@@ -99,7 +102,10 @@ mod tests {
         );
         assert_eq!(
             error.kind,
-            RunnerErrorKind::FilterInvalidInput("boolean".to_string())
+            RunnerErrorKind::FilterInvalidInput {
+                actual: "boolean".to_string(),
+                expected: "string".to_string()
+            }
         );
     }
 

--- a/packages/hurl/src/runner/filter/replace.rs
+++ b/packages/hurl/src/runner/filter/replace.rs
@@ -37,7 +37,10 @@ pub fn eval_replace(
             Ok(Some(Value::String(s)))
         }
         v => {
-            let kind = RunnerErrorKind::FilterInvalidInput(v.repr());
+            let kind = RunnerErrorKind::FilterInvalidInput {
+                actual: v.repr(),
+                expected: "string".to_string(),
+            };
             Err(RunnerError::new(source_info, kind, assert))
         }
     }

--- a/packages/hurl/src/runner/filter/replace_regex.rs
+++ b/packages/hurl/src/runner/filter/replace_regex.rs
@@ -38,7 +38,10 @@ pub fn eval_replace_regex(
             Ok(Some(Value::String(s)))
         }
         v => {
-            let kind = RunnerErrorKind::FilterInvalidInput(v.repr());
+            let kind = RunnerErrorKind::FilterInvalidInput {
+                actual: v.repr(),
+                expected: "string".to_string(),
+            };
             Err(RunnerError::new(source_info, kind, assert))
         }
     }

--- a/packages/hurl/src/runner/filter/split.rs
+++ b/packages/hurl/src/runner/filter/split.rs
@@ -38,7 +38,10 @@ pub fn eval_split(
             Ok(Some(Value::List(values)))
         }
         v => {
-            let kind = RunnerErrorKind::FilterInvalidInput(v.repr());
+            let kind = RunnerErrorKind::FilterInvalidInput {
+                actual: v.repr(),
+                expected: "string".to_string(),
+            };
             Err(RunnerError::new(source_info, kind, assert))
         }
     }

--- a/packages/hurl/src/runner/filter/to_date.rs
+++ b/packages/hurl/src/runner/filter/to_date.rs
@@ -64,7 +64,10 @@ pub fn eval_to_date(
             Err(RunnerError::new(source_info, kind, assert))
         }
         v => {
-            let kind = RunnerErrorKind::FilterInvalidInput(v.repr());
+            let kind = RunnerErrorKind::FilterInvalidInput {
+                actual: v.kind().to_string(),
+                expected: "string".to_string(),
+            };
             Err(RunnerError::new(source_info, kind, assert))
         }
     }
@@ -255,7 +258,10 @@ mod tests {
         );
         assert_eq!(
             ret.unwrap_err().kind,
-            RunnerErrorKind::FilterInvalidInput("bytes <c4e3ba>".to_string())
+            RunnerErrorKind::FilterInvalidInput {
+                actual: "bytes".to_string(),
+                expected: "string".to_string()
+            }
         );
     }
 }

--- a/packages/hurl/src/runner/filter/to_float.rs
+++ b/packages/hurl/src/runner/filter/to_float.rs
@@ -31,19 +31,25 @@ pub fn eval_to_float(
         Value::String(v) => match v.parse::<f64>() {
             Ok(f) => Ok(Some(Value::Number(Number::Float(f)))),
             _ => {
-                let kind = RunnerErrorKind::FilterInvalidInput(value.repr());
+                let kind = RunnerErrorKind::FilterInvalidInput {
+                    actual: value.repr(),
+                    expected: "float string".to_string(),
+                };
                 Err(RunnerError::new(source_info, kind, assert))
             }
         },
         Value::Number(Number::BigInteger(_)) => {
-            let kind = RunnerErrorKind::FilterInvalidInput(format!(
-                "{} is too big to be cast as a float",
-                value.repr()
-            ));
+            let kind = RunnerErrorKind::FilterInvalidInput {
+                actual: format!("{} is too big to be cast as a float", value.repr()),
+                expected: "castable number".to_string(),
+            };
             Err(RunnerError::new(source_info, kind, assert))
         }
         v => {
-            let kind = RunnerErrorKind::FilterInvalidInput(v.repr());
+            let kind = RunnerErrorKind::FilterInvalidInput {
+                actual: v.repr(),
+                expected: "integer, float, or string".to_string(),
+            };
             Err(RunnerError::new(source_info, kind, assert))
         }
     }
@@ -128,14 +134,20 @@ mod tests {
         .unwrap();
         assert_eq!(
             err.kind,
-            RunnerErrorKind::FilterInvalidInput("string <3x.1415>".to_string())
+            RunnerErrorKind::FilterInvalidInput {
+                actual: "string <3x.1415>".to_string(),
+                expected: "float string".to_string()
+            }
         );
         let err = eval_filter(&filter, &Value::Bool(true), &variables, false)
             .err()
             .unwrap();
         assert_eq!(
             err.kind,
-            RunnerErrorKind::FilterInvalidInput("boolean <true>".to_string())
+            RunnerErrorKind::FilterInvalidInput {
+                actual: "boolean <true>".to_string(),
+                expected: "integer, float, or string".to_string()
+            }
         );
     }
 }

--- a/packages/hurl/src/runner/filter/to_hex.rs
+++ b/packages/hurl/src/runner/filter/to_hex.rs
@@ -28,7 +28,10 @@ pub fn eval_to_hex(
     match value {
         Value::Bytes(value) => Ok(Some(Value::String(hex::encode(value)))),
         v => {
-            let kind = RunnerErrorKind::FilterInvalidInput(v.kind().to_string());
+            let kind = RunnerErrorKind::FilterInvalidInput {
+                actual: v.kind().to_string(),
+                expected: "bytes".to_string(),
+            };
             Err(RunnerError::new(source_info, kind, assert))
         }
     }
@@ -75,7 +78,10 @@ mod tests {
         );
         assert_eq!(
             ret.unwrap_err().kind,
-            RunnerErrorKind::FilterInvalidInput("string".to_string())
+            RunnerErrorKind::FilterInvalidInput {
+                actual: "string".to_string(),
+                expected: "bytes".to_string()
+            }
         );
     }
 }

--- a/packages/hurl/src/runner/filter/to_int.rs
+++ b/packages/hurl/src/runner/filter/to_int.rs
@@ -31,12 +31,18 @@ pub fn eval_to_int(
         Value::String(v) => match v.parse::<i64>() {
             Ok(i) => Ok(Some(Value::Number(Number::Integer(i)))),
             _ => {
-                let kind = RunnerErrorKind::FilterInvalidInput(value.repr());
+                let kind = RunnerErrorKind::FilterInvalidInput {
+                    actual: value.repr(),
+                    expected: "integer string".to_string(),
+                };
                 Err(RunnerError::new(source_info, kind, assert))
             }
         },
         v => {
-            let kind = RunnerErrorKind::FilterInvalidInput(v.repr());
+            let kind = RunnerErrorKind::FilterInvalidInput {
+                actual: v.repr(),
+                expected: "integer, float, or string".to_string(),
+            };
             Err(RunnerError::new(source_info, kind, assert))
         }
     }
@@ -109,14 +115,20 @@ mod tests {
         .unwrap();
         assert_eq!(
             err.kind,
-            RunnerErrorKind::FilterInvalidInput("string <123x>".to_string())
+            RunnerErrorKind::FilterInvalidInput {
+                actual: "string <123x>".to_string(),
+                expected: "integer string".to_string()
+            }
         );
         let err = eval_filter(&filter, &Value::Bool(true), &variables, false)
             .err()
             .unwrap();
         assert_eq!(
             err.kind,
-            RunnerErrorKind::FilterInvalidInput("boolean <true>".to_string())
+            RunnerErrorKind::FilterInvalidInput {
+                actual: "boolean <true>".to_string(),
+                expected: "integer, float, or string".to_string()
+            }
         );
     }
 }

--- a/packages/hurl/src/runner/filter/to_string.rs
+++ b/packages/hurl/src/runner/filter/to_string.rs
@@ -30,10 +30,10 @@ pub fn eval_to_string(
     match value.render() {
         Some(value) => Ok(Some(Value::String(value))),
         None => {
-            let kind = RunnerErrorKind::FilterInvalidInput(format!(
-                "{} can not be converted to a string",
-                value.repr()
-            ));
+            let kind = RunnerErrorKind::FilterInvalidInput {
+                actual: value.repr(),
+                expected: "a renderable value".to_string(),
+            };
             Err(RunnerError::new(source_info, kind, assert))
         }
     }
@@ -79,9 +79,10 @@ mod tests {
             .unwrap();
         assert_eq!(
             err.kind,
-            RunnerErrorKind::FilterInvalidInput(
-                "list <[]> can not be converted to a string".to_string()
-            )
+            RunnerErrorKind::FilterInvalidInput {
+                actual: "list <[]>".to_string(),
+                expected: "a renderable value".to_string()
+            }
         );
     }
 }

--- a/packages/hurl/src/runner/filter/url_decode.rs
+++ b/packages/hurl/src/runner/filter/url_decode.rs
@@ -35,7 +35,10 @@ pub fn eval_url_decode(
             Ok(Some(Value::String(decoded.to_string())))
         }
         v => {
-            let kind = RunnerErrorKind::FilterInvalidInput(v.kind().to_string());
+            let kind = RunnerErrorKind::FilterInvalidInput {
+                actual: v.kind().to_string(),
+                expected: "string".to_string(),
+            };
             Err(RunnerError::new(source_info, kind, assert))
         }
     }

--- a/packages/hurl/src/runner/filter/url_encode.rs
+++ b/packages/hurl/src/runner/filter/url_encode.rs
@@ -40,7 +40,10 @@ pub fn eval_url_encode(
             Ok(Some(Value::String(encoded)))
         }
         v => {
-            let kind = RunnerErrorKind::FilterInvalidInput(v.kind().to_string());
+            let kind = RunnerErrorKind::FilterInvalidInput {
+                actual: v.kind().to_string(),
+                expected: "string".to_string(),
+            };
             Err(RunnerError::new(source_info, kind, assert))
         }
     }

--- a/packages/hurl/src/runner/filter/url_query_param.rs
+++ b/packages/hurl/src/runner/filter/url_query_param.rs
@@ -52,7 +52,10 @@ pub fn eval_url_query_param(
             }
         },
         v => {
-            let kind = RunnerErrorKind::FilterInvalidInput(v.kind().to_string());
+            let kind = RunnerErrorKind::FilterInvalidInput {
+                actual: v.kind().to_string(),
+                expected: "string".to_string(),
+            };
             Err(RunnerError::new(source_info, kind, assert))
         }
     }
@@ -128,7 +131,10 @@ mod tests {
 
         assert_eq!(
             ret.unwrap_err().kind,
-            RunnerErrorKind::FilterInvalidInput("bytes".to_string())
+            RunnerErrorKind::FilterInvalidInput {
+                actual: "bytes".to_string(),
+                expected: "string".to_string()
+            }
         );
     }
     #[test]

--- a/packages/hurl/src/runner/filter/utf8_decode.rs
+++ b/packages/hurl/src/runner/filter/utf8_decode.rs
@@ -29,7 +29,10 @@ pub fn eval_utf8_decode(
             Ok(Some(Value::String(decoded.to_string())))
         }
         v => {
-            let kind = RunnerErrorKind::FilterInvalidInput(v.kind().to_string());
+            let kind = RunnerErrorKind::FilterInvalidInput {
+                actual: v.kind().to_string(),
+                expected: "bytes".to_string(),
+            };
             Err(RunnerError::new(source_info, kind, assert))
         }
     }

--- a/packages/hurl/src/runner/filter/utf8_encode.rs
+++ b/packages/hurl/src/runner/filter/utf8_encode.rs
@@ -29,7 +29,10 @@ pub fn eval_utf8_encode(
             Ok(Some(Value::Bytes(encoded)))
         }
         v => {
-            let kind = RunnerErrorKind::FilterInvalidInput(v.kind().to_string());
+            let kind = RunnerErrorKind::FilterInvalidInput {
+                actual: v.kind().to_string(),
+                expected: "string".to_string(),
+            };
             Err(RunnerError::new(source_info, kind, assert))
         }
     }

--- a/packages/hurl/src/runner/filter/xpath.rs
+++ b/packages/hurl/src/runner/filter/xpath.rs
@@ -35,14 +35,20 @@ pub fn eval_xpath(
             let Ok(doc) = Document::parse(xml, Format::Html) else {
                 return Err(RunnerError::new(
                     source_info,
-                    RunnerErrorKind::FilterInvalidInput("value is not a valid XML".to_string()),
+                    RunnerErrorKind::FilterInvalidInput {
+                        actual: "value is not a valid XML".to_string(),
+                        expected: "valid XML string".to_string(),
+                    },
                     false,
                 ));
             };
             eval_xpath_doc(&doc, expr, variables)
         }
         v => {
-            let kind = RunnerErrorKind::FilterInvalidInput(v.kind().to_string());
+            let kind = RunnerErrorKind::FilterInvalidInput {
+                actual: v.kind().to_string(),
+                expected: "string".to_string(),
+            };
             Err(RunnerError::new(source_info, kind, assert))
         }
     }
@@ -132,7 +138,10 @@ mod tests {
 
         assert_eq!(
             ret.unwrap_err().kind,
-            RunnerErrorKind::FilterInvalidInput("value is not a valid XML".to_string())
+            RunnerErrorKind::FilterInvalidInput {
+                actual: "value is not a valid XML".to_string(),
+                expected: "valid XML string".to_string()
+            }
         );
     }
 
@@ -150,7 +159,10 @@ mod tests {
 
         assert_eq!(
             ret.unwrap_err().kind,
-            RunnerErrorKind::FilterInvalidInput("bytes".to_string())
+            RunnerErrorKind::FilterInvalidInput {
+                actual: "bytes".to_string(),
+                expected: "string".to_string()
+            }
         );
     }
 }


### PR DESCRIPTION

This PR improves the clarity of error reporting for invalid filter inputs by refactoring RunnerErrorKind::FilterInvalidInput from a tuple variant to a struct variant with named fields.

Instead of returning a single string describing the invalid input, the error now explicitly includes:
actual – the type/value received
expected – the type/value required by the filter

This provides more structured and actionable error messages for users.
<img width="552" height="212" alt="image" src="https://github.com/user-attachments/assets/fc81497c-9b5e-4820-9470-764c22f448f7" />
