### PR TITLE
Add config_file attribute in option spec

### DIFF
--- a/bin/spec/options/option.py
+++ b/bin/spec/options/option.py
@@ -27,6 +27,7 @@ class Option:
     allow_negative_numbers: bool = False
     deprecated: bool = False
     experimental: bool = False
+    config_file: bool = False
     env_var: Optional[str] = None
 
     def __str__(self):
@@ -58,6 +59,8 @@ class Option:
             s += "\ndeprecated: true"
         if self.experimental:
             s += "\nexperimental: true"
+        if self.config_file:
+            s += "\nconfig_file: true"
         if self.env_var:
             s += "\nenv_var: " + self.env_var
         s += "\n---"
@@ -83,6 +86,7 @@ class Option:
         description = ""
         experimental = False
         in_description = False
+        config_file = False
         env_var = None
 
         for line in s.split("\n"):
@@ -153,6 +157,15 @@ class Option:
                         raise Exception(
                             f"{name}: Expected true or false for experimental attribute"
                         )
+                elif key == "config_file":
+                    if v == "true":
+                        config_file = True
+                    elif v == "false":
+                        config_file = False
+                    else:
+                        raise Exception(
+                            f"{name}: Expected true or false for config_file attribute"
+                        )
                 elif key == "env_var":
                     env_var = v.strip()
                 else:
@@ -181,6 +194,7 @@ class Option:
             deprecated=deprecated,
             experimental=experimental,
             description=description.strip(),
+            config_file=config_file,
             env_var=env_var,
         )
 

--- a/docs/spec/options/hurl/header.option
+++ b/docs/spec/options/hurl/header.option
@@ -5,6 +5,7 @@ value: NAME:VALUE
 help: Pass custom header(s) to server
 help_heading: HTTP options
 multi: append
+config_file: true
 env_var: HURL_HEADER='name1:value1|name2:value2' (headers are separated by |)
 ---
 Add an extra header to include in information sent. Can be used several times in a command.

--- a/docs/spec/options/hurl/max_redirects.option
+++ b/docs/spec/options/hurl/max_redirects.option
@@ -6,6 +6,7 @@ value_parser: clap::value_parser!(i32).range(-1..)
 help: Maximum number of redirects allowed, -1 for unlimited redirects
 help_heading: HTTP options
 allow_negative_numbers: true
+config_file: true
 env_var: HURL_MAX_REDIRS
 ---
 Set maximum number of redirection-followings allowed

--- a/docs/spec/options/hurl/verbose.option
+++ b/docs/spec/options/hurl/verbose.option
@@ -3,6 +3,7 @@ long: verbose
 short: v
 help: Turn on verbose (alias to --verbosity verbose)
 help_heading: Output options
+config_file: true
 env_var: HURL_VERBOSE
 ---
 Turn on verbose output on standard error stream.


### PR DESCRIPTION
```
$ grep --with-filename config_file docs/spec/options/hurl/*.option
docs/spec/options/hurl/header.option:config_file: true
docs/spec/options/hurl/max_redirects.option:config_file: true
docs/spec/options/hurl/verbose.option:config_file: true
```