### PR TITLE
Fix diff source line for multiline template newlines

### DIFF
--- a/packages/hurl/src/runner/assert.rs
+++ b/packages/hurl/src/runner/assert.rs
@@ -82,6 +82,7 @@ impl AssertResult {
                 actual,
                 expected,
                 source_info,
+                source_line_map,
             } => match expected {
                 Err(e) => Some(e.clone()),
                 Ok(expected) => match actual {
@@ -92,7 +93,15 @@ impl AssertResult {
                         } else if use_diff(expected, actual) {
                             let actual = actual.to_string();
                             let expected = expected.to_string();
-                            let hunks = diff(&expected, &actual);
+                            let mut hunks = diff(&expected, &actual);
+                            if let Some(source_line_map) = source_line_map {
+                                for hunk in &mut hunks {
+                                    if let Some(source_line) = source_line_map.get(hunk.source_line)
+                                    {
+                                        hunk.source_line = *source_line;
+                                    }
+                                }
+                            }
                             let source_line = hunks
                                 .clone()
                                 .first()
@@ -209,7 +218,9 @@ pub mod tests {
         Filter, FilterValue, I64, LineTerminator, Predicate, PredicateFunc, PredicateFuncValue,
         PredicateValue, SourceInfo, Whitespace,
     };
+    use hurl_core::error::{DisplaySourceError, OutputFormat};
     use hurl_core::reader::Pos;
+    use hurl_core::text::Format;
     use hurl_core::types::ToSource;
 
     use super::super::query;
@@ -295,5 +306,52 @@ pub mod tests {
             &Value::String("a\n".to_string()),
             &Value::String("b".to_string())
         ));
+    }
+
+    #[test]
+    fn test_implicit_body_diff_uses_multiline_source_line_map() {
+        let content = r#"GET http://localhost:8000/test
+HTTP 200
+```
+line1
+line2{{newline}}line3
+line4
+```"#;
+        let lines = content.lines().collect::<Vec<_>>();
+
+        let assert = AssertResult::ImplicitBody {
+            actual: Ok(Value::String("line1\nline2\nline3\nLINE4\n".to_string())),
+            expected: Ok(Value::String("line1\nline2\nline3\nline4\n".to_string())),
+            source_info: SourceInfo::new(Pos::new(4, 1), Pos::new(7, 1)),
+            source_line_map: Some(vec![0, 1, 1, 2, 3]),
+        };
+
+        let error = assert.to_runner_error().unwrap();
+
+        assert_eq!(
+            error.source_info,
+            SourceInfo::new(Pos::new(6, 1), Pos::new(6, 1))
+        );
+        assert_eq!(
+            error.message(&lines).to_string(Format::Plain),
+            "\n 6 | line4\n   |   -line4\n   |   +LINE4\n   |"
+        );
+        assert_eq!(
+            error.render(
+                "test.hurl",
+                content,
+                Some(SourceInfo::new(Pos::new(1, 1), Pos::new(7, 3))),
+                OutputFormat::Terminal(false)
+            ),
+            r#"Assert body value
+  --> test.hurl:6:1
+   |
+   | GET http://localhost:8000/test
+   | ...
+ 6 | line4
+   |   -line4
+   |   +LINE4
+   |"#
+        );
     }
 }

--- a/packages/hurl/src/runner/multiline.rs
+++ b/packages/hurl/src/runner/multiline.rs
@@ -15,13 +15,13 @@
  * limitations under the License.
  *
  */
-use hurl_core::ast::{MultilineString, MultilineStringKind};
+use hurl_core::ast::{MultilineString, MultilineStringKind, Template, TemplateElement};
 use hurl_core::types::ToSource;
 use serde_json::json;
 
 use super::error::RunnerError;
 use super::json::eval_json_value;
-use super::template::eval_template;
+use super::template::{eval_template, eval_template_element};
 use super::variable::VariableSet;
 
 /// Renders to string a multiline body, given a set of variables.
@@ -55,17 +55,89 @@ pub fn eval_multiline(
     }
 }
 
