### PR TITLE
Add support for curl --data-raw option in hurlfmt import

### DIFF
--- a/integration/hurlfmt/tests_ok/import_curl.in
+++ b/integration/hurlfmt/tests_ok/import_curl.in
@@ -13,4 +13,6 @@ curl --verbose https://localhost:8001/hello
 curl --ntlm https://localhost:8001/hello
 curl --negotiate https://localhost:8001/hello
 curl --header 'Empty-Header;' http://localhost:8000/hello
+curl --data-raw '@data.txt' http://localhost:8000/post-raw
+curl --header 'Content-Type: application/json' --data-raw '{"name":"Bob"}' http://localhost:8000/post-raw-json
 

--- a/integration/hurlfmt/tests_ok/import_curl.out
+++ b/integration/hurlfmt/tests_ok/import_curl.out
@@ -70,3 +70,15 @@ negotiate: true
 GET http://localhost:8000/hello
 Empty-Header:
 
+POST http://localhost:8000/post-raw
+Content-Type: application/x-www-form-urlencoded
+```
+@data.txt
+```
+
+POST http://localhost:8000/post-raw-json
+Content-Type: application/json
+```
+{"name":"Bob"}
+```
+

--- a/packages/hurlfmt/src/curl/commands.rs
+++ b/packages/hurlfmt/src/curl/commands.rs
@@ -58,6 +58,15 @@ pub fn data() -> clap::Arg {
         .long("data")
         .short('d')
         .value_name("data")
+        .overrides_with("data_raw")
+        .num_args(1)
+}
+
+pub fn data_raw() -> clap::Arg {
+    clap::Arg::new("data_raw")
+        .long("data-raw")
+        .value_name("data")
+        .overrides_with("data")
         .num_args(1)
 }
 

--- a/packages/hurlfmt/src/curl/matches.rs
+++ b/packages/hurlfmt/src/curl/matches.rs
@@ -20,22 +20,21 @@ use clap::ArgMatches;
 use super::HurlOption;
 
 pub fn body(arg_matches: &ArgMatches) -> Option<String> {
-    match get_string(arg_matches, "data") {
-        None => None,
-        Some(v) => {
-            if let Some(filename) = v.strip_prefix('@') {
-                Some(format!("file, {filename};"))
-            } else {
-                Some(format!("```\n{v}\n```"))
-            }
-        }
+    if let Some(v) = get_string(arg_matches, "data_raw") {
+        return Some(format!("```\n{v}\n```"));
+    }
+    let v = get_string(arg_matches, "data")?;
+    if let Some(filename) = v.strip_prefix('@') {
+        Some(format!("file, {filename};"))
+    } else {
+        Some(format!("```\n{v}\n```"))
     }
 }
 
 pub fn method(arg_matches: &ArgMatches) -> String {
     match get_string(arg_matches, "method") {
         None => {
-            if arg_matches.contains_id("data") {
+            if has_arg(arg_matches, "data_raw") || has_arg(arg_matches, "data") {
                 "POST".to_string()
             } else {
                 "GET".to_string()
@@ -65,7 +64,9 @@ pub fn cookies(arg_matches: &ArgMatches) -> Vec<String> {
 pub fn headers(arg_matches: &ArgMatches) -> Vec<String> {
     let mut headers = get_strings(arg_matches, "headers").unwrap_or_default();
     if !has_content_type(&headers) {
-        if let Some(data) = get_string(arg_matches, "data") {
+        if has_arg(arg_matches, "data_raw") {
+            headers.push("Content-Type: application/x-www-form-urlencoded".to_string());
+        } else if let Some(data) = get_string(arg_matches, "data") {
             if !data.starts_with('@') {
                 headers.push("Content-Type: application/x-www-form-urlencoded".to_string());
             }
@@ -117,6 +118,10 @@ fn has_content_type(headers: &Vec<String>) -> bool {
         }
     }
     false
+}
+
+fn has_arg(matches: &ArgMatches, name: &str) -> bool {
+    matches.get_one::<String>(name).is_some()
 }
 
 fn has_flag(matches: &ArgMatches, name: &str) -> bool {

--- a/packages/hurlfmt/src/curl/mod.rs
+++ b/packages/hurlfmt/src/curl/mod.rs
@@ -65,6 +65,7 @@ fn parse_line(s: &str) -> Result<String, String> {
     let mut command = clap::Command::new("curl")
         .arg(commands::compressed())
         .arg(commands::data())
+        .arg(commands::data_raw())
         .arg(commands::digest())
         .arg(commands::headers())
         .arg(commands::cookies())
@@ -457,6 +458,54 @@ negotiate: true
         assert_eq!(
             parse_line("curl --negotiate http://localhost:8000/hello").unwrap(),
             hurl_str
+        );
+    }
+
+    #[test]
+    fn test_data_raw_literal() {
+        let hurl_str = r#"POST http://example.com/
+Content-Type: application/x-www-form-urlencoded
+```
+@filename
+```
+"#;
+        assert_eq!(
+            parse_line(r#"curl --data-raw @filename http://example.com/"#).unwrap(),
+            hurl_str
+        );
+    }
+
+    #[test]
+    fn test_data_raw_plain() {
+        let hurl_str = r#"POST http://localhost:8000/hello
+Content-Type: text/plain
+```
+hello
+```
+"#;
+        assert_eq!(
+            parse_line(
+                r#"curl --data-raw 'hello' -H 'Content-Type: text/plain' -X POST http://localhost:8000/hello"#
+            )
+            .unwrap(),
+            hurl_str
+        );
+    }
+
+    #[test]
+    fn test_data_raw_json() {
+        let hurl_str = r#"POST http://localhost:3000/data
+Content-Type: application/json
+```
+{"key1":"value1", "key2":"value2"}
+```
+"#;
+        assert_eq!(
+            hurl_str,
+            parse_line(
+                r#"curl --data-raw '{"key1":"value1", "key2":"value2"}' -H 'Content-Type: application/json' -X POST http://localhost:3000/data"#
+            )
+            .unwrap()
         );
     }
 }


### PR DESCRIPTION
`hurlfmt --in curl` currently chokes on `--data-raw`. This PR adds support for it.

`--data-raw` works like `--data` but treats `@` literally instead of reading from a file. The two flags are wired as mutually exclusive via clap's `overrides_with` so the last one wins, same as real curl.

Added unit tests for the main cases (literal `@`, plain body, JSON with explicit Content-Type) and integration tests in the existing `import_curl` suite. I did not add tests for the overrides as I thought it was low value and basically testing `clap`, but if you want them for documentation, just let me know.

Also let me know if the approach looks good or if you'd prefer a different implementation (i.e. preference for an enum for data/data-raw)

Closes #4411