### PR TITLE
Update from Rust 2021 to Rust 2024

### DIFF
--- a/packages/hurl/Cargo.toml
+++ b/packages/hurl/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hurl"
 version = "8.0.0-SNAPSHOT"
 authors = ["Fabrice Reix <fabrice.reix@orange.com>", "Jean-Christophe Amiel <jeanchristophe.amiel@orange.com>", "Filipe Pinto <filipe.pinto@orange.com>"]
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 description = "Hurl, run and test HTTP requests"
 documentation = "https://hurl.dev"

--- a/packages/hurl/src/cli/options/args.rs
+++ b/packages/hurl/src/cli/options/args.rs
@@ -21,9 +21,9 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::time::Duration;
 
-use clap::builder::styling::{AnsiColor, Effects};
-use clap::builder::Styles;
 use clap::ArgMatches;
+use clap::builder::Styles;
+use clap::builder::styling::{AnsiColor, Effects};
 use hurl::pretty::PrettyMode;
 use hurl::runner::Value;
 use hurl_core::input::Input;
@@ -32,8 +32,8 @@ use hurl_core::types::{BytesPerSec, Count, DurationUnit};
 use super::context::RunContext;
 use super::variables::TypeKind;
 use super::variables_file::VariablesFile;
-use super::{commands, duration, get_version, secret, CliOptions};
-use super::{variables, CliOptionsError, ErrorFormat, HttpVersion, IpResolve, Output};
+use super::{CliOptions, commands, duration, get_version, secret};
+use super::{CliOptionsError, ErrorFormat, HttpVersion, IpResolve, Output, variables};
 use super::{OutputType, Verbosity};
 
 /// Parses the command line arguments given a `context` and default options values.
@@ -142,7 +142,7 @@ pub fn parse_cli_args(
             return Err(CliOptionsError::from_clap(
                 error,
                 default_options.color_stdout,
-            ))
+            ));
         }
     };
 
@@ -981,7 +981,7 @@ fn glob_files(matches: &ArgMatches) -> Result<Vec<Input>, CliOptionsError> {
                 Err(_) => {
                     return Err(CliOptionsError::Error(
                         "Failed to read glob pattern".to_string(),
-                    ))
+                    ));
                 }
             };
             let mut files = vec![];
@@ -991,7 +991,7 @@ fn glob_files(matches: &ArgMatches) -> Result<Vec<Input>, CliOptionsError> {
                     Err(_) => {
                         return Err(CliOptionsError::Error(
                             "Failed to read glob pattern".to_string(),
-                        ))
+                        ));
                     }
                 }
             }