+/// Renders to string a multiline body and returns the rendered line-to-source-line mapping.
+///
+/// The returned vector is indexed by rendered 0-based line number and stores the corresponding
+/// 0-based source line offset within the multiline template.
+pub fn eval_multiline_with_source_line_map(
+    multiline: &MultilineString,
+    variables: &VariableSet,
+) -> Result<(String, Vec<usize>), RunnerError> {
+    match &multiline.kind {
+        MultilineStringKind::Text(value)
+        | MultilineStringKind::Json(value)
+        | MultilineStringKind::Xml(value) => {
+            eval_multiline_template_with_source_line_map(value, variables)
+        }
+        MultilineStringKind::Raw(value) => {
+            let rendered = value.to_source().to_string();
+            Ok((rendered.clone(), identity_source_line_map(&rendered)))
+        }
+        MultilineStringKind::GraphQl(graphql) => {
+            let body = eval_multiline(multiline, variables)?;
+            let source_line_map = identity_source_line_map(&graphql.value.to_source().to_string());
+            Ok((body, source_line_map))
+        }
+    }
+}
+
+fn eval_multiline_template_with_source_line_map(
+    template: &Template,
+    variables: &VariableSet,
+) -> Result<(String, Vec<usize>), RunnerError> {
+    let mut rendered = String::new();
+    let mut source_line_map = vec![0];
+    let mut source_line = 0;
+
+    for element in &template.elements {
+        match element {
+            TemplateElement::String { value, .. } => {
+                rendered.push_str(value);
+                for c in value.chars() {
+                    if c == '\n' {
+                        source_line += 1;
+                        source_line_map.push(source_line);
+                    }
+                }
+            }
+            TemplateElement::Placeholder(_) => {
+                let value = eval_template_element(element, variables)?;
+                rendered.push_str(&value);
+                for c in value.chars() {
+                    if c == '\n' {
+                        source_line_map.push(source_line);
+                    }
+                }
+            }
+        }
+    }
+    Ok((rendered, source_line_map))
+}
+
+fn identity_source_line_map(rendered: &str) -> Vec<usize> {
+    let mut source_line_map = vec![0];
+    let mut source_line = 0;
+    for c in rendered.chars() {
+        if c == '\n' {
+            source_line += 1;
+            source_line_map.push(source_line);
+        }
+    }
+    source_line_map
+}
+
 #[cfg(test)]
 mod tests {
     use hurl_core::ast::{
-        GraphQl, GraphQlVariables, JsonObjectElement, JsonValue, MultilineString,
-        MultilineStringKind, SourceInfo, Template, TemplateElement, Whitespace,
+        Expr, ExprKind, GraphQl, GraphQlVariables, JsonObjectElement, JsonValue, MultilineString,
+        MultilineStringKind, Placeholder, SourceInfo, Template, TemplateElement, Variable,
+        Whitespace,
     };
     use hurl_core::reader::Pos;
     use hurl_core::types::ToSource;
 
-    use crate::runner::VariableSet;
-    use crate::runner::multiline::eval_multiline;
+    use crate::runner::multiline::{eval_multiline, eval_multiline_with_source_line_map};
+    use crate::runner::{Value, VariableSet};
 
     fn whitespace() -> Whitespace {
         Whitespace {
@@ -190,5 +262,52 @@ mod tests {
 
         let body = eval_multiline(&multiline, &hurl_variables).unwrap();
         assert_eq!(body, r#"{"query":"{\n  human(id: \"1000\") {\n    name\n    height(unit: FOOT)\n  }\n}","variables":{"episode":"JEDI","withFriends":false}}"#.to_string());
+    }
+
+    #[test]
+    fn eval_multiline_with_source_line_map_preserves_newline_expanding_placeholders() {
+        let multiline = MultilineString {
+            space: whitespace(),
+            newline: newline(),
+            kind: MultilineStringKind::Text(Template::new(
+                None,
+                vec![
+                    TemplateElement::String {
+                        value: "line1\nline2".to_string(),
+                        source: "line1\nline2".to_source(),
+                    },
+                    TemplateElement::Placeholder(Placeholder {
+                        space0: Whitespace {
+                            value: String::new(),
+                            source_info: SourceInfo::new(Pos::new(3, 8), Pos::new(3, 8)),
+                        },
+                        expr: Expr {
+                            source_info: SourceInfo::new(Pos::new(3, 8), Pos::new(3, 15)),
+                            kind: ExprKind::Variable(Variable {
+                                name: "newline".to_string(),
+                                source_info: SourceInfo::new(Pos::new(3, 8), Pos::new(3, 15)),
+                            }),
+                        },
+                        space1: Whitespace {
+                            value: String::new(),
+                            source_info: SourceInfo::new(Pos::new(3, 15), Pos::new(3, 15)),
+                        },
+                    }),
+                    TemplateElement::String {
+                        value: "line3\nline4\n".to_string(),
+                        source: "line3\nline4\n".to_source(),
+                    },
+                ],
+                SourceInfo::new(Pos::new(2, 1), Pos::new(5, 1)),
+            )),
+        };
+        let mut variables = VariableSet::new();
+        variables.insert("newline".to_string(), Value::String("\n".to_string()));
+
+        let (body, source_line_map) =
+            eval_multiline_with_source_line_map(&multiline, &variables).unwrap();
+
+        assert_eq!(body, "line1\nline2\nline3\nline4\n".to_string());
+        assert_eq!(source_line_map, vec![0, 1, 1, 2, 3]);
     }
 }

--- a/packages/hurl/src/runner/response.rs
+++ b/packages/hurl/src/runner/response.rs
@@ -15,7 +15,9 @@
  * limitations under the License.
  *
  */
-use hurl_core::ast::{Base64, Body, Bytes, Hex, Response, SourceInfo, StatusValue};
+use hurl_core::ast::{
+    Base64, Body, Bytes, Hex, MultilineStringKind, Response, SourceInfo, StatusValue,
+};
 
 use crate::http;
 use crate::util::path::ContextDir;
@@ -194,6 +196,7 @@ fn eval_implicit_body_asserts(
                 actual,
                 expected,
                 source_info: spec_body.space0.source_info,
+                source_line_map: None,
             }
         }
         Bytes::Xml(value) => {
@@ -216,6 +219,7 @@ fn eval_implicit_body_asserts(
                 actual,
                 expected,
                 source_info: spec_body.space0.source_info,
+                source_line_map: None,
             }
         }
         Bytes::OnelineString(value) => {
@@ -241,12 +245,26 @@ fn eval_implicit_body_asserts(
                 actual,
                 expected,
                 source_info: value.source_info,
+                source_line_map: None,
             }
         }
         Bytes::MultilineString(multi) => {
-            let expected = match multiline::eval_multiline(multi, variables) {
-                Ok(s) => Ok(Value::String(s)),
-                Err(e) => Err(e),
+            let (expected, source_line_map) = match &multi.kind {
+                MultilineStringKind::Text(_)
+                | MultilineStringKind::Json(_)
+                | MultilineStringKind::Xml(_) => {
+                    match multiline::eval_multiline_with_source_line_map(multi, variables) {
+                        Ok((s, source_line_map)) => (Ok(Value::String(s)), Some(source_line_map)),
+                        Err(e) => (Err(e), None),
+                    }
+                }
+                _ => {
+                    let expected = match multiline::eval_multiline(multi, variables) {
+                        Ok(s) => Ok(Value::String(s)),
+                        Err(e) => Err(e),
+                    };
+                    (expected, None)
+                }
             };
             let actual = match http_response.text() {
                 Ok(s) => Ok(Value::String(s)),
@@ -266,6 +284,7 @@ fn eval_implicit_body_asserts(
                 actual,
                 expected,
                 source_info: multi.value().source_info,
+                source_line_map,
             }
         }
         Bytes::Base64(Base64 {
@@ -296,6 +315,7 @@ fn eval_implicit_body_asserts(
                     start: space0.source_info.end,
                     end: space1.source_info.start,
                 },
+                source_line_map: None,
             }
         }
         Bytes::Hex(Hex {
@@ -326,6 +346,7 @@ fn eval_implicit_body_asserts(
                     start: space0.source_info.end,
                     end: space1.source_info.start,
                 },
+                source_line_map: None,
             }
         }
         Bytes::File { .. } => {
@@ -351,6 +372,7 @@ fn eval_implicit_body_asserts(
                 actual,
                 expected,
                 source_info: spec_body.space0.source_info,
+                source_line_map: None,
             }
         }
     }

--- a/packages/hurl/src/runner/result.rs
+++ b/packages/hurl/src/runner/result.rs
@@ -167,6 +167,7 @@ pub enum AssertResult {
         actual: Result<Value, RunnerError>,
         expected: Result<Value, RunnerError>,
         source_info: SourceInfo,
+        source_line_map: Option<Vec<usize>>,
     },
     /// Explicit assert on HTTP response.
     Explicit {

--- a/packages/hurl/src/runner/template.rs
+++ b/packages/hurl/src/runner/template.rs
@@ -34,7 +34,7 @@ pub fn eval_template(template: &Template, variables: &VariableSet) -> Result<Str
     Ok(value)
 }
 
-fn eval_template_element(
+pub(crate) fn eval_template_element(
     template_element: &TemplateElement,
     variables: &VariableSet,
 ) -> Result<String, RunnerError> {


### PR DESCRIPTION
Fixes #3946.

When a multiline expected body contains a template variable that renders to a newline, the diff output can count rendered lines instead of source lines and point at the closing fence instead of the body line that actually failed.

This keeps a rendered-line to source-line mapping for multiline template bodies and rewrites the diff hunk source line from that mapping before rendering the error.

Validation:
- `cargo fmt --all --check`
- `cargo test --lib`
- `cargo test -p hurl runner:: -- --nocapture`
- direct CLI repro against a local test server before and after the patch
