### PR TITLE
feat: add header unset and empty-value syntax

### DIFF
--- a/integration/hurl/tests_ok/empty_value_header/empty_value_header.hurl
+++ b/integration/hurl/tests_ok/empty_value_header/empty_value_header.hurl
@@ -1,0 +1,3 @@
+GET http://localhost:8000/empty-value-header
+X-Custom;
+HTTP 200

--- a/integration/hurl/tests_ok/empty_value_header/empty_value_header.ps1
+++ b/integration/hurl/tests_ok/empty_value_header/empty_value_header.ps1
@@ -1,0 +1,4 @@
+Set-StrictMode -Version latest
+$ErrorActionPreference = 'Stop'
+
+hurl tests_ok/empty_value_header/empty_value_header.hurl

--- a/integration/hurl/tests_ok/empty_value_header/empty_value_header.py
+++ b/integration/hurl/tests_ok/empty_value_header/empty_value_header.py
@@ -1,0 +1,8 @@
+from app import app
+from flask import request
+
+
+@app.route("/empty-value-header")
+def empty_value_header():
+    assert request.headers.get("X-Custom") == ""
+    return ""

--- a/integration/hurl/tests_ok/empty_value_header/empty_value_header.sh
+++ b/integration/hurl/tests_ok/empty_value_header/empty_value_header.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+hurl tests_ok/empty_value_header/empty_value_header.hurl

--- a/integration/hurl/tests_ok/header/headers.hurl
+++ b/integration/hurl/tests_ok/header/headers.hurl
@@ -49,5 +49,5 @@ HTTP 200
 Beverage: cafe  # TBC send utf8
 
 GET http://localhost:8000/empty-headers
-Empty-Header:
+Empty-Header;
 HTTP 200

--- a/integration/hurl/tests_ok/unset_header/unset_header.hurl
+++ b/integration/hurl/tests_ok/unset_header/unset_header.hurl
@@ -1,0 +1,3 @@
+GET http://localhost:8000/unset-header
+Authorization:
+HTTP 200

--- a/integration/hurl/tests_ok/unset_header/unset_header.ps1
+++ b/integration/hurl/tests_ok/unset_header/unset_header.ps1
@@ -1,0 +1,4 @@
+Set-StrictMode -Version latest
+$ErrorActionPreference = 'Stop'
+
+hurl --header 'Authorization: Bearer token123' tests_ok/unset_header/unset_header.hurl

--- a/integration/hurl/tests_ok/unset_header/unset_header.py
+++ b/integration/hurl/tests_ok/unset_header/unset_header.py
@@ -1,0 +1,8 @@
+from app import app
+from flask import request
+
+
+@app.route("/unset-header")
+def unset_header():
+    assert "Authorization" not in request.headers
+    return ""

--- a/integration/hurl/tests_ok/unset_header/unset_header.sh
+++ b/integration/hurl/tests_ok/unset_header/unset_header.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+hurl --header 'Authorization: Bearer token123' tests_ok/unset_header/unset_header.hurl

--- a/integration/hurlfmt/tests_ok/import_curl.out
+++ b/integration/hurlfmt/tests_ok/import_curl.out
@@ -68,7 +68,7 @@ GET https://localhost:8001/hello
 negotiate: true
 
 GET http://localhost:8000/hello
-Empty-Header:
+Empty-Header;
 
 POST http://localhost:8000/post-raw
 Content-Type: application/x-www-form-urlencoded