--- a/packages/hurl/src/cli/options/config_file.rs
+++ b/packages/hurl/src/cli/options/config_file.rs
@@ -51,25 +51,25 @@ pub fn parse_config_file(
     config_file_path: Option<&Path>,
     default_options: CliOptions,
 ) -> Result<CliOptions, CliOptionsError> {
-    if let Some(config_file_path) = config_file_path {
-        if config_file_path.exists() {
-            let content = std::fs::read_to_string(config_file_path).map_err(|e| {
-                CliOptionsError::Error(format!(
-                    "Failed to read config file {}: {}",
-                    config_file_path.display(),
-                    e
-                ))
-            })?;
-            return parse_config(&content, default_options).map_err(|e| {
-                CliOptionsError::Error(format!(
-                    "{}:{}:{}: {}",
-                    config_file_path.display(),
-                    e.pos().line,
-                    e.pos().column,
-                    e.message
-                ))
-            });
-        }
+    if let Some(config_file_path) = config_file_path
+        && config_file_path.exists()
+    {
+        let content = std::fs::read_to_string(config_file_path).map_err(|e| {
+            CliOptionsError::Error(format!(
+                "Failed to read config file {}: {}",
+                config_file_path.display(),
+                e
+            ))
+        })?;
+        return parse_config(&content, default_options).map_err(|e| {
+            CliOptionsError::Error(format!(
+                "{}:{}:{}: {}",
+                config_file_path.display(),
+                e.pos().line,
+                e.pos().column,
+                e.message
+            ))
+        });
     }
     Ok(default_options)
 }

--- a/packages/hurl/src/cli/options/context.rs
+++ b/packages/hurl/src/cli/options/context.rs
@@ -314,11 +314,7 @@ impl RunContext {
             // According to the NO_COLOR spec, any presence of the variable should disable color, but to
             // maintain backward compatibility with code < 7.1.0, we check that the NO_COLOR env is at
             // least not empty.
-            if !v.is_empty() {
-                Some(true)
-            } else {
-                None
-            }
+            if !v.is_empty() { Some(true) } else { None }
         } else {
             self.get_env_var_bool(HURL_NO_COLOR)
         }

--- a/packages/hurl/src/cli/options/env_vars.rs
+++ b/packages/hurl/src/cli/options/env_vars.rs
@@ -31,8 +31,8 @@ use super::context::{
 };
 use super::variables::TypeKind;
 use super::{
-    duration, secret, variables, CliOptions, CliOptionsError, ErrorFormat, HttpVersion, IpResolve,
-    OutputType, RunContext, Verbosity,
+    CliOptions, CliOptionsError, ErrorFormat, HttpVersion, IpResolve, OutputType, RunContext,
+    Verbosity, duration, secret, variables,
 };
 
 fn compressed(context: &RunContext, default_value: bool) -> bool {
@@ -262,11 +262,13 @@ fn pretty(context: &RunContext, default_value: PrettyMode) -> PrettyMode {
 
 fn progress_bar(context: &RunContext, default_value: bool) -> bool {
     // The progress bar is automatically displayed for test mode when stderr is a TTY and not running in CI.
-    if let Some(true) = context.test_env_var() {
-        if context.is_stderr_term() && !context.is_ci_env_var() {
-            return true;
-        }
+    if let Some(true) = context.test_env_var()
+        && context.is_stderr_term()
+        && !context.is_ci_env_var()
+    {
+        return true;
     }
+
     default_value
 }
 
@@ -471,7 +473,7 @@ fn err_from_cli_err(error: CliOptionsError, env: &'static str) -> CliOptionsErro
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_env_vars, CliOptions, RunContext};
+    use super::{CliOptions, RunContext, parse_env_vars};
     use hurl::runner::{Number, Value};
     use std::collections::HashMap;
 

--- a/packages/hurl/src/cli/options/mod.rs
+++ b/packages/hurl/src/cli/options/mod.rs
@@ -41,8 +41,8 @@ use hurl::util::path::ContextDir;
 use hurl_core::input::{Input, InputKind};
 use hurl_core::types::{BytesPerSec, Count};
 
-pub use crate::cli::options::context::RunContext;
 use crate::cli::CliError;
+pub use crate::cli::options::context::RunContext;
 use crate::runner::{RunnerOptions, RunnerOptionsBuilder, Value};
 pub use error::CliOptionsError;
 

--- a/packages/hurl/src/cli/options/variables_file.rs
+++ b/packages/hurl/src/cli/options/variables_file.rs
@@ -16,7 +16,7 @@
  *
  */
 use crate::cli::options::variables::TypeKind;
-use crate::cli::options::{variables, CliOptionsError};
+use crate::cli::options::{CliOptionsError, variables};
 use hurl::runner::Value;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Lines};

--- a/packages/hurl/src/http/client.rs
+++ b/packages/hurl/src/http/client.rs
@@ -20,11 +20,11 @@ use std::str;
 use std::str::FromStr;
 use std::time::Instant;
 
-use base64::engine::general_purpose;
 use base64::Engine;
+use base64::engine::general_purpose;
 use chrono::Utc;
 use curl::easy::{List, NetRc, SslOpt};
-use curl::{easy, Error, Version};
+use curl::{Error, Version, easy};
 use hurl_core::types::Count;
 
 use super::call::Call;
@@ -35,7 +35,7 @@ use super::debug;
 use super::easy_ext;
 use super::error::HttpError;
 use super::header::{
-    Header, HeaderVec, ACCEPT_ENCODING, AUTHORIZATION, CONTENT_TYPE, COOKIE, EXPECT, LOCATION,
+    ACCEPT_ENCODING, AUTHORIZATION, CONTENT_TYPE, COOKIE, EXPECT, Header, HeaderVec, LOCATION,
     USER_AGENT,
 };
 use super::ip::IpAddr;
@@ -118,10 +118,10 @@ impl Client {
             logger.debug(&format!("=> Redirect to {redirect_url}"));
             logger.debug("");
             redirect_count += 1;
-            if let Count::Finite(max_redirect) = options.max_redirect {
-                if redirect_count > max_redirect {
-                    return Err(HttpError::TooManyRedirect);
-                }
+            if let Count::Finite(max_redirect) = options.max_redirect
+                && redirect_count > max_redirect
+            {
+                return Err(HttpError::TooManyRedirect);
             };
 
             let redirect_method = redirect_method(status, &request_spec.method);
@@ -296,10 +296,10 @@ impl Client {
         // - <https://curl.se/docs/manpage.html#--max-filesize>
         // > Note: before curl 8.4.0, when the file size is not known prior to download, for such files
         // > this option has no effect even if the file transfer ends up being larger than this given limit.
-        if let Some(max_filesize) = options.max_filesize {
-            if response_body.len() as u64 > max_filesize {
-                return Err(HttpError::AllowedResponseSizeExceeded(max_filesize));
-            }
+        if let Some(max_filesize) = options.max_filesize
+            && response_body.len() as u64 > max_filesize
+        {
+            return Err(HttpError::AllowedResponseSizeExceeded(max_filesize));
         }
 
         let status = self.handle.response_code()?;
@@ -516,16 +516,16 @@ impl Client {
             request_spec.implicit_content_type.as_deref(),
             options,
         )?;
-        if let Some(aws_sigv4) = &options.aws_sigv4 {
-            if let Err(e) = self.handle.aws_sigv4(aws_sigv4.as_str()) {
-                return match e.code() {
-                    curl_sys::CURLE_UNKNOWN_OPTION => Err(HttpError::LibcurlUnknownOption {
-                        option: "aws-sigv4".to_string(),
-                        minimum_version: "7.75.0".to_string(),
-                    }),
-                    _ => Err(e.into()),
-                };
-            }
+        if let Some(aws_sigv4) = &options.aws_sigv4
+            && let Err(e) = self.handle.aws_sigv4(aws_sigv4.as_str())
+        {
+            return match e.code() {
+                curl_sys::CURLE_UNKNOWN_OPTION => Err(HttpError::LibcurlUnknownOption {
+                    option: "aws-sigv4".to_string(),
+                    minimum_version: "7.75.0".to_string(),
+                }),
+                _ => Err(e.into()),
+            };
         }
         if *method == Method("HEAD".to_string()) {
             self.handle.nobody(true)?;

--- a/packages/hurl/src/http/cookie_store.rs
+++ b/packages/hurl/src/http/cookie_store.rs
@@ -496,6 +496,9 @@ mod tests {
                 "#HttpOnly_example.com\t\t   FALSE\t\t  \t/\tFALSE\t1\tcookie2\tfoo bar baz",
             )
             .unwrap();
-        assert_eq!(cookie_store.to_netscape(), "localhost\tTRUE\t/\tFALSE\t0\tcookie1\tvalueA\n#HttpOnly_example.com\tFALSE\t/\tFALSE\t1\tcookie2\tfoo bar baz\n");
+        assert_eq!(
+            cookie_store.to_netscape(),
+            "localhost\tTRUE\t/\tFALSE\t0\tcookie1\tvalueA\n#HttpOnly_example.com\tFALSE\t/\tFALSE\t1\tcookie2\tfoo bar baz\n"
+        );
     }
 }

--- a/packages/hurl/src/http/curl_cmd.rs
+++ b/packages/hurl/src/http/curl_cmd.rs
@@ -25,7 +25,7 @@ use crate::runner::Output;
 use crate::util::path::ContextDir;
 
 use super::cookie_store::CookieStore;
-use super::header::{Header, HeaderVec, CONTENT_TYPE};
+use super::header::{CONTENT_TYPE, Header, HeaderVec};
 use super::options::ClientOptions;
 use super::param::Param;
 use super::request::{CredentialForwarding, FollowLocation, IpResolve, RequestedHttpVersion};

--- a/packages/hurl/src/http/debug.rs
+++ b/packages/hurl/src/http/debug.rs
@@ -29,11 +29,11 @@ use super::mimetype;
 /// If `debug` is true, logs are printed using debug (with * prefix), otherwise logs are printed
 /// in info.
 pub fn log_body(body: &[u8], headers: &HeaderVec, debug: bool, logger: &mut Logger) {
-    if let Some(content_type) = headers.content_type() {
-        if !mimetype::is_kind_of_text(content_type) {
-            log_bytes(body, 64, debug, logger);
-            return;
-        }
+    if let Some(content_type) = headers.content_type()
+        && !mimetype::is_kind_of_text(content_type)
+    {
+        log_bytes(body, 64, debug, logger);
+        return;
     }
     // Decode body as text:
     let encoding = match headers.character_encoding() {

--- a/packages/hurl/src/http/easy_ext.rs
+++ b/packages/hurl/src/http/easy_ext.rs
@@ -19,9 +19,9 @@ use std::ffi::{CStr, CString};
 use std::ptr;
 use std::time::Duration;
 
-use curl::easy::Easy;
 use curl::Error;
-use curl_sys::{curl_certinfo, curl_off_t, curl_slist, CURLINFO, CURLOPT_NETRC_FILE};
+use curl::easy::Easy;
+use curl_sys::{CURLINFO, CURLOPT_NETRC_FILE, curl_certinfo, curl_off_t, curl_slist};
 
 /// Some definitions not present in curl-sys
 const CURLINFO_OFF_T: CURLINFO = 0x600000;

--- a/packages/hurl/src/http/header.rs
+++ b/packages/hurl/src/http/header.rs
@@ -155,8 +155,8 @@ impl<'a> Extend<&'a Header> for HeaderVec {
 
 #[cfg(test)]
 mod tests {
-    use crate::http::header::HeaderVec;
     use crate::http::Header;
+    use crate::http::header::HeaderVec;
 
     #[test]
     fn test_simple_header_map() {

--- a/packages/hurl/src/http/headers_helper.rs
+++ b/packages/hurl/src/http/headers_helper.rs
@@ -18,7 +18,7 @@
 use encoding_rs::Encoding;
 
 use super::error::HttpError;
-use super::header::{HeaderVec, CONTENT_ENCODING, CONTENT_TYPE};
+use super::header::{CONTENT_ENCODING, CONTENT_TYPE, HeaderVec};
 use super::mimetype;
 use super::response_decoding::ContentEncoding;
 

--- a/packages/hurl/src/http/mod.rs
+++ b/packages/hurl/src/http/mod.rs
@@ -26,7 +26,7 @@ pub use self::cookie_store::{Cookie, CookieStore};
 pub use self::curl_cmd::CurlCmd;
 pub(crate) use self::error::HttpError;
 pub use self::header::{
-    Header, HeaderVec, ACCEPT_ENCODING, AUTHORIZATION, CONTENT_TYPE, COOKIE, EXPECT, USER_AGENT,
+    ACCEPT_ENCODING, AUTHORIZATION, CONTENT_TYPE, COOKIE, EXPECT, Header, HeaderVec, USER_AGENT,
 };
 pub(crate) use self::options::{ClientOptions, Verbosity};
 pub(crate) use self::param::Param;

--- a/packages/hurl/src/http/request.rs
+++ b/packages/hurl/src/http/request.rs
@@ -17,7 +17,7 @@
  */
 use std::fmt;
 
-use super::header::{HeaderVec, COOKIE};
+use super::header::{COOKIE, HeaderVec};
 use super::request_cookie::RequestCookie;
 use super::url::Url;
 

--- a/packages/hurl/src/http/response_cookie.rs
+++ b/packages/hurl/src/http/response_cookie.rs
@@ -134,12 +134,11 @@ impl ResponseCookie {
     /// Converts a cookie attribute value named `name` into an integer.
     fn attr_as_i64(&self, name: &str) -> Option<i64> {
         for attr in &self.attributes {
-            if attr.name.to_lowercase() == name.to_lowercase() {
-                if let Some(v) = &attr.value {
-                    if let Ok(v2) = v.as_str().parse::<i64>() {
-                        return Some(v2);
-                    }
-                }
+            if attr.name.to_lowercase() == name.to_lowercase()
+                && let Some(v) = &attr.value
+                && let Ok(v2) = v.as_str().parse::<i64>()
+            {
+                return Some(v2);
             }
         }
         None

--- a/packages/hurl/src/http/response_debug.rs
+++ b/packages/hurl/src/http/response_debug.rs
@@ -29,12 +29,13 @@ impl Response {
         // We try to decode the HTTP body as text if the response has a text kind content type.
         // If it ok, we print each line of the body in debug format. Otherwise, we
         // print the body first 64 bytes.
-        if let Some(content_type) = self.headers.content_type() {
-            if !mimetype::is_kind_of_text(content_type) {
-                debug::log_bytes(&self.body, 64, debug, logger);
-                return;
-            }
+        if let Some(content_type) = self.headers.content_type()
+            && !mimetype::is_kind_of_text(content_type)
+        {
+            debug::log_bytes(&self.body, 64, debug, logger);
+            return;
         }
+
         match self.text() {
             Ok(text) => debug::log_text(&text, debug, logger),
             Err(_) => debug::log_bytes(&self.body, 64, debug, logger),

--- a/packages/hurl/src/http/response_decoding.rs
+++ b/packages/hurl/src/http/response_decoding.rs
@@ -127,7 +127,7 @@ fn uncompress_gzip(data: &[u8]) -> Result<Vec<u8>, HttpError> {
         Err(_) => {
             return Err(HttpError::CouldNotUncompressResponse {
                 description: "gzip".to_string(),
-            })
+            });
         }
     };
     let mut buf = Vec::new();
@@ -146,7 +146,7 @@ fn uncompress_zlib(data: &[u8]) -> Result<Vec<u8>, HttpError> {
         Err(_) => {
             return Err(HttpError::CouldNotUncompressResponse {
                 description: "zlib".to_string(),
-            })
+            });
         }
     };
     let mut buf = Vec::new();

--- a/packages/hurl/src/http/url.rs
+++ b/packages/hurl/src/http/url.rs
@@ -213,7 +213,7 @@ impl From<UrlError> for HttpError {
 mod tests {
     use std::str::FromStr;
 
-    use super::{try_scheme, Url, UrlError};
+    use super::{Url, UrlError, try_scheme};
     use crate::http::Param;
 
     #[test]
@@ -224,7 +224,7 @@ mod tests {
             "http://localhost:8000/cookies",
             "http://localhost",
             "https://localhost:8000",
-            "http://localhost:8000/path-as-is/../resource"
+            "http://localhost:8000/path-as-is/../resource",
         ];
         for url in urls {
             assert!(Url::from_str(url).is_ok());

--- a/packages/hurl/src/http/version.rs
+++ b/packages/hurl/src/http/version.rs
@@ -51,10 +51,10 @@ pub fn libcurl_version_info() -> CurlVersionInfo {
     if let Some(s) = version.libidn_version() {
         libraries.push(format!("libidn2/{s}"));
     }
-    if let Some(s) = version.iconv_version_num() {
-        if s != 0 {
-            libraries.push(format!("iconv/{s}"));
-        }
+    if let Some(s) = version.iconv_version_num()
+        && s != 0
+    {
+        libraries.push(format!("iconv/{s}"));
     }
     if let Some(s) = version.libssh_version() {
         libraries.push(s.to_string());

--- a/packages/hurl/src/json/value.rs
+++ b/packages/hurl/src/json/value.rs
@@ -17,8 +17,8 @@
  */
 use std::str::FromStr;
 
-use base64::engine::general_purpose;
 use base64::Engine;
+use base64::engine::general_purpose;
 
 use crate::runner::{Number, Value};
 use crate::util::redacted::Redact;

--- a/packages/hurl/src/jsonpath/eval/comparison.rs
+++ b/packages/hurl/src/jsonpath/eval/comparison.rs
@@ -139,228 +139,284 @@ mod tests {
           "arr": [2, 3]
         });
         // Empty nodelists
-        assert!(ComparisonExpr::new(
-            Comparable::SingularQuery(name_query("absent1")),
-            Comparable::SingularQuery(name_query("absent2")),
-            ComparisonOp::Equal
-        )
-        .eval(current_value, &root_value));
+        assert!(
+            ComparisonExpr::new(
+                Comparable::SingularQuery(name_query("absent1")),
+                Comparable::SingularQuery(name_query("absent2")),
+                ComparisonOp::Equal
+            )
+            .eval(current_value, &root_value)
+        );
 
         // == implies <=
-        assert!(ComparisonExpr::new(
-            Comparable::SingularQuery(name_query("absent1")),
-            Comparable::SingularQuery(name_query("absent2")),
-            ComparisonOp::LessOrEqual
-        )
-        .eval(current_value, &root_value));
+        assert!(
+            ComparisonExpr::new(
+                Comparable::SingularQuery(name_query("absent1")),
+                Comparable::SingularQuery(name_query("absent2")),
+                ComparisonOp::LessOrEqual
+            )
+            .eval(current_value, &root_value)
+        );
 
         // Empty nodelist
-        assert!(!ComparisonExpr::new(
-            Comparable::SingularQuery(name_query("absent")),
-            Comparable::Literal(Literal::String("g".to_string())),
-            ComparisonOp::Equal
-        )
-        .eval(current_value, &root_value));
+        assert!(
+            !ComparisonExpr::new(
+                Comparable::SingularQuery(name_query("absent")),
+                Comparable::Literal(Literal::String("g".to_string())),
+                ComparisonOp::Equal
+            )
+            .eval(current_value, &root_value)
+        );
 
         // Empty nodelists
-        assert!(!ComparisonExpr::new(
-            Comparable::SingularQuery(name_query("absent1")),
-            Comparable::SingularQuery(name_query("absent2")),
-            ComparisonOp::NotEqual
-        )
-        .eval(current_value, &root_value));
+        assert!(
+            !ComparisonExpr::new(
+                Comparable::SingularQuery(name_query("absent1")),
+                Comparable::SingularQuery(name_query("absent2")),
+                ComparisonOp::NotEqual
+            )
+            .eval(current_value, &root_value)
+        );
 
         // Empty nodelist
-        assert!(ComparisonExpr::new(
-            Comparable::SingularQuery(name_query("absent")),
-            Comparable::Literal(Literal::String("g".to_string())),
-            ComparisonOp::NotEqual
-        )
-        .eval(current_value, &root_value));
+        assert!(
+            ComparisonExpr::new(
+                Comparable::SingularQuery(name_query("absent")),
+                Comparable::Literal(Literal::String("g".to_string())),
+                ComparisonOp::NotEqual
+            )
+            .eval(current_value, &root_value)
+        );
 
         // Numeric comparison
-        assert!(ComparisonExpr::new(
-            Comparable::Literal(Literal::Number(Number::Integer(1))),
-            Comparable::Literal(Literal::Number(Number::Integer(2))),
-            ComparisonOp::LessOrEqual
-        )
-        .eval(current_value, &root_value));
+        assert!(
+            ComparisonExpr::new(
+                Comparable::Literal(Literal::Number(Number::Integer(1))),
+                Comparable::Literal(Literal::Number(Number::Integer(2))),
+                ComparisonOp::LessOrEqual
+            )
+            .eval(current_value, &root_value)
+        );
 
         // Numeric comparison
-        assert!(!ComparisonExpr::new(
-            Comparable::Literal(Literal::Number(Number::Integer(1))),
-            Comparable::Literal(Literal::Number(Number::Integer(2))),
-            ComparisonOp::Greater
-        )
-        .eval(current_value, &root_value));
+        assert!(
+            !ComparisonExpr::new(
+                Comparable::Literal(Literal::Number(Number::Integer(1))),
+                Comparable::Literal(Literal::Number(Number::Integer(2))),
+                ComparisonOp::Greater
+            )
+            .eval(current_value, &root_value)
+        );
 
         // Type mismatch
-        assert!(!ComparisonExpr::new(
-            Comparable::Literal(Literal::Number(Number::Integer(13))),
-            Comparable::Literal(Literal::String("13".to_string())),
-            ComparisonOp::Equal
-        )
-        .eval(current_value, &root_value));
+        assert!(
+            !ComparisonExpr::new(
+                Comparable::Literal(Literal::Number(Number::Integer(13))),
+                Comparable::Literal(Literal::String("13".to_string())),
+                ComparisonOp::Equal
+            )
+            .eval(current_value, &root_value)
+        );
 
         // String comparison
-        assert!(ComparisonExpr::new(
-            Comparable::Literal(Literal::String("a".to_string())),
-            Comparable::Literal(Literal::String("b".to_string())),
-            ComparisonOp::LessOrEqual
-        )
-        .eval(current_value, &root_value));
+        assert!(
+            ComparisonExpr::new(
+                Comparable::Literal(Literal::String("a".to_string())),
+                Comparable::Literal(Literal::String("b".to_string())),
+                ComparisonOp::LessOrEqual
+            )
+            .eval(current_value, &root_value)
+        );
 
         // String comparison
-        assert!(!ComparisonExpr::new(
-            Comparable::Literal(Literal::String("a".to_string())),
-            Comparable::Literal(Literal::String("b".to_string())),
-            ComparisonOp::Greater
-        )
-        .eval(current_value, &root_value));
+        assert!(
+            !ComparisonExpr::new(
+                Comparable::Literal(Literal::String("a".to_string())),
+                Comparable::Literal(Literal::String("b".to_string())),
+                ComparisonOp::Greater
+            )
+            .eval(current_value, &root_value)
+        );
 
         // Type mismatch
-        assert!(!ComparisonExpr::new(
-            Comparable::SingularQuery(name_query("obj")),
-            Comparable::SingularQuery(name_query("arr")),
-            ComparisonOp::Equal
-        )
-        .eval(current_value, &root_value));
+        assert!(
+            !ComparisonExpr::new(
+                Comparable::SingularQuery(name_query("obj")),
+                Comparable::SingularQuery(name_query("arr")),
+                ComparisonOp::Equal
+            )
+            .eval(current_value, &root_value)
+        );
 
         // Type mismatch
-        assert!(ComparisonExpr::new(
-            Comparable::SingularQuery(name_query("obj")),
-            Comparable::SingularQuery(name_query("arr")),
-            ComparisonOp::NotEqual
-        )
-        .eval(current_value, &root_value));
+        assert!(
+            ComparisonExpr::new(
+                Comparable::SingularQuery(name_query("obj")),
+                Comparable::SingularQuery(name_query("arr")),
+                ComparisonOp::NotEqual
+            )
+            .eval(current_value, &root_value)
+        );
 
         // Object comparison
-        assert!(ComparisonExpr::new(
-            Comparable::SingularQuery(name_query("obj")),
-            Comparable::SingularQuery(name_query("obj")),
-            ComparisonOp::Equal
-        )
-        .eval(current_value, &root_value));
+        assert!(
+            ComparisonExpr::new(
+                Comparable::SingularQuery(name_query("obj")),
+                Comparable::SingularQuery(name_query("obj")),
+                ComparisonOp::Equal
+            )
+            .eval(current_value, &root_value)
+        );
 
         // Object comparison
-        assert!(!ComparisonExpr::new(
-            Comparable::SingularQuery(name_query("obj")),
-            Comparable::SingularQuery(name_query("obj")),
-            ComparisonOp::NotEqual
-        )
-        .eval(current_value, &root_value));
+        assert!(
+            !ComparisonExpr::new(
+                Comparable::SingularQuery(name_query("obj")),
+                Comparable::SingularQuery(name_query("obj")),
+                ComparisonOp::NotEqual
+            )
+            .eval(current_value, &root_value)
+        );
 
         // Array comparison
-        assert!(ComparisonExpr::new(
-            Comparable::SingularQuery(name_query("arr")),
-            Comparable::SingularQuery(name_query("arr")),
-            ComparisonOp::Equal
-        )
-        .eval(current_value, &root_value));
+        assert!(
+            ComparisonExpr::new(
+                Comparable::SingularQuery(name_query("arr")),
+                Comparable::SingularQuery(name_query("arr")),
+                ComparisonOp::Equal
+            )
+            .eval(current_value, &root_value)
+        );
 
         // Array comparison
-        assert!(!ComparisonExpr::new(
-            Comparable::SingularQuery(name_query("arr")),
-            Comparable::SingularQuery(name_query("arr")),
-            ComparisonOp::NotEqual
-        )
-        .eval(current_value, &root_value));
+        assert!(
+            !ComparisonExpr::new(
+                Comparable::SingularQuery(name_query("arr")),
+                Comparable::SingularQuery(name_query("arr")),
+                ComparisonOp::NotEqual
+            )
+            .eval(current_value, &root_value)
+        );
 
         // Type mismatch
-        assert!(!ComparisonExpr::new(
-            Comparable::SingularQuery(name_query("obj")),
-            Comparable::Literal(Literal::Number(Number::Integer(17))),
-            ComparisonOp::Equal
-        )
-        .eval(current_value, &root_value));
+        assert!(
+            !ComparisonExpr::new(
+                Comparable::SingularQuery(name_query("obj")),
+                Comparable::Literal(Literal::Number(Number::Integer(17))),
+                ComparisonOp::Equal
+            )
+            .eval(current_value, &root_value)
+        );
 
         // Type mismatch
-        assert!(ComparisonExpr::new(
-            Comparable::SingularQuery(name_query("obj")),
-            Comparable::Literal(Literal::Number(Number::Integer(17))),
-            ComparisonOp::NotEqual
-        )
-        .eval(current_value, &root_value));
+        assert!(
+            ComparisonExpr::new(
+                Comparable::SingularQuery(name_query("obj")),
+                Comparable::Literal(Literal::Number(Number::Integer(17))),
+                ComparisonOp::NotEqual
+            )
+            .eval(current_value, &root_value)
+        );
 
         // Objects and arrays do not offer < comparison
-        assert!(!ComparisonExpr::new(
-            Comparable::SingularQuery(name_query("obj")),
-            Comparable::SingularQuery(name_query("arr")),
-            ComparisonOp::LessOrEqual
-        )
-        .eval(current_value, &root_value));
+        assert!(
+            !ComparisonExpr::new(
+                Comparable::SingularQuery(name_query("obj")),
+                Comparable::SingularQuery(name_query("arr")),
+                ComparisonOp::LessOrEqual
+            )
+            .eval(current_value, &root_value)
+        );
 
         // Objects and arrays do not offer < comparison
-        assert!(!ComparisonExpr::new(
-            Comparable::SingularQuery(name_query("obj")),
-            Comparable::SingularQuery(name_query("arr")),
-            ComparisonOp::Less
-        )
-        .eval(current_value, &root_value));
+        assert!(
+            !ComparisonExpr::new(
+                Comparable::SingularQuery(name_query("obj")),
+                Comparable::SingularQuery(name_query("arr")),
+                ComparisonOp::Less
+            )
+            .eval(current_value, &root_value)
+        );
 
         // == implies <=
-        assert!(ComparisonExpr::new(
-            Comparable::SingularQuery(name_query("obj")),
-            Comparable::SingularQuery(name_query("obj")),
-            ComparisonOp::LessOrEqual
-        )
-        .eval(current_value, &root_value));
+        assert!(
+            ComparisonExpr::new(
+                Comparable::SingularQuery(name_query("obj")),
+                Comparable::SingularQuery(name_query("obj")),
+                ComparisonOp::LessOrEqual
+            )
+            .eval(current_value, &root_value)
+        );
 
         // == implies <=
-        assert!(ComparisonExpr::new(
-            Comparable::SingularQuery(name_query("arr")),
-            Comparable::SingularQuery(name_query("arr")),
-            ComparisonOp::LessOrEqual
-        )
-        .eval(current_value, &root_value));
+        assert!(
+            ComparisonExpr::new(
+                Comparable::SingularQuery(name_query("arr")),
+                Comparable::SingularQuery(name_query("arr")),
+                ComparisonOp::LessOrEqual
+            )
+            .eval(current_value, &root_value)
+        );
 
         // Arrays do not offer < comparison
-        assert!(!ComparisonExpr::new(
-            Comparable::Literal(Literal::Number(Number::Integer(1))),
-            Comparable::SingularQuery(name_query("arr")),
-            ComparisonOp::LessOrEqual
-        )
-        .eval(current_value, &root_value));
+        assert!(
+            !ComparisonExpr::new(
+                Comparable::Literal(Literal::Number(Number::Integer(1))),
+                Comparable::SingularQuery(name_query("arr")),
+                ComparisonOp::LessOrEqual
+            )
+            .eval(current_value, &root_value)
+        );
 
         // Arrays do not offer < comparison
-        assert!(!ComparisonExpr::new(
-            Comparable::Literal(Literal::Number(Number::Integer(1))),
-            Comparable::SingularQuery(name_query("arr")),
-            ComparisonOp::GreaterOrEqual
-        )
-        .eval(current_value, &root_value));
+        assert!(
+            !ComparisonExpr::new(
+                Comparable::Literal(Literal::Number(Number::Integer(1))),
+                Comparable::SingularQuery(name_query("arr")),
+                ComparisonOp::GreaterOrEqual
+            )
+            .eval(current_value, &root_value)
+        );
 
         // Arrays do not offer < comparison
-        assert!(!ComparisonExpr::new(
-            Comparable::Literal(Literal::Number(Number::Integer(1))),
-            Comparable::SingularQuery(name_query("arr")),
-            ComparisonOp::Greater
-        )
-        .eval(current_value, &root_value));
+        assert!(
+            !ComparisonExpr::new(
+                Comparable::Literal(Literal::Number(Number::Integer(1))),
+                Comparable::SingularQuery(name_query("arr")),
+                ComparisonOp::Greater
+            )
+            .eval(current_value, &root_value)
+        );
 
         // Arrays do not offer < comparison
-        assert!(!ComparisonExpr::new(
-            Comparable::Literal(Literal::Number(Number::Integer(1))),
-            Comparable::SingularQuery(name_query("arr")),
-            ComparisonOp::Less
-        )
-        .eval(current_value, &root_value));
+        assert!(
+            !ComparisonExpr::new(
+                Comparable::Literal(Literal::Number(Number::Integer(1))),
+                Comparable::SingularQuery(name_query("arr")),
+                ComparisonOp::Less
+            )
+            .eval(current_value, &root_value)
+        );
 
         // == implies <=
-        assert!(ComparisonExpr::new(
-            Comparable::Literal(Literal::Bool(true)),
-            Comparable::Literal(Literal::Bool(true)),
-            ComparisonOp::LessOrEqual
-        )
-        .eval(current_value, &root_value));
+        assert!(
+            ComparisonExpr::new(
+                Comparable::Literal(Literal::Bool(true)),
+                Comparable::Literal(Literal::Bool(true)),
+                ComparisonOp::LessOrEqual
+            )
+            .eval(current_value, &root_value)
+        );
 
         // Booleans do not offer < comparison
-        assert!(!ComparisonExpr::new(
-            Comparable::Literal(Literal::Bool(true)),
-            Comparable::Literal(Literal::Bool(true)),
-            ComparisonOp::Greater
-        )
-        .eval(current_value, &root_value));
+        assert!(
+            !ComparisonExpr::new(
+                Comparable::Literal(Literal::Bool(true)),
+                Comparable::Literal(Literal::Bool(true)),
+                ComparisonOp::Greater
+            )
+            .eval(current_value, &root_value)
+        );
     }
 
     #[test]

--- a/packages/hurl/src/jsonpath/eval/expr.rs
+++ b/packages/hurl/src/jsonpath/eval/expr.rs
@@ -43,11 +43,7 @@ impl TestExpr {
                 logical_type_function.eval(current_value, root_value)
             }
         };
-        if self.not() {
-            !value
-        } else {
-            value
-        }
+        if self.not() { !value } else { value }
     }
 }
 

--- a/packages/hurl/src/jsonpath/eval/function/functions.rs
+++ b/packages/hurl/src/jsonpath/eval/function/functions.rs
@@ -19,8 +19,8 @@
 use regex::Regex;
 use serde_json::Value;
 
-use crate::jsonpath::ast::function::functions::{LogicalTypeFunction, ValueTypeFunction};
 use crate::jsonpath::ast::function::LogicalType;
+use crate::jsonpath::ast::function::functions::{LogicalTypeFunction, ValueTypeFunction};
 
 impl ValueTypeFunction {
     pub fn eval(

--- a/packages/hurl/src/jsonpath/eval/selector.rs
+++ b/packages/hurl/src/jsonpath/eval/selector.rs
@@ -46,11 +46,12 @@ impl Selector {
 
 impl NameSelector {
     pub fn eval(&self, current_value: &serde_json::Value) -> Option<serde_json::Value> {
-        if let serde_json::Value::Object(key_values) = current_value {
-            if let Some(value) = key_values.get(self.value()) {
-                return Some(value.clone());
-            }
+        if let serde_json::Value::Object(key_values) = current_value
+            && let Some(value) = key_values.get(self.value())
+        {
+            return Some(value.clone());
         }
+
         None
     }
 }
@@ -177,11 +178,7 @@ fn filter(
 }
 
 fn normalize_index(i: i64, len: i64) -> i64 {
-    if i >= 0 {
-        i
-    } else {
-        len + i
-    }
+    if i >= 0 { i } else { len + i }
 }
 
 #[cfg(test)]
@@ -265,9 +262,11 @@ mod tests {
     fn test_array_slice_selector() {
         let current_value = json!(["a", "b", "c", "d", "e", "f", "g"]);
 
-        assert!(ArraySliceSelector::new(Some(1), Some(3), 0)
-            .eval(&current_value)
-            .is_empty(),);
+        assert!(
+            ArraySliceSelector::new(Some(1), Some(3), 0)
+                .eval(&current_value)
+                .is_empty(),
+        );
 
         let array_selector = ArraySliceSelector::new(Some(1), Some(3), 1);
         assert_eq!(array_selector.get_start(7), 1);

--- a/packages/hurl/src/jsonpath/parser/comparison.rs
+++ b/packages/hurl/src/jsonpath/parser/comparison.rs
@@ -19,11 +19,11 @@
 use crate::jsonpath::ast::comparison::Comparable;
 use crate::jsonpath::ast::comparison::ComparisonExpr;
 use crate::jsonpath::ast::comparison::ComparisonOp;
+use crate::jsonpath::parser::ParseResult;
 use crate::jsonpath::parser::function::functions::try_value_type_function;
 use crate::jsonpath::parser::literal;
 use crate::jsonpath::parser::primitives::{match_str, skip_whitespace};
 use crate::jsonpath::parser::singular_query::try_parse as try_singular_query;
-use crate::jsonpath::parser::ParseResult;
 use crate::jsonpath::parser::{ParseError, ParseErrorKind};
 
 use hurl_core::reader::Reader;

--- a/packages/hurl/src/jsonpath/parser/function/functions.rs
+++ b/packages/hurl/src/jsonpath/parser/function/functions.rs
@@ -18,8 +18,8 @@
 
 use super::argument;
 use crate::jsonpath::ast::function::functions::{LogicalTypeFunction, ValueTypeFunction};
-use crate::jsonpath::parser::primitives::{expect_str, match_str, skip_whitespace};
 use crate::jsonpath::parser::ParseResult;
+use crate::jsonpath::parser::primitives::{expect_str, match_str, skip_whitespace};
 use hurl_core::reader::Reader;
 
 /// Try to parse a function return a ValueType

--- a/packages/hurl/src/jsonpath/parser/query.rs
+++ b/packages/hurl/src/jsonpath/parser/query.rs
@@ -20,7 +20,7 @@ use hurl_core::reader::Reader;
 
 use crate::jsonpath::ast::query::{AbsoluteQuery, Query, RelativeQuery};
 use crate::jsonpath::parser::primitives::{expect_str, match_str};
-use crate::jsonpath::parser::{segments, ParseError, ParseErrorKind, ParseResult};
+use crate::jsonpath::parser::{ParseError, ParseErrorKind, ParseResult, segments};
 
 pub fn parse(reader: &mut Reader) -> ParseResult<AbsoluteQuery> {
     expect_str("$", reader)?;

--- a/packages/hurl/src/jsonpath/parser/segments.rs
+++ b/packages/hurl/src/jsonpath/parser/segments.rs
@@ -16,13 +16,13 @@
  *
  */
 
-use super::primitives::match_str;
 use super::ParseResult;
+use super::primitives::match_str;
 use crate::jsonpath::ast::segment::{ChildSegment, DescendantSegment, Segment};
 use crate::jsonpath::ast::selector::{NameSelector, Selector, WildcardSelector};
 use crate::jsonpath::parser::primitives::expect_str;
 use crate::jsonpath::parser::primitives::skip_whitespace;
-use crate::jsonpath::parser::{selectors, ParseError, ParseErrorKind};
+use crate::jsonpath::parser::{ParseError, ParseErrorKind, selectors};
 use hurl_core::reader::Reader;
 
 /// Parse segments

--- a/packages/hurl/src/jsonpath/parser/singular_query.rs
+++ b/packages/hurl/src/jsonpath/parser/singular_query.rs
@@ -20,11 +20,11 @@ use crate::jsonpath::ast::selector::{IndexSelector, NameSelector};
 use crate::jsonpath::ast::singular_query::{
     AbsoluteSingularQuery, RelativeSingularQuery, SingularQuery, SingularQuerySegment,
 };
+use crate::jsonpath::parser::ParseResult;
 use crate::jsonpath::parser::literal::number::try_integer;
 use crate::jsonpath::parser::primitives::match_str;
 use crate::jsonpath::parser::primitives::{expect_str, skip_whitespace};
 use crate::jsonpath::parser::selectors::try_name_selector;
-use crate::jsonpath::parser::ParseResult;
 use crate::jsonpath::parser::{ParseError, ParseErrorKind};
 use hurl_core::reader::Reader;
 

--- a/packages/hurl/src/jsonpath/tests/cts.rs
+++ b/packages/hurl/src/jsonpath/tests/cts.rs
@@ -293,9 +293,11 @@ fn run() {
     let count_total = testcases.len();
 
     // Make sure that ignored tests are in the test suite
-    assert!(IGNORED_TESTS
-        .iter()
-        .all(|ignored_test| testcases.clone().any(|tc| &tc.name == ignored_test)));
+    assert!(
+        IGNORED_TESTS
+            .iter()
+            .all(|ignored_test| testcases.clone().any(|tc| &tc.name == ignored_test))
+    );
 
     let testcases = testcases.filter(|tc| !IGNORED_TESTS.contains(&tc.name.as_str()));
     let count_ignored = count_total - testcases.clone().count();

--- a/packages/hurl/src/main.rs
+++ b/packages/hurl/src/main.rs
@@ -19,8 +19,8 @@ mod cli;
 mod run;
 
 use std::collections::HashSet;
-use std::io::prelude::*;
 use std::io::IsTerminal;
+use std::io::prelude::*;
 use std::path::Path;
 use std::process::ExitCode;
 use std::time::Instant;

--- a/packages/hurl/src/output/raw.rs
+++ b/packages/hurl/src/output/raw.rs
@@ -15,11 +15,11 @@
  * limitations under the License.
  *
  */
-use super::error::OutputErrorKind;
 use super::OutputError;
+use super::error::OutputErrorKind;
 use crate::pretty;
-use crate::pretty::json::Color;
 use crate::pretty::PrettyMode;
+use crate::pretty::json::Color;
 use crate::runner::{HurlResult, Output};
 use crate::util::term::Stdout;
 use std::cmp::min;

--- a/packages/hurl/src/parallel/progress.rs
+++ b/packages/hurl/src/parallel/progress.rs
@@ -295,10 +295,10 @@ fn build_progress(
             progress.push("\n");
 
             // We wrap the progress string with new lines if necessary
-            if let Some(max_width) = max_width {
-                if progress.len() >= max_width {
-                    progress = progress.wrap(max_width);
-                }
+            if let Some(max_width) = max_width
+                && progress.len() >= max_width
+            {
+                progress = progress.wrap(max_width);
             }
 
             let progress = progress.to_string(format);
@@ -330,7 +330,7 @@ fn progress_bar(current: Index, last: Index) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{mpsc, Arc, Mutex};
+    use std::sync::{Arc, Mutex, mpsc};
 
     use crate::parallel::job::Job;
     use crate::parallel::progress::{build_progress, progress_bar};

--- a/packages/hurl/src/parallel/runner.rs
+++ b/packages/hurl/src/parallel/runner.rs
@@ -16,7 +16,7 @@
  *
  */
 use std::sync::mpsc::{Receiver, Sender};
-use std::sync::{mpsc, Arc, Mutex};
+use std::sync::{Arc, Mutex, mpsc};
 
 use super::error::JobError;
 use super::job::{Job, JobQueue, JobResult};
@@ -273,10 +273,10 @@ impl ParallelRunner {
                         }
                         None => {
                             // If we have received all the job results, we can stop the run.
-                            if let Count::Finite(jobs_count) = jobs_count {
-                                if results.len() == jobs_count {
-                                    break;
-                                }
+                            if let Count::Finite(jobs_count) = jobs_count
+                                && results.len() == jobs_count
+                            {
+                                break;
                             }
                         }
                     }

--- a/packages/hurl/src/parallel/worker.rs
+++ b/packages/hurl/src/parallel/worker.rs
@@ -73,73 +73,75 @@ impl Worker {
         let rx = Arc::clone(rx);
         let tx = tx.clone();
 
-        let thread = thread::spawn(move || loop {
-            let Ok(job) = rx.lock().unwrap().recv() else {
-                return;
-            };
-            // In parallel execution, standard output and standard error messages are buffered
-            // (in sequential mode, we'll use immediate standard output and error).
-            let mut stdout = Stdout::new(WriteMode::Buffered);
-            let stderr = Stderr::new(WriteMode::Buffered);
-
-            // We also create a common logger for this run (logger verbosity can eventually be
-            // mutated on each entry).
-            let secrets = job.variables.secrets();
-            let mut logger = Logger::new(&job.logger_options, stderr, &secrets);
-
-            // Create a worker progress listener.
-            let progress = WorkerProgress::new(worker_id, &job, &tx);
-
-            let content = job.filename.read_to_string();
-            let content = match content {
-                Ok(c) => c,
-                Err(e) => {
-                    let msg = InputReadErrorMsg::new(worker_id, &job, e);
-                    _ = tx.send(WorkerMessage::InputReadError(msg));
+        let thread = thread::spawn(move || {
+            loop {
+                let Ok(job) = rx.lock().unwrap().recv() else {
                     return;
+                };
+                // In parallel execution, standard output and standard error messages are buffered
+                // (in sequential mode, we'll use immediate standard output and error).
+                let mut stdout = Stdout::new(WriteMode::Buffered);
+                let stderr = Stderr::new(WriteMode::Buffered);
+
+                // We also create a common logger for this run (logger verbosity can eventually be
+                // mutated on each entry).
+                let secrets = job.variables.secrets();
+                let mut logger = Logger::new(&job.logger_options, stderr, &secrets);
+
+                // Create a worker progress listener.
+                let progress = WorkerProgress::new(worker_id, &job, &tx);
+
+                let content = job.filename.read_to_string();
+                let content = match content {
+                    Ok(c) => c,
+                    Err(e) => {
+                        let msg = InputReadErrorMsg::new(worker_id, &job, e);
+                        _ = tx.send(WorkerMessage::InputReadError(msg));
+                        return;
+                    }
+                };
+
+                // Try to parse the content
+                let hurl_file = parser::parse_hurl_file(&content);
+                let hurl_file = match hurl_file {
+                    Ok(h) => h,
+                    Err(error) => {
+                        let filename = job.filename.to_string();
+                        let message = error.render(
+                            &filename,
+                            &content,
+                            None,
+                            OutputFormat::Terminal(logger.color),
+                        );
+                        logger.error_rich(&message);
+                        let msg = ParsingErrorMsg::new(worker_id, &job, &logger.stderr);
+                        _ = tx.send(WorkerMessage::ParsingError(msg));
+                        return;
+                    }
+                };
+
+                // Now, we have a syntactically correct HurlFile instance, we can run it.
+                let result = runner::run_entries(
+                    &hurl_file.entries,
+                    &content,
+                    Some(&job.filename),
+                    &job.runner_options,
+                    &job.variables,
+                    &mut stdout,
+                    Some(&progress),
+                    &mut logger,
+                );
+
+                if result.success && result.entries.last().is_none() {
+                    logger.warning(&format!(
+                        "No entry have been executed for file {}",
+                        job.filename
+                    ));
                 }
-            };
-
-            // Try to parse the content
-            let hurl_file = parser::parse_hurl_file(&content);
-            let hurl_file = match hurl_file {
-                Ok(h) => h,
-                Err(error) => {
-                    let filename = job.filename.to_string();
-                    let message = error.render(
-                        &filename,
-                        &content,
-                        None,
-                        OutputFormat::Terminal(logger.color),
-                    );
-                    logger.error_rich(&message);
-                    let msg = ParsingErrorMsg::new(worker_id, &job, &logger.stderr);
-                    _ = tx.send(WorkerMessage::ParsingError(msg));
-                    return;
-                }
-            };
-
-            // Now, we have a syntactically correct HurlFile instance, we can run it.
-            let result = runner::run_entries(
-                &hurl_file.entries,
-                &content,
-                Some(&job.filename),
-                &job.runner_options,
-                &job.variables,
-                &mut stdout,
-                Some(&progress),
-                &mut logger,
-            );
-
-            if result.success && result.entries.last().is_none() {
-                logger.warning(&format!(
-                    "No entry have been executed for file {}",
-                    job.filename
-                ));
+                let job_result = JobResult::new(job, content, result);
+                let msg = CompletedMsg::new(worker_id, job_result, stdout, logger.stderr);
+                _ = tx.send(WorkerMessage::Completed(msg));
             }
-            let job_result = JobResult::new(job, content, result);
-            let msg = CompletedMsg::new(worker_id, job_result, stdout, logger.stderr);
-            _ = tx.send(WorkerMessage::Completed(msg));
         });
 
         Worker {

--- a/packages/hurl/src/report/html/report.rs
+++ b/packages/hurl/src/report/html/report.rs
@@ -15,8 +15,8 @@
  * limitations under the License.
  *
  */
-use crate::report::html::{HTMLResult, Testcase};
 use crate::report::ReportError;
+use crate::report::html::{HTMLResult, Testcase};
 use chrono::{DateTime, Local};
 use regex::Regex;
 use std::io::Write;

--- a/packages/hurl/src/report/html/run.rs
+++ b/packages/hurl/src/report/html/run.rs
@@ -18,8 +18,8 @@
 use hurl_core::ast::HurlFile;
 
 use crate::http::Call;
-use crate::report::html::nav::Tab;
 use crate::report::html::Testcase;
+use crate::report::html::nav::Tab;
 use crate::runner::EntryResult;
 use crate::util::redacted::Redact;
 

--- a/packages/hurl/src/report/html/source.rs
+++ b/packages/hurl/src/report/html/source.rs
@@ -17,8 +17,8 @@
  */
 use hurl_core::ast::{HurlFile, SourceInfo};
 
-use crate::report::html::nav::Tab;
 use crate::report::html::Testcase;
+use crate::report::html::nav::Tab;
 use crate::runner::RunnerError;
 
 impl Testcase {

--- a/packages/hurl/src/report/html/timeline/calls.rs
+++ b/packages/hurl/src/report/html/timeline/calls.rs
@@ -18,6 +18,7 @@
 use std::iter::zip;
 
 use crate::http::Call;
+use crate::report::html::Testcase;
 use crate::report::html::timeline::svg::Attribute::{
     Class, Fill, FontFamily, FontSize, Height, Href, TextDecoration, ViewBox, Width, X, Y,
 };
@@ -26,8 +27,7 @@ use crate::report::html::timeline::unit::{Pixel, Px};
 use crate::report::html::timeline::util::{
     new_failure_icon, new_retry_icon, new_success_icon, trunc_str,
 };
-use crate::report::html::timeline::{svg, CallContext, CallContextKind, CALL_HEIGHT};
-use crate::report::html::Testcase;
+use crate::report::html::timeline::{CALL_HEIGHT, CallContext, CallContextKind, svg};
 use crate::util::redacted::Redact;
 
 impl Testcase {

--- a/packages/hurl/src/report/html/timeline/mod.rs
+++ b/packages/hurl/src/report/html/timeline/mod.rs
@@ -16,9 +16,9 @@
  *
  */
 use crate::http::Call;
+use crate::report::html::Testcase;
 use crate::report::html::nav::Tab;
 use crate::report::html::timeline::unit::Pixel;
-use crate::report::html::Testcase;
 use crate::runner::EntryResult;
 use hurl_core::ast::HurlFile;
 use hurl_core::types::Index;

--- a/packages/hurl/src/report/html/timeline/util.rs
+++ b/packages/hurl/src/report/html/timeline/util.rs
@@ -61,17 +61,35 @@ pub fn new_stripes(
 
 /// Returns the SVG success icon identified by `id`.
 pub fn new_success_icon(id: &str) -> Element {
-    new_icon(id, 512.px(), 512.px(), "M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM369 209L241 337c-9.4 9.4-24.6 9.4-33.9 0l-64-64c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l47 47L335 175c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9z", "#10bb00")
+    new_icon(
+        id,
+        512.px(),
+        512.px(),
+        "M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM369 209L241 337c-9.4 9.4-24.6 9.4-33.9 0l-64-64c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l47 47L335 175c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9z",
+        "#10bb00",
+    )
 }
 
 /// Returns the SVG failure icon identified by `id`.
 pub fn new_failure_icon(id: &str) -> Element {
-    new_icon(id, 512.px(), 512.px(), "M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zm0-384c13.3 0 24 10.7 24 24V264c0 13.3-10.7 24-24 24s-24-10.7-24-24V152c0-13.3 10.7-24 24-24zM224 352a32 32 0 1 1 64 0 32 32 0 1 1 -64 0z", "red")
+    new_icon(
+        id,
+        512.px(),
+        512.px(),
+        "M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zm0-384c13.3 0 24 10.7 24 24V264c0 13.3-10.7 24-24 24s-24-10.7-24-24V152c0-13.3 10.7-24 24-24zM224 352a32 32 0 1 1 64 0 32 32 0 1 1 -64 0z",
+        "red",
+    )
 }
 
 /// Returns the SVG retry icon identified by id.
 pub fn new_retry_icon(id: &str) -> Element {
-    new_icon(id, 512.px(), 512.px(), "M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zm0-384c13.3 0 24 10.7 24 24V264c0 13.3-10.7 24-24 24s-24-10.7-24-24V152c0-13.3 10.7-24 24-24zM224 352a32 32 0 1 1 64 0 32 32 0 1 1 -64 0z", "gold")
+    new_icon(
+        id,
+        512.px(),
+        512.px(),
+        "M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zm0-384c13.3 0 24 10.7 24 24V264c0 13.3-10.7 24-24 24s-24-10.7-24-24V152c0-13.3 10.7-24 24-24zM224 352a32 32 0 1 1 64 0 32 32 0 1 1 -64 0z",
+        "gold",
+    )
 }
 
 /// Returns a SVG icon identified by `id`, with a `width` pixel by `height` pixel size, `path` and `color`.

--- a/packages/hurl/src/report/html/timeline/waterfall.rs
+++ b/packages/hurl/src/report/html/timeline/waterfall.rs
@@ -21,20 +21,20 @@ use std::time::Duration;
 use chrono::{DateTime, Utc};
 
 use crate::http::Call;
+use crate::report::html::Testcase;
 use crate::report::html::timeline::nice::NiceScale;
 use crate::report::html::timeline::svg::Attribute::{
-    Class, Fill, Filter, FloodOpacity, FontFamily, FontSize, FontWeight, Height, Href, Id, Opacity,
-    StdDeviation, Stroke, StrokeWidth, TextDecoration, ViewBox, Width, DX, DY, X, Y,
+    Class, DX, DY, Fill, Filter, FloodOpacity, FontFamily, FontSize, FontWeight, Height, Href, Id,
+    Opacity, StdDeviation, Stroke, StrokeWidth, TextDecoration, ViewBox, Width, X, Y,
 };
-use crate::report::html::timeline::svg::{new_a, Element};
+use crate::report::html::timeline::svg::{Element, new_a};
 use crate::report::html::timeline::unit::{
     Byte, Interval, Microsecond, Millisecond, Pixel, Px, Scale, Second, TimeUnit,
 };
 use crate::report::html::timeline::util::{
     new_failure_icon, new_retry_icon, new_stripes, new_success_icon, trunc_str,
 };
-use crate::report::html::timeline::{svg, CallContext, CallContextKind, CALL_HEIGHT, CALL_INSET};
-use crate::report::html::Testcase;
+use crate::report::html::timeline::{CALL_HEIGHT, CALL_INSET, CallContext, CallContextKind, svg};
 use crate::util::redacted::Redact;
 
 /// Returns the start and end date for these entries.

--- a/packages/hurl/src/report/json/deserialize.rs
+++ b/packages/hurl/src/report/json/deserialize.rs
@@ -39,10 +39,11 @@ pub fn parse_json_report(filename: &Path) -> Result<Vec<Value>, ReportError> {
     // TODO: if the existing JSON report is not valid, we consider that there is no
     // existing report to append, without displaying any error or warning. Maybe a better option
     // would be to raise an error here and ask the user to explicitly deal with this error.
-    if let Ok(Some(Value::Array(values))) = serde_json::from_str(&s) {
-        if values.iter().all(HurlResult::is_deserializable) {
-            return Ok(values);
-        }
+    if let Ok(Some(Value::Array(values))) = serde_json::from_str(&s)
+        && values.iter().all(HurlResult::is_deserializable)
+    {
+        return Ok(values);
     }
+
     Ok(vec![])
 }

--- a/packages/hurl/src/report/junit/mod.rs
+++ b/packages/hurl/src/report/junit/mod.rs
@@ -61,8 +61,8 @@ use std::path::Path;
 
 pub use testcase::Testcase;
 
-use crate::report::junit::xml::{Element, XmlDocument};
 use crate::report::ReportError;
+use crate::report::junit::xml::{Element, XmlDocument};
 use crate::util::path::create_dir_all;
 
 /// Creates a JUnit from a list of `testcases`.
@@ -134,7 +134,7 @@ mod tests {
 
     use crate::http::HttpError;
     use crate::report::junit::xml::XmlDocument;
-    use crate::report::junit::{create_testsuite, Testcase};
+    use crate::report::junit::{Testcase, create_testsuite};
     use crate::runner::{EntryResult, HurlResult, RunnerError, RunnerErrorKind};
     use hurl_core::ast::SourceInfo;
     use hurl_core::input::Input;

--- a/packages/hurl/src/report/junit/xml/reader.rs
+++ b/packages/hurl/src/report/junit/xml/reader.rs
@@ -63,7 +63,7 @@ impl XmlDocument {
                     root = Some(element);
                 }
                 Ok(XmlEvent::EndElement { .. }) => {
-                    return Err(InvalidXml("Invalid end of element".to_string()))
+                    return Err(InvalidXml("Invalid end of element".to_string()));
                 }
                 Ok(XmlEvent::CData(_)) => {}
                 Ok(XmlEvent::Comment(_)) => {}
@@ -90,13 +90,13 @@ impl Element {
         loop {
             match reader.next() {
                 Ok(XmlEvent::Doctype { .. }) => {
-                    return Err(InvalidXml("Invalid doc type".to_string()))
+                    return Err(InvalidXml("Invalid doc type".to_string()));
                 }
                 Ok(XmlEvent::StartDocument { .. }) => {
-                    return Err(InvalidXml("Invalid start of document".to_string()))
+                    return Err(InvalidXml("Invalid start of document".to_string()));
                 }
                 Ok(XmlEvent::EndDocument) => {
-                    return Err(InvalidXml("Invalid stop of document".to_string()))
+                    return Err(InvalidXml("Invalid stop of document".to_string()));
                 }
                 Ok(XmlEvent::ProcessingInstruction { name, data }) => {
                     let child = XmlNode::ProcessingInstruction(name, data);
@@ -113,7 +113,7 @@ impl Element {
                         Ok(element)
                     } else {
                         Err(InvalidXml(format!("Bag closing element {name}")))
-                    }
+                    };
                 }
                 Ok(XmlEvent::CData(value)) => {
                     let child = XmlNode::CData(value);

--- a/packages/hurl/src/report/junit/xml/writer.rs
+++ b/packages/hurl/src/report/junit/xml/writer.rs
@@ -20,11 +20,11 @@ use std::fmt;
 use std::fmt::{Debug, Formatter};
 use std::string::FromUtf8Error;
 
+use xml::EventWriter;
 use xml::attribute::Attribute;
 use xml::name::Name;
 use xml::namespace::Namespace;
 use xml::writer::{Error, XmlEvent};
-use xml::EventWriter;
 
 use crate::report::junit::xml::{Element, XmlDocument, XmlNode};
 

--- a/packages/hurl/src/run.rs
+++ b/packages/hurl/src/run.rs
@@ -28,9 +28,9 @@ use hurl_core::error::{DisplaySourceError, OutputFormat};
 use hurl_core::input::Input;
 use hurl_core::types::Count;
 
-use crate::cli::options::CliOptions;
 use crate::cli::CliError;
-use crate::{cli, HurlRun};
+use crate::cli::options::CliOptions;
+use crate::{HurlRun, cli};
 
 /// Runs Hurl `files` sequentially, given a current directory and command-line options (see
 /// [`crate::cli::options::CliOptions`]). This function returns a list of [`HurlRun`] results or

--- a/packages/hurl/src/runner/assert.rs
+++ b/packages/hurl/src/runner/assert.rs
@@ -206,8 +206,8 @@ pub mod tests {
     use std::path::Path;
 
     use hurl_core::ast::{
-        Filter, FilterValue, LineTerminator, Predicate, PredicateFunc, PredicateFuncValue,
-        PredicateValue, SourceInfo, Whitespace, I64,
+        Filter, FilterValue, I64, LineTerminator, Predicate, PredicateFunc, PredicateFuncValue,
+        PredicateValue, SourceInfo, Whitespace,
     };
     use hurl_core::reader::Pos;
     use hurl_core::types::ToSource;

--- a/packages/hurl/src/runner/cache.rs
+++ b/packages/hurl/src/runner/cache.rs
@@ -58,9 +58,9 @@ impl BodyCache {
 
 #[cfg(test)]
 mod tests {
+    use crate::runner::Value;
     use crate::runner::cache::BodyCache;
     use crate::runner::xpath::{Document, Format};
-    use crate::runner::Value;
 
     #[test]
     fn add_and_retry_html() {

--- a/packages/hurl/src/runner/entry.rs
+++ b/packages/hurl/src/runner/entry.rs
@@ -146,26 +146,26 @@ pub fn run(
     let mut cache = BodyCache::new();
     let mut asserts = vec![];
 
-    if !runner_options.no_assert {
-        if let Some(response_spec) = &entry.response {
-            let mut status_asserts =
-                response::eval_version_status_asserts(response_spec, http_response);
-            let errors = asserts_to_errors(&status_asserts);
-            asserts.append(&mut status_asserts);
-            if !errors.is_empty() {
-                logger.debug("");
-                return EntryResult {
-                    entry_index,
-                    source_info,
-                    calls,
-                    captures: vec![],
-                    asserts,
-                    errors,
-                    transfer_duration,
-                    compressed,
-                    curl_cmd,
-                };
-            }
+    if !runner_options.no_assert
+        && let Some(response_spec) = &entry.response
+    {
+        let mut status_asserts =
+            response::eval_version_status_asserts(response_spec, http_response);
+        let errors = asserts_to_errors(&status_asserts);
+        asserts.append(&mut status_asserts);
+        if !errors.is_empty() {
+            logger.debug("");
+            return EntryResult {
+                entry_index,
+                source_info,
+                calls,
+                captures: vec![],
+                asserts,
+                errors,
+                transfer_duration,
+                compressed,
+                curl_cmd,
+            };
         }
     };
 
@@ -199,18 +199,18 @@ pub fn run(
     logger.debug("");
 
     // Compute asserts
-    if !runner_options.no_assert {
-        if let Some(response_spec) = &entry.response {
-            warn_deprecated(response_spec, logger);
-            let mut other_asserts = response::eval_asserts(
-                response_spec,
-                variables,
-                &responses,
-                &mut cache,
-                context_dir,
-            );
-            asserts.append(&mut other_asserts);
-        }
+    if !runner_options.no_assert
+        && let Some(response_spec) = &entry.response
+    {
+        warn_deprecated(response_spec, logger);
+        let mut other_asserts = response::eval_asserts(
+            response_spec,
+            variables,
+            &responses,
+            &mut cache,
+            context_dir,
+        );
+        asserts.append(&mut other_asserts);
     };
 
     let errors = asserts_to_errors(&asserts);

--- a/packages/hurl/src/runner/error.rs
+++ b/packages/hurl/src/runner/error.rs
@@ -476,9 +476,7 @@ mod tests {
         let error = RunnerError::new(error_source_info, kind, true);
 
         assert_eq!(
-            error
-                .message(&lines)
-                .to_string(Format::Plain),
+            error.message(&lines).to_string(Format::Plain),
             "\n 1 | GET http://unknown\n   |     ^^^^^^^^^^^^^^ (6) Could not resolve host: unknown\n   |"
         );
         assert_eq!(
@@ -553,9 +551,9 @@ xpath "strong(//head/title)" == "Hello"
         let entry_source_info = SourceInfo::new(Pos::new(1, 1), Pos::new(1, 22));
         let error = RunnerError::new(error_source_info, RunnerErrorKind::InvalidXPathEval, true);
         assert_eq!(
-        &error.message(&lines).to_string(Format::Plain),
-        "\n 4 | xpath \"strong(//head/title)\" == \"Hello\"\n   |       ^^^^^^^^^^^^^^^^^^^^^^ XPath expression is not valid\n   |"
-    );
+            &error.message(&lines).to_string(Format::Plain),
+            "\n 4 | xpath \"strong(//head/title)\" == \"Hello\"\n   |       ^^^^^^^^^^^^^^^^^^^^^^ XPath expression is not valid\n   |"
+        );
         assert_eq!(
             error.render(
                 filename,

--- a/packages/hurl/src/runner/filter/base64_decode.rs
+++ b/packages/hurl/src/runner/filter/base64_decode.rs
@@ -15,8 +15,8 @@
  * limitations under the License.
  *
  */
-use base64::prelude::BASE64_STANDARD;
 use base64::Engine;
+use base64::prelude::BASE64_STANDARD;
 use hurl_core::ast::SourceInfo;
 
 use crate::runner::{RunnerError, RunnerErrorKind, Value};
@@ -48,8 +48,8 @@ mod tests {
     use hurl_core::reader::Pos;
 
     use super::*;
-    use crate::runner::filter::eval::eval_filter;
     use crate::runner::VariableSet;
+    use crate::runner::filter::eval::eval_filter;
 
     #[test]
     fn eval_filter_base64_decode_ok() {

--- a/packages/hurl/src/runner/filter/base64_encode.rs
+++ b/packages/hurl/src/runner/filter/base64_encode.rs
@@ -15,8 +15,8 @@
  * limitations under the License.
  *
  */
-use base64::prelude::BASE64_STANDARD;
 use base64::Engine;
+use base64::prelude::BASE64_STANDARD;
 use hurl_core::ast::SourceInfo;
 
 use crate::runner::{RunnerError, RunnerErrorKind, Value};
@@ -42,8 +42,8 @@ mod tests {
     use hurl_core::reader::Pos;
 
     use super::*;
-    use crate::runner::filter::eval::eval_filter;
     use crate::runner::VariableSet;
+    use crate::runner::filter::eval::eval_filter;
 
     #[test]
     fn eval_filter_base64_encode_ok() {

--- a/packages/hurl/src/runner/filter/base64_url_safe_decode.rs
+++ b/packages/hurl/src/runner/filter/base64_url_safe_decode.rs
@@ -15,9 +15,9 @@
  * limitations under the License.
  *
  */
-use base64::prelude::BASE64_URL_SAFE_NO_PAD;
 use base64::DecodeError::InvalidPadding;
 use base64::Engine;
+use base64::prelude::BASE64_URL_SAFE_NO_PAD;
 use hurl_core::ast::SourceInfo;
 
 use crate::runner::{RunnerError, RunnerErrorKind, Value};
@@ -58,8 +58,8 @@ mod tests {
     use hurl_core::reader::Pos;
 
     use super::*;
-    use crate::runner::filter::eval::eval_filter;
     use crate::runner::VariableSet;
+    use crate::runner::filter::eval::eval_filter;
 
     #[test]
     fn eval_filter_base64_url_safe_decode_ok() {

--- a/packages/hurl/src/runner/filter/base64_url_safe_encode.rs
+++ b/packages/hurl/src/runner/filter/base64_url_safe_encode.rs
@@ -15,8 +15,8 @@
  * limitations under the License.
  *
  */
-use base64::prelude::BASE64_URL_SAFE_NO_PAD;
 use base64::Engine;
+use base64::prelude::BASE64_URL_SAFE_NO_PAD;
 use hurl_core::ast::SourceInfo;
 
 use crate::runner::{RunnerError, RunnerErrorKind, Value};
@@ -42,8 +42,8 @@ mod tests {
     use hurl_core::reader::Pos;
 
     use super::*;
-    use crate::runner::filter::eval::eval_filter;
     use crate::runner::VariableSet;
+    use crate::runner::filter::eval::eval_filter;
 
     #[test]
     fn eval_filter_base64_url_safe_encode_ok() {

--- a/packages/hurl/src/runner/filter/count.rs
+++ b/packages/hurl/src/runner/filter/count.rs
@@ -42,8 +42,8 @@ mod tests {
     use hurl_core::reader::Pos;
 
     use super::*;
-    use crate::runner::filter::eval::eval_filter;
     use crate::runner::VariableSet;
+    use crate::runner::filter::eval::eval_filter;
 
     #[test]
     fn eval_filter_count() {

--- a/packages/hurl/src/runner/filter/days_after_now.rs
+++ b/packages/hurl/src/runner/filter/days_after_now.rs
@@ -40,14 +40,14 @@ pub fn eval_days_after_now(
 
 #[cfg(test)]
 mod tests {
-    use chrono::offset::Utc;
     use chrono::Duration;
+    use chrono::offset::Utc;
     use hurl_core::ast::{Filter, FilterValue, SourceInfo};
     use hurl_core::reader::Pos;
 
     use super::*;
-    use crate::runner::filter::eval::eval_filter;
     use crate::runner::VariableSet;
+    use crate::runner::filter::eval::eval_filter;
 
     #[test]
     fn eval_filter_days_after_before_now() {

--- a/packages/hurl/src/runner/filter/decode.rs
+++ b/packages/hurl/src/runner/filter/decode.rs
@@ -58,8 +58,8 @@ mod tests {
     use hurl_core::types::ToSource;
 
     use super::*;
-    use crate::runner::filter::eval::eval_filter;
     use crate::runner::VariableSet;
+    use crate::runner::filter::eval::eval_filter;
 
     /// Helper function to return a new filter given an `encoding`
     fn new_decode_filter(encoding: &str) -> Filter {

--- a/packages/hurl/src/runner/filter/format.rs
+++ b/packages/hurl/src/runner/filter/format.rs
@@ -53,15 +53,15 @@ pub fn eval_date_format(
 
 #[cfg(test)]
 mod tests {
-    use chrono::offset::Utc;
     use chrono::TimeZone;
+    use chrono::offset::Utc;
     use hurl_core::ast::{Filter, FilterValue, SourceInfo, Template, TemplateElement, Whitespace};
     use hurl_core::reader::Pos;
     use hurl_core::types::ToSource;
 
     use super::*;
-    use crate::runner::filter::eval::eval_filter;
     use crate::runner::VariableSet;
+    use crate::runner::filter::eval::eval_filter;
 
     /// Helper function to return a new filter given a `fmt`
     fn new_date_format_filter(fmt: &str) -> Filter {

--- a/packages/hurl/src/runner/filter/nth.rs
+++ b/packages/hurl/src/runner/filter/nth.rs
@@ -17,7 +17,7 @@
  */
 use hurl_core::ast::{IntegerValue, Placeholder, SourceInfo};
 
-use crate::runner::{expr, Number, RunnerError, RunnerErrorKind, Value, VariableSet};
+use crate::runner::{Number, RunnerError, RunnerErrorKind, Value, VariableSet, expr};
 
 /// Returns the element from a collection `value` at a zero-based index.
 pub fn eval_nth(
@@ -78,7 +78,7 @@ fn eval_integer_value(n: &IntegerValue, variables: &VariableSet) -> Result<i64, 
 
 #[cfg(test)]
 mod tests {
-    use hurl_core::ast::{Filter, FilterValue, IntegerValue, SourceInfo, Whitespace, I64};
+    use hurl_core::ast::{Filter, FilterValue, I64, IntegerValue, SourceInfo, Whitespace};
     use hurl_core::reader::Pos;
     use hurl_core::types::ToSource;
 

--- a/packages/hurl/src/runner/filter/to_hex.rs
+++ b/packages/hurl/src/runner/filter/to_hex.rs
@@ -17,7 +17,7 @@
  */
 use hurl_core::ast::SourceInfo;
 
-use crate::runner::{hex, RunnerError, RunnerErrorKind, Value};
+use crate::runner::{RunnerError, RunnerErrorKind, Value, hex};
 
 /// Converts bytes `value` to hexadecimal string.
 pub fn eval_to_hex(
@@ -40,8 +40,8 @@ mod tests {
     use hurl_core::reader::Pos;
 
     use super::*;
-    use crate::runner::filter::eval::eval_filter;
     use crate::runner::VariableSet;
+    use crate::runner::filter::eval::eval_filter;
 
     #[test]
     fn eval_filter_to_hex_ok() {

--- a/packages/hurl/src/runner/filter/xpath.rs
+++ b/packages/hurl/src/runner/filter/xpath.rs
@@ -75,8 +75,8 @@ mod tests {
     use hurl_core::types::ToSource;
 
     use super::*;
-    use crate::runner::filter::eval::eval_filter;
     use crate::runner::VariableSet;
+    use crate::runner::filter::eval::eval_filter;
 
     /// Helper function to return a new filter given a `expr`
     fn new_xpath_filter(expr: &str) -> Filter {

--- a/packages/hurl/src/runner/hurl_file.rs
+++ b/packages/hurl/src/runner/hurl_file.rs
@@ -365,15 +365,13 @@ fn run_request(
 
         // When --output is overridden on a request level, we output the HTTP response only if the
         // call has succeeded. Output errors are not taken into account for retrying requests.
-        if let Some(output) = &options.output {
-            if !has_error {
-                let source_info = get_output_source_info(entry);
-                if let Err(error) =
-                    result.write_response(output, &options.context_dir, stdout, source_info)
-                {
-                    result.errors.push(error);
-                    has_error = true;
-                }
+        if !has_error && let Some(output) = &options.output {
+            let source_info = get_output_source_info(entry);
+            if let Err(error) =
+                result.write_response(output, &options.context_dir, stdout, source_info)
+            {
+                result.errors.push(error);
+                has_error = true;
             }
         }
 
@@ -491,10 +489,10 @@ fn get_non_default_options(options: &RunnerOptions) -> Vec<(&'static str, String
         non_default_options.push(("max redirect", options.max_redirect.to_string()));
     }
 
-    if options.proxy != default_options.proxy {
-        if let Some(proxy) = &options.proxy {
-            non_default_options.push(("proxy", proxy.to_string()));
-        }
+    if options.proxy != default_options.proxy
+        && let Some(proxy) = &options.proxy
+    {
+        non_default_options.push(("proxy", proxy.to_string()));
     }
 
     if options.retry != default_options.retry {
@@ -505,10 +503,10 @@ fn get_non_default_options(options: &RunnerOptions) -> Vec<(&'static str, String
         non_default_options.push(("retry", value));
     }
 
-    if options.unix_socket != default_options.unix_socket {
-        if let Some(unix_socket) = &options.unix_socket {
-            non_default_options.push(("unix socket", unix_socket.to_string()));
-        }
+    if options.unix_socket != default_options.unix_socket
+        && let Some(unix_socket) = &options.unix_socket
+    {
+        non_default_options.push(("unix socket", unix_socket.to_string()));
     }
 
     non_default_options
@@ -562,14 +560,15 @@ fn log_errors(
         return;
     }
 
-    if logger.error_format == ErrorFormat::Long {
-        if let Some(Call { response, .. }) = entry_result.calls.last() {
-            logger.info_curl_cmd(&entry_result.curl_cmd.to_string());
-            logger.info("");
+    if logger.error_format == ErrorFormat::Long
+        && let Some(Call { response, .. }) = entry_result.calls.last()
+    {
+        logger.info_curl_cmd(&entry_result.curl_cmd.to_string());
+        logger.info("");
 
-            response.log_info_all(logger);
-        }
+        response.log_info_all(logger);
     }
+
     entry_result.errors.iter().for_each(|error| {
         let filename = filename.map_or(String::new(), |f| f.to_string());
         let message = error.render(

--- a/packages/hurl/src/runner/multiline.rs
+++ b/packages/hurl/src/runner/multiline.rs
@@ -64,8 +64,8 @@ mod tests {
     use hurl_core::reader::Pos;
     use hurl_core::types::ToSource;
 
-    use crate::runner::multiline::eval_multiline;
     use crate::runner::VariableSet;
+    use crate::runner::multiline::eval_multiline;
 
     fn whitespace() -> Whitespace {
         Whitespace {

--- a/packages/hurl/src/runner/options.rs
+++ b/packages/hurl/src/runner/options.rs
@@ -519,7 +519,7 @@ fn eval_number(number: &AstNumber) -> Value {
 #[cfg(test)]
 mod tests {
     use hurl_core::ast::{
-        Duration, Expr, ExprKind, Placeholder, SourceInfo, Variable, Whitespace, U64,
+        Duration, Expr, ExprKind, Placeholder, SourceInfo, U64, Variable, Whitespace,
     };
     use hurl_core::reader::Pos;
     use hurl_core::types::{DurationUnit, ToSource};

--- a/packages/hurl/src/runner/output.rs
+++ b/packages/hurl/src/runner/output.rs
@@ -117,7 +117,7 @@ impl Output {
                             &filename,
                             &e.to_string(),
                             source_info,
-                        ))
+                        ));
                     }
                 };
                 match file.write_all(bytes) {

--- a/packages/hurl/src/runner/predicate.rs
+++ b/packages/hurl/src/runner/predicate.rs
@@ -815,8 +815,8 @@ mod tests {
     use std::path::Path;
 
     use hurl_core::ast::{
-        Expr, ExprKind, Float, Placeholder, Regex, Template, TemplateElement, Variable, Whitespace,
-        I64,
+        Expr, ExprKind, Float, I64, Placeholder, Regex, Template, TemplateElement, Variable,
+        Whitespace,
     };
     use hurl_core::types::ToSource;
 
@@ -859,13 +859,15 @@ mod tests {
             },
         };
 
-        assert!(eval_predicate(
-            &predicate,
-            &variables,
-            &Some(Value::Bool(true)),
-            &context_dir
-        )
-        .is_ok());
+        assert!(
+            eval_predicate(
+                &predicate,
+                &variables,
+                &Some(Value::Bool(true)),
+                &context_dir
+            )
+            .is_ok()
+        );
 
         let error = eval_predicate(
             &predicate,
@@ -887,13 +889,15 @@ mod tests {
             SourceInfo::new(Pos::new(1, 0), Pos::new(1, 0))
         );
 
-        assert!(eval_predicate(
-            &predicate,
-            &variables,
-            &Some(Value::Number(Number::Integer(1))),
-            &context_dir
-        )
-        .is_ok());
+        assert!(
+            eval_predicate(
+                &predicate,
+                &variables,
+                &Some(Value::Number(Number::Integer(1))),
+                &context_dir
+            )
+            .is_ok()
+        );
     }
 
     #[test]
@@ -1333,13 +1337,15 @@ mod tests {
         };
 
         let variables = VariableSet::new();
-        assert!(eval_predicate(
-            &predicate,
-            &variables,
-            &Some(Value::Number(Number::Integer(1))),
-            &context_dir
-        )
-        .is_ok());
+        assert!(
+            eval_predicate(
+                &predicate,
+                &variables,
+                &Some(Value::Number(Number::Integer(1))),
+                &context_dir
+            )
+            .is_ok()
+        );
 
         // startswith predicate generates a type error with an integer value
         // predicate: `not startWith "toto"`

--- a/packages/hurl/src/runner/query.rs
+++ b/packages/hurl/src/runner/query.rs
@@ -192,7 +192,7 @@ fn parse_cache_xml<'cache>(
                 query_source_info,
                 RunnerErrorKind::Http(e),
                 false,
-            ))
+            ));
         }
     };
     let format = if response.is_html() {
@@ -245,7 +245,7 @@ fn parse_cache_json<'cache>(
                 query_source_info,
                 RunnerErrorKind::Http(e),
                 false,
-            ))
+            ));
         }
     };
     let json = match serde_json::from_str(&text) {
@@ -279,7 +279,7 @@ fn eval_query_regex(
                 query_source_info,
                 RunnerErrorKind::Http(inner),
                 false,
-            ))
+            ));
         }
     };
     let re = match regex {
@@ -292,7 +292,7 @@ fn eval_query_regex(
                         t.source_info,
                         RunnerErrorKind::InvalidRegex,
                         false,
-                    ))
+                    ));
                 }
             }
         }
@@ -1505,14 +1505,16 @@ pub mod tests {
 
     #[test]
     fn test_query_certificate() {
-        assert!(eval_query_certificate(
-            &Response {
-                ..default_response()
-            },
-            CertificateAttributeName::Subject
-        )
-        .unwrap()
-        .is_none());
+        assert!(
+            eval_query_certificate(
+                &Response {
+                    ..default_response()
+                },
+                CertificateAttributeName::Subject
+            )
+            .unwrap()
+            .is_none()
+        );
 
         let subject = Some("A=B, C=D".to_string());
         let issuer = Some(String::new());

--- a/packages/hurl/src/runner/request.rs
+++ b/packages/hurl/src/runner/request.rs
@@ -17,15 +17,15 @@
  */
 use std::str::FromStr;
 
-use base64::engine::general_purpose;
 use base64::Engine;
+use base64::engine::general_purpose;
 use hurl_core::ast::Body as AstBody;
 use hurl_core::ast::Method as AstMethod;
 use hurl_core::ast::{Bytes, MultilineString, MultilineStringKind, Request, Template};
 
 use crate::http::{
-    Body, Header, HeaderVec, Method, Param, RequestCookie, RequestSpec, Url, UrlError,
-    AUTHORIZATION,
+    AUTHORIZATION, Body, Header, HeaderVec, Method, Param, RequestCookie, RequestSpec, Url,
+    UrlError,
 };
 use crate::util::path::ContextDir;
 
@@ -171,12 +171,12 @@ fn eval_url(url_template: &Template, variables: &VariableSet) -> Result<Url, Run
 /// Returns the string used to set a new cookie in the cookie store.
 pub fn get_cmd_cookie_storage_set(request: &Request) -> Option<String> {
     for line_terminator in request.line_terminators.iter() {
-        if let Some(s) = &line_terminator.comment {
-            if s.value.contains("@cookie_storage_set:") {
-                let index = "#@cookie_storage_set:".to_string().len();
-                let value = &s.value[index..s.value.len()].to_string().trim().to_string();
-                return Some(value.to_string());
-            }
+        if let Some(s) = &line_terminator.comment
+            && s.value.contains("@cookie_storage_set:")
+        {
+            let index = "#@cookie_storage_set:".to_string().len();
+            let value = &s.value[index..s.value.len()].to_string().trim().to_string();
+            return Some(value.to_string());
         }
     }
     None
@@ -187,10 +187,10 @@ pub fn get_cmd_cookie_storage_set(request: &Request) -> Option<String> {
 /// Returns `true` if the cookie storage should be cleared, `false` otherwise.
 pub fn get_cmd_cookie_storage_clear(request: &Request) -> bool {
     for line_terminator in request.line_terminators.iter() {
-        if let Some(s) = &line_terminator.comment {
-            if s.value.contains("@cookie_storage_clear") {
-                return true;
-            }
+        if let Some(s) = &line_terminator.comment
+            && s.value.contains("@cookie_storage_clear")
+        {
+            return true;
         }
     }
     false

--- a/packages/hurl/src/runner/value_impl.rs
+++ b/packages/hurl/src/runner/value_impl.rs
@@ -279,22 +279,30 @@ mod tests {
 
     #[test]
     fn test_starts_with() {
-        assert!(Value::String("Hello".to_string())
-            .starts_with(&Value::String("H".to_string()))
-            .unwrap());
-        assert!(!Value::Bytes(vec![0, 1, 2])
-            .starts_with(&Value::Bytes(vec![0, 2]))
-            .unwrap());
+        assert!(
+            Value::String("Hello".to_string())
+                .starts_with(&Value::String("H".to_string()))
+                .unwrap()
+        );
+        assert!(
+            !Value::Bytes(vec![0, 1, 2])
+                .starts_with(&Value::Bytes(vec![0, 2]))
+                .unwrap()
+        );
     }
 
     #[test]
     fn test_ends_with() {
-        assert!(Value::String("Hello".to_string())
-            .ends_with(&Value::String("o".to_string()))
-            .unwrap());
-        assert!(!Value::Bytes(vec![0, 1, 2])
-            .ends_with(&Value::Bytes(vec![0, 2]))
-            .unwrap());
+        assert!(
+            Value::String("Hello".to_string())
+                .ends_with(&Value::String("o".to_string()))
+                .unwrap()
+        );
+        assert!(
+            !Value::Bytes(vec![0, 1, 2])
+                .ends_with(&Value::Bytes(vec![0, 2]))
+                .unwrap()
+        );
     }
 
     #[test]
@@ -303,9 +311,11 @@ mod tests {
         assert!(contains(&haystack, &[1]));
         assert!(contains(&haystack, &[1, 2]));
         assert!(!contains(&haystack, &[1, 3]));
-        assert!(Value::String("abc".to_string())
-            .contains(&Value::String("ab".to_string()))
-            .unwrap());
+        assert!(
+            Value::String("abc".to_string())
+                .contains(&Value::String("ab".to_string()))
+                .unwrap()
+        );
         let values = Value::List(vec![
             Value::Number(Number::Integer(0)),
             Value::Number(Number::Integer(2)),
@@ -348,24 +358,36 @@ mod tests {
     #[test]
     fn test_iso_date() {
         // Some values from <https://datatracker.ietf.org/doc/html/rfc3339>
-        assert!(Value::String("1985-04-12T23:20:50.52Z".to_string())
-            .is_iso_date()
-            .unwrap());
-        assert!(Value::String("1996-12-19T16:39:57-08:00".to_string())
-            .is_iso_date()
-            .unwrap());
-        assert!(Value::String("1990-12-31T23:59:60Z".to_string())
-            .is_iso_date()
-            .unwrap());
-        assert!(Value::String("1990-12-31T15:59:60-08:00".to_string())
-            .is_iso_date()
-            .unwrap());
-        assert!(Value::String("1937-01-01T12:00:27.87+00:20".to_string())
-            .is_iso_date()
-            .unwrap());
-        assert!(!Value::String("1978-01-15".to_string())
-            .is_iso_date()
-            .unwrap());
+        assert!(
+            Value::String("1985-04-12T23:20:50.52Z".to_string())
+                .is_iso_date()
+                .unwrap()
+        );
+        assert!(
+            Value::String("1996-12-19T16:39:57-08:00".to_string())
+                .is_iso_date()
+                .unwrap()
+        );
+        assert!(
+            Value::String("1990-12-31T23:59:60Z".to_string())
+                .is_iso_date()
+                .unwrap()
+        );
+        assert!(
+            Value::String("1990-12-31T15:59:60-08:00".to_string())
+                .is_iso_date()
+                .unwrap()
+        );
+        assert!(
+            Value::String("1937-01-01T12:00:27.87+00:20".to_string())
+                .is_iso_date()
+                .unwrap()
+        );
+        assert!(
+            !Value::String("1978-01-15".to_string())
+                .is_iso_date()
+                .unwrap()
+        );
         assert_eq!(
             Value::Bool(true).is_iso_date().unwrap_err(),
             EvalError::Type

--- a/packages/hurl/src/runner/xpath.rs
+++ b/packages/hurl/src/runner/xpath.rs
@@ -130,7 +130,7 @@ fn parse_html_string_patched(
     }
 }
 
-extern "C" {
+unsafe extern "C" {
     pub fn silentErrorFunc(
         ctx: *mut ::std::os::raw::c_void,
         msg: *const ::std::os::raw::c_char,

--- a/packages/hurl_core/Cargo.toml
+++ b/packages/hurl_core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hurl_core"
 version = "8.0.0-SNAPSHOT"
 authors = ["Fabrice Reix <fabrice.reix@orange.com>", "Jean-Christophe Amiel <jeanchristophe.amiel@orange.com>", "Filipe Pinto <filipe.pinto@orange.com>"]
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 description = "Hurl Core"
 documentation = "https://hurl.dev"

--- a/packages/hurl_core/src/ast/core.rs
+++ b/packages/hurl_core/src/ast/core.rs
@@ -21,7 +21,7 @@ use crate::types::{SourceString, ToSource};
 
 use super::option::EntryOption;
 use super::primitive::{
-    Bytes, KeyValue, LineTerminator, Placeholder, SourceInfo, Template, Whitespace, I64,
+    Bytes, I64, KeyValue, LineTerminator, Placeholder, SourceInfo, Template, Whitespace,
 };
 use super::section::{Assert, Capture, Cookie, MultipartParam, RegexValue, Section, SectionValue};
 

--- a/packages/hurl_core/src/ast/option.rs
+++ b/packages/hurl_core/src/ast/option.rs
@@ -20,7 +20,7 @@ use std::fmt;
 use crate::types::{Count, DurationUnit, SourceString, ToSource};
 
 use super::primitive::{
-    LineTerminator, Number, Placeholder, SourceInfo, Template, Whitespace, U64,
+    LineTerminator, Number, Placeholder, SourceInfo, Template, U64, Whitespace,
 };
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/packages/hurl_core/src/ast/visit.rs
+++ b/packages/hurl_core/src/ast/visit.rs
@@ -26,8 +26,8 @@ use crate::ast::{
     FilterValue, Hex, HurlFile, IntegerValue, JsonValue, KeyValue, LineTerminator, Method,
     MultilineString, MultipartParam, NaturalOption, Number, OptionKind, Placeholder, Predicate,
     PredicateFuncValue, PredicateValue, Query, QueryValue, Regex, RegexValue, Request, Response,
-    Section, SectionValue, StatusValue, Template, VariableDefinition, VariableValue,
-    VerbosityOption, VersionValue, Whitespace, U64,
+    Section, SectionValue, StatusValue, Template, U64, VariableDefinition, VariableValue,
+    VerbosityOption, VersionValue, Whitespace,
 };
 use crate::types::{Count, DurationUnit, SourceString, ToSource};
 
@@ -819,8 +819,8 @@ pub fn walk_verbosity_option<V: Visitor>(visitor: &mut V, value: &VerbosityOptio
 
 #[cfg(test)]
 mod tests {
-    use crate::ast::visit::Visitor;
     use crate::ast::Assert;
+    use crate::ast::visit::Visitor;
     use crate::parser;
 
     #[test]

--- a/packages/hurl_core/src/format/html.rs
+++ b/packages/hurl_core/src/format/html.rs
@@ -17,8 +17,8 @@
  */
 use crate::ast::visit::Visitor;
 use crate::ast::{
-    visit, Comment, Entry, FilterValue, JsonValue, Method, Placeholder, Regex, Request, Response,
-    Template, Whitespace, U64,
+    Comment, Entry, FilterValue, JsonValue, Method, Placeholder, Regex, Request, Response,
+    Template, U64, Whitespace, visit,
 };
 use crate::ast::{
     CookiePath, HurlFile, MultilineString, Number, PredicateFuncValue, QueryValue, StatusValue,

--- a/packages/hurl_core/src/parser/bytes.rs
+++ b/packages/hurl_core/src/parser/bytes.rs
@@ -20,7 +20,7 @@ use crate::combinator::choice;
 use crate::parser::json::parse as parse_json;
 use crate::parser::multiline::multiline_string;
 use crate::parser::string::backtick_template;
-use crate::parser::{primitives, xml, ParseResult};
+use crate::parser::{ParseResult, primitives, xml};
 use crate::reader::Reader;
 
 pub fn bytes(reader: &mut Reader) -> ParseResult<Bytes> {

--- a/packages/hurl_core/src/parser/cookiepath.rs
+++ b/packages/hurl_core/src/parser/cookiepath.rs
@@ -18,7 +18,7 @@
 use crate::ast::{CookieAttribute, CookieAttributeName, CookiePath};
 use crate::combinator::optional;
 use crate::parser::primitives::{literal, try_literal, zero_or_more_spaces};
-use crate::parser::{string, ParseError, ParseErrorKind, ParseResult};
+use crate::parser::{ParseError, ParseErrorKind, ParseResult, string};
 use crate::reader::Reader;
 
 pub fn cookiepath(reader: &mut Reader) -> ParseResult<CookiePath> {

--- a/packages/hurl_core/src/parser/expr.rs
+++ b/packages/hurl_core/src/parser/expr.rs
@@ -16,7 +16,7 @@
  *
  */
 use crate::ast::{Expr, ExprKind, SourceInfo, Variable};
-use crate::parser::{function, ParseError, ParseErrorKind, ParseResult};
+use crate::parser::{ParseError, ParseErrorKind, ParseResult, function};
 use crate::reader::Reader;
 
 /// Parse an expression

--- a/packages/hurl_core/src/parser/filename.rs
+++ b/packages/hurl_core/src/parser/filename.rs
@@ -18,7 +18,7 @@
 use super::placeholder;
 use crate::ast::{SourceInfo, Template, TemplateElement};
 use crate::parser::primitives::try_literal;
-use crate::parser::{string, ParseError, ParseErrorKind, ParseResult};
+use crate::parser::{ParseError, ParseErrorKind, ParseResult, string};
 use crate::reader::Reader;
 use crate::types::ToSource;
 
@@ -58,13 +58,13 @@ pub fn parse(reader: &mut Reader) -> ParseResult<Template> {
         let kind = ParseErrorKind::Filename;
         return Err(ParseError::new(start.pos, false, kind));
     }
-    if let Some(TemplateElement::String { source, .. }) = elements.first() {
-        if source.starts_with('[') {
-            let kind = ParseErrorKind::Expecting {
-                value: "filename".to_string(),
-            };
-            return Err(ParseError::new(start.pos, false, kind));
-        }
+    if let Some(TemplateElement::String { source, .. }) = elements.first()
+        && source.starts_with('[')
+    {
+        let kind = ParseErrorKind::Expecting {
+            value: "filename".to_string(),
+        };
+        return Err(ParseError::new(start.pos, false, kind));
     }
 
     let end = reader.cursor();

--- a/packages/hurl_core/src/parser/filename_password.rs
+++ b/packages/hurl_core/src/parser/filename_password.rs
@@ -18,7 +18,7 @@
 use super::placeholder;
 use crate::ast::{SourceInfo, Template, TemplateElement};
 use crate::parser::primitives::try_literal;
-use crate::parser::{string, ParseError, ParseErrorKind, ParseResult};
+use crate::parser::{ParseError, ParseErrorKind, ParseResult, string};
 use crate::reader::Reader;
 use crate::types::ToSource;
 
@@ -59,13 +59,13 @@ pub fn parse(reader: &mut Reader) -> ParseResult<Template> {
         let kind = ParseErrorKind::Filename;
         return Err(ParseError::new(start.pos, false, kind));
     }
-    if let Some(TemplateElement::String { source, .. }) = elements.first() {
-        if source.starts_with('[') {
-            let kind = ParseErrorKind::Expecting {
-                value: "filename".to_string(),
-            };
-            return Err(ParseError::new(start.pos, false, kind));
-        }
+    if let Some(TemplateElement::String { source, .. }) = elements.first()
+        && source.starts_with('[')
+    {
+        let kind = ParseErrorKind::Expecting {
+            value: "filename".to_string(),
+        };
+        return Err(ParseError::new(start.pos, false, kind));
     }
 
     let end = reader.cursor();

--- a/packages/hurl_core/src/parser/filter.rs
+++ b/packages/hurl_core/src/parser/filter.rs
@@ -16,12 +16,12 @@
  *
  */
 use crate::ast::{Filter, FilterValue, IntegerValue, SourceInfo, Whitespace};
-use crate::combinator::{choice, ParseError as ParseErrorTrait};
+use crate::combinator::{ParseError as ParseErrorTrait, choice};
 use crate::parser::number::integer;
 use crate::parser::primitives::{one_or_more_spaces, try_literal, zero_or_more_spaces};
 use crate::parser::query::regex_value;
 use crate::parser::string::quoted_template;
-use crate::parser::{placeholder, ParseError, ParseErrorKind, ParseResult};
+use crate::parser::{ParseError, ParseErrorKind, ParseResult, placeholder};
 use crate::reader::Reader;
 
 pub fn filters(reader: &mut Reader) -> ParseResult<Vec<(Whitespace, Filter)>> {

--- a/packages/hurl_core/src/parser/json.rs
+++ b/packages/hurl_core/src/parser/json.rs
@@ -17,10 +17,10 @@
  */
 use super::placeholder;
 use crate::ast::{JsonListElement, JsonObjectElement, JsonValue, SourceInfo, Template};
-use crate::combinator::{choice, non_recover, ParseError as ParseErrorTrait};
+use crate::combinator::{ParseError as ParseErrorTrait, choice, non_recover};
 use crate::parser::primitives::{boolean, hex_digit, literal, try_literal};
 use crate::parser::template::EncodedString;
-use crate::parser::{templatize, JsonErrorVariant, ParseError, ParseErrorKind, ParseResult};
+use crate::parser::{JsonErrorVariant, ParseError, ParseErrorKind, ParseResult, templatize};
 use crate::reader::{Pos, Reader};
 
 pub fn parse(reader: &mut Reader) -> ParseResult<JsonValue> {
@@ -40,11 +40,11 @@ pub fn parse(reader: &mut Reader) -> ParseResult<JsonValue> {
 
 /// Helper for parse, but already knowing that we are inside a JSON body.
 fn parse_in_json(reader: &mut Reader) -> ParseResult<JsonValue> {
-    if let Some(c) = reader.peek() {
-        if c == ',' {
-            let kind = ParseErrorKind::Json(JsonErrorVariant::EmptyElement);
-            return Err(ParseError::new(reader.cursor().pos, false, kind));
-        }
+    if let Some(c) = reader.peek()
+        && c == ','
+    {
+        let kind = ParseErrorKind::Json(JsonErrorVariant::EmptyElement);
+        return Err(ParseError::new(reader.cursor().pos, false, kind));
     }
     match parse(reader) {
         Ok(r) => Ok(r),

--- a/packages/hurl_core/src/parser/key_string.rs
+++ b/packages/hurl_core/src/parser/key_string.rs
@@ -18,7 +18,7 @@
 use super::placeholder;
 use crate::ast::{SourceInfo, Template, TemplateElement};
 use crate::parser::primitives::try_literal;
-use crate::parser::{string, ParseError, ParseErrorKind, ParseResult};
+use crate::parser::{ParseError, ParseErrorKind, ParseResult, string};
 use crate::reader::Reader;
 use crate::types::ToSource;
 
@@ -55,13 +55,13 @@ pub fn parse(reader: &mut Reader) -> ParseResult<Template> {
         };
         return Err(ParseError::new(start.pos, false, kind));
     }
-    if let Some(TemplateElement::String { source, .. }) = elements.first() {
-        if source.starts_with('[') {
-            let kind = ParseErrorKind::Expecting {
-                value: "key-string".to_string(),
-            };
-            return Err(ParseError::new(start.pos, false, kind));
-        }
+    if let Some(TemplateElement::String { source, .. }) = elements.first()
+        && source.starts_with('[')
+    {
+        let kind = ParseErrorKind::Expecting {
+            value: "key-string".to_string(),
+        };
+        return Err(ParseError::new(start.pos, false, kind));
     }
 
     let end = reader.cursor();

--- a/packages/hurl_core/src/parser/multiline.rs
+++ b/packages/hurl_core/src/parser/multiline.rs
@@ -22,7 +22,7 @@ use crate::ast::{
 use crate::combinator::{choice, optional, zero_or_more};
 use crate::parser::json::object_value;
 use crate::parser::primitives::{literal, newline, try_literal, zero_or_more_spaces};
-use crate::parser::{template, ParseError, ParseErrorKind, ParseResult};
+use crate::parser::{ParseError, ParseErrorKind, ParseResult, template};
 use crate::reader::Reader;
 use crate::typing::ToSource;
 
@@ -309,7 +309,7 @@ fn graphql_variables(reader: &mut Reader) -> ParseResult<GraphQlVariables> {
                 start.pos,
                 false,
                 ParseErrorKind::GraphQlVariables,
-            ))
+            ));
         }
     };
     let whitespace = zero_or_more_whitespaces(reader)?;

--- a/packages/hurl_core/src/parser/number.rs
+++ b/packages/hurl_core/src/parser/number.rs
@@ -15,7 +15,7 @@
  * limitations under the License.
  *
  */
-use crate::ast::{Float, Number, I64, U64};
+use crate::ast::{Float, I64, Number, U64};
 use crate::parser::primitives::try_literal;
 use crate::parser::{ParseError, ParseErrorKind, ParseResult};
 use crate::reader::Reader;

--- a/packages/hurl_core/src/parser/option.rs
+++ b/packages/hurl_core/src/parser/option.rs
@@ -17,8 +17,8 @@
  */
 use super::placeholder;
 use crate::ast::{
-    is_variable_reserved, BooleanOption, CountOption, DurationOption, EntryOption, NaturalOption,
-    OptionKind, SourceInfo, VariableDefinition, VariableValue, VerbosityOption,
+    BooleanOption, CountOption, DurationOption, EntryOption, NaturalOption, OptionKind, SourceInfo,
+    VariableDefinition, VariableValue, VerbosityOption, is_variable_reserved,
 };
 use crate::combinator::{choice, non_recover};
 use crate::parser::duration::duration;
@@ -28,7 +28,7 @@ use crate::parser::primitives::{
     zero_or_more_spaces,
 };
 use crate::parser::string::{quoted_template, unquoted_template};
-use crate::parser::{filename, filename_password, ParseError, ParseErrorKind, ParseResult};
+use crate::parser::{ParseError, ParseErrorKind, ParseResult, filename, filename_password};
 use crate::reader::Reader;
 use crate::types::Count;
 
@@ -93,7 +93,7 @@ pub fn parse(reader: &mut Reader) -> ParseResult<EntryOption> {
                 start.pos,
                 false,
                 ParseErrorKind::InvalidOption(option.to_string()),
-            ))
+            ));
         }
     };
 
@@ -492,7 +492,7 @@ fn variable_value(reader: &mut Reader) -> ParseResult<VariableValue> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ast::{LineTerminator, Number, Template, TemplateElement, Whitespace, I64};
+    use crate::ast::{I64, LineTerminator, Number, Template, TemplateElement, Whitespace};
     use crate::reader::Pos;
     use crate::types::ToSource;
 

--- a/packages/hurl_core/src/parser/placeholder.rs
+++ b/packages/hurl_core/src/parser/placeholder.rs
@@ -15,7 +15,7 @@
  * limitations under the License.
  *
  */
-use super::{expr, ParseResult};
+use super::{ParseResult, expr};
 use crate::ast::Placeholder;
 use crate::parser::primitives::{literal, try_literal, zero_or_more_spaces};
 use crate::reader::Reader;

--- a/packages/hurl_core/src/parser/predicate.rs
+++ b/packages/hurl_core/src/parser/predicate.rs
@@ -340,7 +340,7 @@ fn is_object_predicate(reader: &mut Reader) -> ParseResult<PredicateFuncValue> {
 mod tests {
     use super::*;
     use crate::ast::{
-        Expr, ExprKind, Float, Number, Placeholder, Template, TemplateElement, Variable, I64,
+        Expr, ExprKind, Float, I64, Number, Placeholder, Template, TemplateElement, Variable,
     };
     use crate::reader::Pos;
     use crate::types::ToSource;

--- a/packages/hurl_core/src/parser/predicate_value.rs
+++ b/packages/hurl_core/src/parser/predicate_value.rs
@@ -88,7 +88,7 @@ pub fn predicate_value(reader: &mut Reader) -> ParseResult<PredicateValue> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ast::{Float, Number, I64};
+    use crate::ast::{Float, I64, Number};
     use crate::parser::ParseErrorKind;
     use crate::reader::Pos;
     use crate::types::ToSource;

--- a/packages/hurl_core/src/parser/primitives.rs
+++ b/packages/hurl_core/src/parser/primitives.rs
@@ -20,7 +20,7 @@ use crate::ast::{
 };
 use crate::combinator::{one_or_more, optional, recover, zero_or_more};
 use crate::parser::string::unquoted_template;
-use crate::parser::{base64, filename, key_string, ParseError, ParseErrorKind, ParseResult};
+use crate::parser::{ParseError, ParseErrorKind, ParseResult, base64, filename, key_string};
 use crate::reader::Reader;
 use crate::types::{SourceString, ToSource};
 

--- a/packages/hurl_core/src/parser/query.rs
+++ b/packages/hurl_core/src/parser/query.rs
@@ -16,7 +16,7 @@
  *
  */
 use crate::ast::{CertificateAttributeName, Query, QueryValue, RegexValue, SourceInfo};
-use crate::combinator::{choice, ParseError as ParseErrorTrait};
+use crate::combinator::{ParseError as ParseErrorTrait, choice};
 use crate::parser::cookiepath::cookiepath;
 use crate::parser::primitives::{literal, one_or_more_spaces, regex, try_literal};
 use crate::parser::string::{quoted_oneline_string, quoted_template};
@@ -355,7 +355,9 @@ mod tests {
             },
         );
 
-        let mut reader = Reader::new("xpath \"normalize-space(//div[contains(concat(' ',normalize-space(@class),' '),' monthly-price ')])\"");
+        let mut reader = Reader::new(
+            "xpath \"normalize-space(//div[contains(concat(' ',normalize-space(@class),' '),' monthly-price ')])\"",
+        );
         assert_eq!(xpath_query(&mut reader).unwrap(), QueryValue::Xpath {
             space0: Whitespace { value: String::from(" "), source_info: SourceInfo::new(Pos::new(1, 6), Pos::new(1, 7)) },
             expr: Template::new(

--- a/packages/hurl_core/src/parser/sections.rs
+++ b/packages/hurl_core/src/parser/sections.rs
@@ -28,7 +28,7 @@ use crate::parser::primitives::{
 };
 use crate::parser::query::query;
 use crate::parser::string::unquoted_template;
-use crate::parser::{filename, key_string, option, ParseError, ParseErrorKind, ParseResult};
+use crate::parser::{ParseError, ParseErrorKind, ParseResult, filename, key_string, option};
 use crate::reader::{Pos, Reader};
 
 pub fn request_sections(reader: &mut Reader) -> ParseResult<Vec<Section>> {
@@ -326,8 +326,8 @@ fn assert(reader: &mut Reader) -> ParseResult<Assert> {
 mod tests {
     use super::*;
     use crate::ast::{
-        KeyValue, LineTerminator, Number, Predicate, PredicateFunc, PredicateFuncValue,
-        PredicateValue, Query, QueryValue, Template, TemplateElement, I64,
+        I64, KeyValue, LineTerminator, Number, Predicate, PredicateFunc, PredicateFuncValue,
+        PredicateValue, Query, QueryValue, Template, TemplateElement,
     };
     use crate::reader::CharPos;
     use crate::types::ToSource;
@@ -584,7 +584,9 @@ mod tests {
         assert_eq!(content_type.to_string(), "text/html".to_string());
         assert_eq!(reader.cursor().index, CharPos(22));
 
-        let mut reader = Reader::new("file,{{some_file}}; application/vnd.openxmlformats-officedocument.wordprocessingml.document # comment");
+        let mut reader = Reader::new(
+            "file,{{some_file}}; application/vnd.openxmlformats-officedocument.wordprocessingml.document # comment",
+        );
         let file_value = crate::parser::sections::file_value(&mut reader).unwrap();
         let content_type = file_value.content_type.unwrap();
         assert_eq!(

--- a/packages/hurl_core/src/parser/string.rs
+++ b/packages/hurl_core/src/parser/string.rs
@@ -18,7 +18,7 @@
 use crate::ast::{SourceInfo, Template};
 use crate::combinator::one_or_more;
 use crate::parser::primitives::{hex_digit, literal, try_literal};
-use crate::parser::{template, ParseError, ParseErrorKind, ParseResult};
+use crate::parser::{ParseError, ParseErrorKind, ParseResult, template};
 use crate::reader::Reader;
 
 /// Steps:
@@ -217,7 +217,7 @@ pub(crate) fn unicode(reader: &mut Reader) -> ParseResult<char> {
                 reader.cursor().pos,
                 false,
                 ParseErrorKind::Unicode,
-            ))
+            ));
         }
         Some(c) => c,
     };

--- a/packages/hurl_core/src/parser/template.rs
+++ b/packages/hurl_core/src/parser/template.rs
@@ -17,7 +17,7 @@
  */
 use crate::ast::{Placeholder, SourceInfo, TemplateElement};
 use crate::parser::primitives::zero_or_more_spaces;
-use crate::parser::{error, expr, ParseResult};
+use crate::parser::{ParseResult, error, expr};
 use crate::reader::{Pos, Reader};
 use crate::types::SourceString;
 

--- a/packages/hurl_core/src/parser/xml.rs
+++ b/packages/hurl_core/src/parser/xml.rs
@@ -58,7 +58,7 @@ pub fn parse(reader: &mut Reader) -> ParseResult<String> {
                 reader.cursor().pos,
                 true,
                 ParseErrorKind::Xml,
-            ))
+            ));
         }
     }
 

--- a/packages/hurl_core/src/text/styledstring.rs
+++ b/packages/hurl_core/src/text/styledstring.rs
@@ -68,11 +68,11 @@ impl StyledString {
 
     fn push_token(&mut self, token: Token) {
         // Concatenate content to last token if it has the same style
-        if let Some(last) = self.tokens.last_mut() {
-            if last.style == token.style {
-                last.content.push_str(&token.content);
-                return;
-            }
+        if let Some(last) = self.tokens.last_mut()
+            && last.style == token.style
+        {
+            last.content.push_str(&token.content);
+            return;
         }
         self.tokens.push(token);
     }

--- a/packages/hurlfmt/Cargo.toml
+++ b/packages/hurlfmt/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hurlfmt"
 version = "8.0.0-SNAPSHOT"
 authors = ["Fabrice Reix <fabrice.reix@orange.com>", "Jean-Christophe Amiel <jeanchristophe.amiel@orange.com>", "Filipe Pinto <filipe.pinto@orange.com>"]
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 description = "Format Hurl files"
 documentation = "https://hurl.dev"

--- a/packages/hurlfmt/src/command/format.rs
+++ b/packages/hurlfmt/src/command/format.rs
@@ -68,7 +68,7 @@ fn run_format(input_file: &Path) -> Result<(), FormatError> {
             return Err(FormatError::IO {
                 filename: input_file.display().to_string(),
                 message: e.to_string(),
-            })
+            });
         }
         Ok(file) => file,
     };

--- a/packages/hurlfmt/src/curl/commands.rs
+++ b/packages/hurlfmt/src/curl/commands.rs
@@ -15,7 +15,7 @@
  * limitations under the License.
  *
  */
-use clap::{value_parser, ArgAction};
+use clap::{ArgAction, value_parser};
 
 pub fn compressed() -> clap::Arg {
     clap::Arg::new("compressed").long("compressed").num_args(0)

--- a/packages/hurlfmt/src/curl/matches.rs
+++ b/packages/hurlfmt/src/curl/matches.rs
@@ -66,10 +66,10 @@ pub fn headers(arg_matches: &ArgMatches) -> Vec<String> {
     if !has_content_type(&headers) {
         if has_arg(arg_matches, "data_raw") {
             headers.push("Content-Type: application/x-www-form-urlencoded".to_string());
-        } else if let Some(data) = get_string(arg_matches, "data") {
-            if !data.starts_with('@') {
-                headers.push("Content-Type: application/x-www-form-urlencoded".to_string());
-            }
+        } else if let Some(data) = get_string(arg_matches, "data")
+            && !data.starts_with('@')
+        {
+            headers.push("Content-Type: application/x-www-form-urlencoded".to_string());
         }
     }
 

--- a/packages/hurlfmt/src/format/json.rs
+++ b/packages/hurlfmt/src/format/json.rs
@@ -15,8 +15,8 @@
  * limitations under the License.
  *
  */
-use base64::engine::general_purpose;
 use base64::Engine;
+use base64::engine::general_purpose;
 use hurl_core::ast::{
     Assert, Base64, Body, BooleanOption, Bytes, Capture, CertificateAttributeName, Comment, Cookie,
     CountOption, Duration, DurationOption, Entry, EntryOption, File, FilenameParam, Filter,
@@ -739,8 +739,8 @@ impl ToJson for NaturalOption {
 #[cfg(test)]
 pub mod tests {
     use hurl_core::ast::{
-        LineTerminator, Method, Number, PredicateFunc, SourceInfo, Status, Template,
-        TemplateElement, Version, Whitespace, I64,
+        I64, LineTerminator, Method, Number, PredicateFunc, SourceInfo, Status, Template,
+        TemplateElement, Version, Whitespace,
     };
     use hurl_core::reader::Pos;
     use hurl_core::types::ToSource;

--- a/packages/hurlfmt/src/format/text.rs
+++ b/packages/hurlfmt/src/format/text.rs
@@ -18,8 +18,8 @@
 use hurl_core::ast::visit::Visitor;
 use hurl_core::ast::{
     Comment, CookiePath, FilterValue, HurlFile, JsonValue, Method, MultilineString, Number,
-    Placeholder, PredicateFuncValue, QueryValue, Regex, StatusValue, Template, VersionValue,
-    Whitespace, U64,
+    Placeholder, PredicateFuncValue, QueryValue, Regex, StatusValue, Template, U64, VersionValue,
+    Whitespace,
 };
 use hurl_core::text::{Format, Style, StyledString};
 use hurl_core::types::{DurationUnit, SourceString, ToSource};

--- a/packages/hurlfmt/src/linter/rewrite.rs
+++ b/packages/hurlfmt/src/linter/rewrite.rs
@@ -18,11 +18,11 @@
 use hurl_core::ast::{
     Assert, Base64, Body, BooleanOption, Bytes, Capture, CertificateAttributeName, Comment, Cookie,
     CookiePath, CountOption, Duration, DurationOption, Entry, EntryOption, File, FilenameParam,
-    FilenameValue, FilterValue, Hex, HurlFile, IntegerValue, JsonValue, KeyValue, LineTerminator,
-    Method, MultilineString, MultipartParam, NaturalOption, Number, OptionKind, Placeholder,
-    Predicate, PredicateFuncValue, PredicateValue, Query, QueryValue, Regex, RegexValue, Request,
-    Response, Section, SectionValue, StatusValue, Template, VariableDefinition, VariableValue,
-    VerbosityOption, VersionValue, I64, U64,
+    FilenameValue, FilterValue, Hex, HurlFile, I64, IntegerValue, JsonValue, KeyValue,
+    LineTerminator, Method, MultilineString, MultipartParam, NaturalOption, Number, OptionKind,
+    Placeholder, Predicate, PredicateFuncValue, PredicateValue, Query, QueryValue, Regex,
+    RegexValue, Request, Response, Section, SectionValue, StatusValue, Template, U64,
+    VariableDefinition, VariableValue, VerbosityOption, VersionValue,
 };
 use hurl_core::types::{Count, DurationUnit, ToSource};
 

--- a/packages/hurlfmt/src/main.rs
+++ b/packages/hurlfmt/src/main.rs
@@ -21,8 +21,8 @@ use std::process;
 
 use hurl_core::input::{Input, InputKind};
 use hurl_core::text;
-use hurlfmt::cli::options::{InputFormat, OptionsError, OutputFormat};
 use hurlfmt::cli::Logger;
+use hurlfmt::cli::options::{InputFormat, OptionsError, OutputFormat};
 use hurlfmt::command::check::CheckError;
 use hurlfmt::command::export::ExportError;
 use hurlfmt::command::format::FormatError;


### PR DESCRIPTION
See <https://blog.rust-lang.org/2025/02/20/Rust-1.85.0/>. @fabricereix What's impacting us is mainly "chain let if" => <https://doc.rust-lang.org/edition-guide/rust-2024/let-chains.html#let-chains-in-if-and-while>

Before:

```rust
impl NameSelector {
    pub fn eval(&self, current_value: &serde_json::Value) -> Option<serde_json::Value> {
        if let serde_json::Value::Object(key_values) = current_value {
            if let Some(value) = key_values.get(self.value()) {
                return Some(value.clone());
            }
        }
        None
    }
}
```

After:

```rust
impl NameSelector {
    pub fn eval(&self, current_value: &serde_json::Value) -> Option<serde_json::Value> {
        if let serde_json::Value::Object(key_values) = current_value
            && let Some(value) = key_values.get(self.value())
        {
            return Some(value.clone());
        }
        None
    }
}
```
