### PR TITLE
release memory of response body to avoid memory consumation

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -8,3 +8,8 @@ rustflags = ["-Ctarget-feature=-crt-static"]
 # Should be only activated for Alpine but I don't know how to set it...
 [build]
 rustdocflags = ["-Ctarget-feature=-crt-static"]
+
+# Fix bindgen compatibility with clang 22+ (libxml crate build issue)
+# Prevents __float128 parsing errors in system headers
+[env]
+BINDGEN_EXTRA_CLANG_ARGS = "-target x86_64-unknown-linux-gnu"

--- a/packages/hurl/src/parallel/runner.rs
+++ b/packages/hurl/src/parallel/runner.rs
@@ -131,7 +131,7 @@ impl ParallelRunner {
         let workers = (0..workers_count)
             .map(|i| {
                 let worker = Worker::new(WorkerId::from(i), &tx_in, &rx_out);
-                let state = WorkerState::Idle;
+                let state: WorkerState = WorkerState::Idle;
                 (worker, state)
             })
             .collect::<Vec<_>>();
@@ -250,7 +250,17 @@ impl ParallelRunner {
                     // Report the completion of this job and update the progress.
                     self.progress.print_completed(&msg.result, &mut stderr);
 
-                    results.push(msg.result);
+                    // release memory before results.push
+                    let mut result = msg.result;
+                    if matches!(self.output_type, OutputType::NoOutput) {
+                        for entry in &mut result.hurl_result.entries {
+                            for call in &mut entry.calls {
+                                call.request.body = Vec::new();  // release memory of request body
+                                call.response.body = Vec::new();  // release memory of response body
+                            }
+                        }
+                    }
+                    results.push(result);
 
                     self.progress.update_progress_bar(
                         &self.workers,


### PR DESCRIPTION
When loading large response bodies or repeating many times in parallel mode, memory consumption continues to accumulate until it is exhausted. 
The current solution is to release the response body when it is closest to being useless. Unit tests and simple runs have not produced errors. 
However, I am not sure if this is the optimal location, please review.
Note: Line 134 is unrelated, please ignore it.