--- a/packages/hurl/src/http/client.rs
+++ b/packages/hurl/src/http/client.rs
@@ -510,7 +510,7 @@ impl Client {
 
         let mut headers = request_spec.headers.clone();
         headers.extend(&options.headers);
-        // Remove headers that are marked for unsetting
+        // Apply unset directives: remove matching headers from the merged list
         for name in &request_spec.unset_headers {
             headers.retain(|h| !h.name_eq(name));
         }

--- a/packages/hurl/src/http/client.rs
+++ b/packages/hurl/src/http/client.rs
@@ -163,6 +163,7 @@ impl Client {
                 method: redirect_method,
                 url: redirect_url,
                 headers,
+                unset_headers: request_spec.unset_headers,
                 querystring: vec![],
                 form,
                 multipart,
@@ -509,8 +510,13 @@ impl Client {
 
         let mut headers = request_spec.headers.clone();
         headers.extend(&options.headers);
+        // Remove headers that are marked for unsetting
+        for name in &request_spec.unset_headers {
+            headers.retain(|h| !h.name_eq(name));
+        }
         self.set_headers(
             &headers,
+            &request_spec.unset_headers,
             request_spec.implicit_content_type.as_deref(),
             options,
         )?;
@@ -566,10 +572,16 @@ impl Client {
     fn set_headers(
         &mut self,
         headers: &HeaderVec,
+        unset_headers: &[String],
         implicit_content_type: Option<&str>,
         options: &ClientOptions,
     ) -> Result<(), HttpError> {
         let mut list = headers.to_curl_headers()?;
+
+        // Send unset directives to libcurl to also clear any default headers.
+        for name in unset_headers {
+            list.append(&format!("{name}:"))?;
+        }
 
         // If request has no `Content-Type` header, we set it if the content type has been set
         // implicitly on this request.

--- a/packages/hurl/src/http/curl_cmd.rs
+++ b/packages/hurl/src/http/curl_cmd.rs
@@ -69,7 +69,7 @@ impl CurlCmd {
 
         let mut headers = request_spec.headers.clone();
         headers.extend(&options.headers);
-        // Remove headers that are marked for unsetting
+        // Strip headers that match an unset directive before generating curl args
         for name in &request_spec.unset_headers {
             headers.retain(|h| !h.name_eq(name));
         }

--- a/packages/hurl/src/http/curl_cmd.rs
+++ b/packages/hurl/src/http/curl_cmd.rs
@@ -69,8 +69,13 @@ impl CurlCmd {
 
         let mut headers = request_spec.headers.clone();
         headers.extend(&options.headers);
+        // Remove headers that are marked for unsetting
+        for name in &request_spec.unset_headers {
+            headers.retain(|h| !h.name_eq(name));
+        }
         let mut params = headers_params(
             &headers,
+            &request_spec.unset_headers,
             request_spec.implicit_content_type.as_deref(),
             &request_spec.body,
         );
@@ -104,6 +109,7 @@ fn method_params(request_spec: &RequestSpec, follow_location: bool) -> Vec<Strin
 /// an optional implicit content type, and the request body.
 fn headers_params(
     headers: &HeaderVec,
+    unset_headers: &[String],
     implicit_content_type: Option<&str>,
     body: &Body,
 ) -> Vec<String> {
@@ -111,6 +117,12 @@ fn headers_params(
 
     for header in headers.iter() {
         args.append(&mut header.curl_args());
+    }
+
+    // Add unset directives as `Name:` to remove headers from curl
+    for name in unset_headers {
+        args.push("--header".to_string());
+        args.push(encode_shell_string(&format!("{name}:")));
     }
 
     let has_explicit_content_type = headers.contains_key(CONTENT_TYPE);

--- a/packages/hurl/src/http/request_spec.rs
+++ b/packages/hurl/src/http/request_spec.rs
@@ -29,6 +29,9 @@ pub struct RequestSpec {
     pub method: Method,
     pub url: Url,
     pub headers: HeaderVec,
+    /// Header names to unset (remove from request, including CLI-level headers).
+    /// Populated when a header is specified as `Name:` (colon, no value) in the .hurl file.
+    pub unset_headers: Vec<String>,
     pub querystring: Vec<Param>,
     pub form: Vec<Param>,
     pub multipart: Vec<MultipartParam>,
@@ -47,6 +50,7 @@ impl Default for RequestSpec {
             method: Method("GET".to_string()),
             url: Url::default(),
             headers: HeaderVec::new(),
+            unset_headers: vec![],
             querystring: vec![],
             form: vec![],
             multipart: vec![],

--- a/packages/hurl/src/runner/entry.rs
+++ b/packages/hurl/src/runner/entry.rs
@@ -312,6 +312,9 @@ fn log_request(
     for header in &request.headers {
         logger.debug(&header.to_string());
     }
+    for name in &request.unset_headers {
+        logger.debug(&format!("{name}: (unset)"));
+    }
     if !request.querystring.is_empty() {
         logger.debug("[Query]");
         for param in &request.querystring {

--- a/packages/hurl/src/runner/request.rs
+++ b/packages/hurl/src/runner/request.rs
@@ -21,7 +21,9 @@ use base64::engine::general_purpose;
 use base64::Engine;
 use hurl_core::ast::Body as AstBody;
 use hurl_core::ast::Method as AstMethod;
-use hurl_core::ast::{Bytes, MultilineString, MultilineStringKind, Request, Template};
+use hurl_core::ast::{
+    Bytes, KeyValueSeparator, MultilineString, MultilineStringKind, Request, Template,
+};
 
 use crate::http::{
     Body, Header, HeaderVec, Method, Param, RequestCookie, RequestSpec, Url, UrlError,
@@ -46,11 +48,18 @@ pub fn eval_request(
 
     // Headers
     let mut headers = HeaderVec::new();
+    let mut unset_headers = vec![];
     for header in &request.headers {
         let name = template::eval_template(&header.key, variables)?;
-        let value = template::eval_template(&header.value, variables)?;
-        let header = Header::new(&name, &value);
-        headers.push(header);
+        // Colon with empty value = unset directive (remove header)
+        // Semicolon = empty-value header
+        if header.separator == KeyValueSeparator::Colon && header.value.is_empty() {
+            unset_headers.push(name);
+        } else {
+            let value = template::eval_template(&header.value, variables)?;
+            let header = Header::new(&name, &value);
+            headers.push(header);
+        }
     }
 
     // Basic auth
@@ -141,6 +150,7 @@ pub fn eval_request(
         method,
         url,
         headers,
+        unset_headers,
         querystring,
         form,
         multipart,
@@ -203,8 +213,8 @@ fn eval_method(method: &AstMethod) -> Method {
 #[cfg(test)]
 mod tests {
     use hurl_core::ast::{
-        Comment, Expr, ExprKind, KeyValue, LineTerminator, Placeholder, Section, SectionValue,
-        SourceInfo, TemplateElement, Variable, Whitespace,
+        Comment, Expr, ExprKind, KeyValue, KeyValueSeparator, LineTerminator, Placeholder, Section,
+        SectionValue, SourceInfo, TemplateElement, Variable, Whitespace,
     };
     use hurl_core::reader::Pos;
     use hurl_core::types::ToSource;
@@ -272,6 +282,7 @@ mod tests {
             space0: whitespace(),
             key,
             space1: whitespace(),
+            separator: KeyValueSeparator::Colon,
             space2: whitespace(),
             value,
             line_terminator0: line_terminator,

--- a/packages/hurl_core/src/ast/primitive.rs
+++ b/packages/hurl_core/src/ast/primitive.rs
@@ -25,7 +25,7 @@ use super::json::JsonValue;
 
 /// Separator used in a key-value pair.
 /// Colon is the default separator for key-value pairs.
-/// Semicolon is used for headers with empty values (httpie-style).
+/// Semicolon is used for headers with empty values (curl-style `Header;`).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum KeyValueSeparator {
     Colon,

--- a/packages/hurl_core/src/ast/primitive.rs
+++ b/packages/hurl_core/src/ast/primitive.rs
@@ -23,12 +23,22 @@ use crate::types::{SourceString, ToSource};
 
 use super::json::JsonValue;
 
+/// Separator used in a key-value pair.
+/// Colon is the default separator for key-value pairs.
+/// Semicolon is used for headers with empty values (httpie-style).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum KeyValueSeparator {
+    Colon,
+    Semicolon,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct KeyValue {
     pub line_terminators: Vec<LineTerminator>,
     pub space0: Whitespace,
     pub key: Template,
     pub space1: Whitespace,
+    pub separator: KeyValueSeparator,
     pub space2: Whitespace,
     pub value: Template,
     pub line_terminator0: LineTerminator,

--- a/packages/hurl_core/src/ast/visit.rs
+++ b/packages/hurl_core/src/ast/visit.rs
@@ -23,11 +23,11 @@
 use crate::ast::{
     Assert, Base64, Body, BooleanOption, Bytes, Capture, Comment, Cookie, CookiePath, CountOption,
     Duration, DurationOption, Entry, EntryOption, File, FilenameParam, FilenameValue, Filter,
-    FilterValue, Hex, HurlFile, IntegerValue, JsonValue, KeyValue, LineTerminator, Method,
-    MultilineString, MultipartParam, NaturalOption, Number, OptionKind, Placeholder, Predicate,
-    PredicateFuncValue, PredicateValue, Query, QueryValue, Regex, RegexValue, Request, Response,
-    Section, SectionValue, StatusValue, Template, VariableDefinition, VariableValue,
-    VerbosityOption, VersionValue, Whitespace, U64,
+    FilterValue, Hex, HurlFile, IntegerValue, JsonValue, KeyValue, KeyValueSeparator,
+    LineTerminator, Method, MultilineString, MultipartParam, NaturalOption, Number, OptionKind,
+    Placeholder, Predicate, PredicateFuncValue, PredicateValue, Query, QueryValue, Regex,
+    RegexValue, Request, Response, Section, SectionValue, StatusValue, Template,
+    VariableDefinition, VariableValue, VerbosityOption, VersionValue, Whitespace, U64,
 };
 use crate::types::{Count, DurationUnit, SourceString, ToSource};
 
@@ -570,7 +570,10 @@ pub fn walk_kv<V: Visitor>(visitor: &mut V, kv: &KeyValue) {
     visitor.visit_whitespace(&kv.space0);
     visitor.visit_template(&kv.key);
     visitor.visit_whitespace(&kv.space1);
-    visitor.visit_literal(":");
+    match kv.separator {
+        KeyValueSeparator::Colon => visitor.visit_literal(":"),
+        KeyValueSeparator::Semicolon => visitor.visit_literal(";"),
+    }
     visitor.visit_whitespace(&kv.space2);
     visitor.visit_template(&kv.value);
     visitor.visit_lt(&kv.line_terminator0);

--- a/packages/hurl_core/src/parser/parsers.rs
+++ b/packages/hurl_core/src/parser/parsers.rs
@@ -23,8 +23,8 @@ use crate::ast::{
 use crate::combinator::{optional, zero_or_more};
 use crate::parser::bytes::bytes;
 use crate::parser::primitives::{
-    eof, key_value, line_terminator, one_or_more_spaces, optional_line_terminators, try_literal,
-    zero_or_more_spaces,
+    eof, header_key_value, line_terminator, one_or_more_spaces, optional_line_terminators,
+    try_literal, zero_or_more_spaces,
 };
 use crate::parser::sections::{request_sections, response_sections};
 use crate::parser::string::unquoted_template;
@@ -58,7 +58,7 @@ fn request(reader: &mut Reader) -> ParseResult<Request> {
     let space1 = one_or_more_spaces(reader)?;
     let url = unquoted_template(reader)?;
     let line_terminator0 = line_terminator(reader)?;
-    let headers = zero_or_more(key_value, reader)?;
+    let headers = zero_or_more(header_key_value, reader)?;
     let sections = request_sections(reader)?;
     let body = optional(body, reader)?;
     let source_info = SourceInfo::new(start.pos, reader.cursor().pos);
@@ -87,7 +87,7 @@ fn response(reader: &mut Reader) -> ParseResult<Response> {
     let space1 = one_or_more_spaces(reader)?;
     let status = status(reader)?;
     let line_terminator0 = line_terminator(reader)?;
-    let headers = zero_or_more(key_value, reader)?;
+    let headers = zero_or_more(header_key_value, reader)?;
     let sections = response_sections(reader)?;
     let body = optional(body, reader)?;
     let source_info = SourceInfo::new(start.pos, reader.cursor().pos);

--- a/packages/hurl_core/src/parser/primitives.rs
+++ b/packages/hurl_core/src/parser/primitives.rs
@@ -794,6 +794,62 @@ mod tests {
     }
 
     #[test]
+    fn test_header_key_value_semicolon() {
+        let mut reader = Reader::new("Empty-Header;\n");
+        let kv = header_key_value(&mut reader).unwrap();
+        assert_eq!(kv.separator, KeyValueSeparator::Semicolon);
+        assert!(kv.value.elements.is_empty());
+        assert_eq!(
+            kv.key,
+            Template::new(
+                None,
+                vec![TemplateElement::String {
+                    value: "Empty-Header".to_string(),
+                    source: "Empty-Header".to_source(),
+                }],
+                SourceInfo::new(Pos::new(1, 1), Pos::new(1, 13)),
+            ),
+        );
+    }
+
+    #[test]
+    fn test_header_key_value_colon_empty() {
+        let mut reader = Reader::new("Authorization:\n");
+        let kv = header_key_value(&mut reader).unwrap();
+        assert_eq!(kv.separator, KeyValueSeparator::Colon);
+        assert!(kv.value.elements.is_empty());
+        assert_eq!(
+            kv.key,
+            Template::new(
+                None,
+                vec![TemplateElement::String {
+                    value: "Authorization".to_string(),
+                    source: "Authorization".to_source(),
+                }],
+                SourceInfo::new(Pos::new(1, 1), Pos::new(1, 14)),
+            ),
+        );
+    }
+
+    #[test]
+    fn test_header_key_value_colon_with_value() {
+        let mut reader = Reader::new("Content-Type: application/json\n");
+        let kv = header_key_value(&mut reader).unwrap();
+        assert_eq!(kv.separator, KeyValueSeparator::Colon);
+        assert_eq!(
+            kv.value,
+            Template::new(
+                None,
+                vec![TemplateElement::String {
+                    value: "application/json".to_string(),
+                    source: "application/json".to_source(),
+                }],
+                SourceInfo::new(Pos::new(1, 15), Pos::new(1, 31)),
+            ),
+        );
+    }
+
+    #[test]
     fn test_boolean() {
         let mut reader = Reader::new("true");
         assert!(boolean(&mut reader).unwrap());

--- a/packages/hurl_core/src/parser/primitives.rs
+++ b/packages/hurl_core/src/parser/primitives.rs
@@ -16,7 +16,8 @@
  *
  */
 use crate::ast::{
-    Base64, Comment, File, Hex, KeyValue, LineTerminator, Regex, SourceInfo, Whitespace,
+    Base64, Comment, File, Hex, KeyValue, KeyValueSeparator, LineTerminator, Regex, SourceInfo,
+    Template, Whitespace,
 };
 use crate::combinator::{one_or_more, optional, recover, zero_or_more};
 use crate::parser::string::unquoted_template;
@@ -204,6 +205,57 @@ pub fn key_value(reader: &mut Reader) -> ParseResult<KeyValue> {
         space0,
         key,
         space1,
+        separator: KeyValueSeparator::Colon,
+        space2,
+        value,
+        line_terminator0,
+    })
+}
+
+/// Parses a header key-value, supporting both colon and semicolon separators.
+/// - `Name: value` → normal header
+/// - `Name:` → unset header directive (removes this header)
+/// - `Name;` → header with empty value
+pub fn header_key_value(reader: &mut Reader) -> ParseResult<KeyValue> {
+    let line_terminators = optional_line_terminators(reader)?;
+    let space0 = zero_or_more_spaces(reader)?;
+    let key = recover(key_string::parse, reader)?;
+    let space1 = zero_or_more_spaces(reader)?;
+
+    // Try semicolon separator (empty-value header)
+    let save = reader.cursor();
+    if literal(";", reader).is_ok() {
+        let pos = reader.cursor().pos;
+        let space2 = Whitespace {
+            value: String::new(),
+            source_info: SourceInfo::new(pos, pos),
+        };
+        let value = Template::new(None, vec![], SourceInfo::new(pos, pos));
+        let line_terminator0 = line_terminator(reader)?;
+        return Ok(KeyValue {
+            line_terminators,
+            space0,
+            key,
+            space1,
+            separator: KeyValueSeparator::Semicolon,
+            space2,
+            value,
+            line_terminator0,
+        });
+    }
+    reader.seek(save);
+
+    // Colon separator (normal or unset header)
+    recover(|reader1| literal(":", reader1), reader)?;
+    let space2 = zero_or_more_spaces(reader)?;
+    let value = unquoted_template(reader)?;
+    let line_terminator0 = line_terminator(reader)?;
+    Ok(KeyValue {
+        line_terminators,
+        space0,
+        key,
+        space1,
+        separator: KeyValueSeparator::Colon,
         space2,
         value,
         line_terminator0,
@@ -607,6 +659,7 @@ mod tests {
                     value: String::new(),
                     source_info: SourceInfo::new(Pos::new(1, 8), Pos::new(1, 8)),
                 },
+                separator: KeyValueSeparator::Colon,
                 space2: Whitespace {
                     value: " ".to_string(),
                     source_info: SourceInfo::new(Pos::new(1, 9), Pos::new(1, 10)),
@@ -696,6 +749,7 @@ mod tests {
                     value: String::new(),
                     source_info: SourceInfo::new(Pos::new(1, 8), Pos::new(1, 8)),
                 },
+                separator: KeyValueSeparator::Colon,
                 space2: Whitespace {
                     value: " ".to_string(),
                     source_info: SourceInfo::new(Pos::new(1, 9), Pos::new(1, 10)),

--- a/packages/hurl_core/src/parser/sections.rs
+++ b/packages/hurl_core/src/parser/sections.rs
@@ -326,8 +326,8 @@ fn assert(reader: &mut Reader) -> ParseResult<Assert> {
 mod tests {
     use super::*;
     use crate::ast::{
-        KeyValue, LineTerminator, Number, Predicate, PredicateFunc, PredicateFuncValue,
-        PredicateValue, Query, QueryValue, Template, TemplateElement, I64,
+        KeyValue, KeyValueSeparator, LineTerminator, Number, Predicate, PredicateFunc,
+        PredicateFuncValue, PredicateValue, Query, QueryValue, Template, TemplateElement, I64,
     };
     use crate::reader::CharPos;
     use crate::types::ToSource;
@@ -922,6 +922,7 @@ mod tests {
                         value: String::new(),
                         source_info: SourceInfo::new(Pos::new(2, 5), Pos::new(2, 5))
                     },
+                    separator: KeyValueSeparator::Colon,
                     space2: Whitespace {
                         value: String::new(),
                         source_info: SourceInfo::new(Pos::new(2, 6), Pos::new(2, 6))

--- a/packages/hurlfmt/src/curl/mod.rs
+++ b/packages/hurlfmt/src/curl/mod.rs
@@ -108,7 +108,7 @@ fn format(
     let mut s = format!("{method} {url}");
     for header in headers {
         if let Some(stripped) = header.strip_suffix(";") {
-            s.push_str(format!("\n{stripped}:").as_str());
+            s.push_str(format!("\n{stripped};").as_str());
         } else {
             s.push_str(format!("\n{header}").as_str());
         }
@@ -230,7 +230,7 @@ Test: '
     #[test]
     fn test_empty_headers() {
         let hurl_str = r#"GET http://localhost:8000/empty-headers
-Empty-Header:
+Empty-Header;
 "#;
         assert_eq!(
             parse_line("curl http://localhost:8000/empty-headers -H 'Empty-Header;'").unwrap(),

--- a/packages/hurlfmt/src/format/json.rs
+++ b/packages/hurlfmt/src/format/json.rs
@@ -739,8 +739,8 @@ impl ToJson for NaturalOption {
 #[cfg(test)]
 pub mod tests {
     use hurl_core::ast::{
-        LineTerminator, Method, Number, PredicateFunc, SourceInfo, Status, Template,
-        TemplateElement, Version, Whitespace, I64,
+        KeyValueSeparator, LineTerminator, Method, Number, PredicateFunc, SourceInfo, Status,
+        Template, TemplateElement, Version, Whitespace, I64,
     };
     use hurl_core::reader::Pos;
     use hurl_core::types::ToSource;
@@ -791,6 +791,7 @@ pub mod tests {
                         SourceInfo::new(Pos::new(0, 0), Pos::new(0, 0))
                     ),
                     space1: whitespace(),
+                    separator: KeyValueSeparator::Colon,
                     space2: whitespace(),
                     value: Template::new(
                         None,

--- a/packages/hurlfmt/src/linter/rewrite.rs
+++ b/packages/hurlfmt/src/linter/rewrite.rs
@@ -18,11 +18,11 @@
 use hurl_core::ast::{
     Assert, Base64, Body, BooleanOption, Bytes, Capture, CertificateAttributeName, Comment, Cookie,
     CookiePath, CountOption, Duration, DurationOption, Entry, EntryOption, File, FilenameParam,
-    FilenameValue, FilterValue, Hex, HurlFile, IntegerValue, JsonValue, KeyValue, LineTerminator,
-    Method, MultilineString, MultipartParam, NaturalOption, Number, OptionKind, Placeholder,
-    Predicate, PredicateFuncValue, PredicateValue, Query, QueryValue, Regex, RegexValue, Request,
-    Response, Section, SectionValue, StatusValue, Template, VariableDefinition, VariableValue,
-    VerbosityOption, VersionValue, I64, U64,
+    FilenameValue, FilterValue, Hex, HurlFile, IntegerValue, JsonValue, KeyValue,
+    KeyValueSeparator, LineTerminator, Method, MultilineString, MultipartParam, NaturalOption,
+    Number, OptionKind, Placeholder, Predicate, PredicateFuncValue, PredicateValue, Query,
+    QueryValue, Regex, RegexValue, Request, Response, Section, SectionValue, StatusValue, Template,
+    VariableDefinition, VariableValue, VerbosityOption, VersionValue, I64, U64,
 };
 use hurl_core::types::{Count, DurationUnit, ToSource};
 
@@ -385,7 +385,10 @@ impl Lint for KeyValue {
             .iter()
             .for_each(|lt| s.push_str(&lint_lt(lt, false)));
         s.push_str(&self.key.lint());
-        s.push(':');
+        match self.separator {
+            KeyValueSeparator::Colon => s.push(':'),
+            KeyValueSeparator::Semicolon => s.push(';'),
+        }
         if !self.value.is_empty() {
             s.push(' ');
             s.push_str(&self.value.lint());

--- a/packages/hurlfmt/src/linter/rules.rs
+++ b/packages/hurlfmt/src/linter/rules.rs
@@ -18,7 +18,8 @@
 use hurl_core::ast::{
     Assert, Base64, Body, Bytes, Capture, Comment, Cookie, CookieAttribute, CookieAttributeName,
     CookiePath, DurationOption, Entry, EntryOption, File, FilenameParam, Filter, FilterValue,
-    GraphQl, Hex, HurlFile, KeyValue, LineTerminator, MultilineString, MultilineStringAttribute,
+    GraphQl, Hex, HurlFile, KeyValue, KeyValueSeparator, LineTerminator, MultilineString,
+    MultilineStringAttribute,
     MultilineStringKind, MultipartParam, OptionKind, Predicate, PredicateFunc, PredicateFuncValue,
     PredicateValue, Query, QueryValue, RegexValue, Request, Response, Section, SectionValue,
     SourceInfo, Template, VariableDefinition, Whitespace,
@@ -508,6 +509,7 @@ fn lint_key_value(key_value: &KeyValue) -> KeyValue {
         space0: empty_whitespace(),
         key: key_value.key.clone(),
         space1: empty_whitespace(),
+        separator: key_value.separator,
         space2: if key_value.value.elements.is_empty() {
             empty_whitespace()
         } else {


### PR DESCRIPTION
Adds two new header behaviors following curl's `-H` conventions:

1. `Header-Name:` (colon with no value) unsets the header, removing it from the request even if set via `--header` on the CLI. Curl gets `Header-Name:` which also strips its implicit headers like `Host` or `User-Agent` if needed.

2. `Header-Name;` (semicolon) sends the header with an empty value. This replaces the old `Header-Name:` behavior for empty-value headers.

The implementation adds a `KeyValueSeparator` enum (Colon/Semicolon) to `KeyValue` in the AST, a `header_key_value()` parser that handles both syntaxes, and an `unset_headers` field on `RequestSpec` that the HTTP client uses to filter out matching headers before sending.

This is a breaking change: existing `.hurl` files using `Header-Name:` to send empty-value headers need to switch to `Header-Name;`.

**What's included:**
- AST: `KeyValueSeparator` enum on `KeyValue`
- Parser: `header_key_value()` with semicolon support + unit tests
- Runner: separates unset directives from normal headers in `eval_request()`
- HTTP client: applies unset logic after merging request + CLI headers
- curl_cmd: emits `Name:` format for unset headers
- Integration tests for both unset and empty-value scenarios