### PR TITLE
Support unit-suffixed retry-interval template values

### DIFF
--- a/packages/hurl/src/cli/options/duration.rs
+++ b/packages/hurl/src/cli/options/duration.rs
@@ -15,11 +15,9 @@
  * limitations under the License.
  *
  */
-use std::str::FromStr;
 use std::time::Duration;
 
-use hurl_core::types::DurationUnit;
-use regex::Regex;
+use hurl_core::types::{self, DurationUnit};
 
 use super::CliOptionsError;
 
@@ -33,34 +31,7 @@ pub fn duration_from_str(
     value: &str,
     default_unit: DurationUnit,
 ) -> Result<Duration, CliOptionsError> {
-    let re = Regex::new(r"^(\d+)([a-zA-Z]*)$").unwrap();
-    let Some(caps) = re.captures(value) else {
-        let error = CliOptionsError::Error("Invalid duration".to_string());
-        return Err(error);
-    };
-    let source = caps.get(1).unwrap().as_str().to_string();
-    let duration = source
-        .parse::<u64>()
-        .map_err(|_| CliOptionsError::Error("Duration value too large".to_string()))?;
-    let unit = caps.get(2).unwrap().as_str();
-    let unit = if unit.is_empty() {
-        default_unit
-    } else {
-        DurationUnit::from_str(unit).map_err(CliOptionsError::Error)?
-    };
-    let millis = match unit {
-        DurationUnit::MilliSecond => Some(duration),
-        DurationUnit::Second => duration.checked_mul(1000),
-        DurationUnit::Minute => duration.checked_mul(1000 * 60),
-        DurationUnit::Hour => duration.checked_mul(1000 * 60 * 60),
-    };
-    match millis {
-        Some(millis) => Ok(Duration::from_millis(millis)),
-        None => {
-            let error = CliOptionsError::Error("Duration value too large".to_string());
-            Err(error)
-        }
-    }
+    types::duration_from_str(value, default_unit).map_err(CliOptionsError::Error)
 }
 
 #[cfg(test)]
@@ -84,6 +55,14 @@ mod tests {
         assert_eq!(
             duration_from_str("10mm", DurationUnit::MilliSecond).unwrap_err(),
             CliOptionsError::Error("Invalid duration unit mm".to_string())
+        );
+        assert_eq!(
+            duration_from_str("18446744073709551616", DurationUnit::MilliSecond).unwrap_err(),
+            CliOptionsError::Error("Duration value too large".to_string())
+        );
+        assert_eq!(
+            duration_from_str("18446744073709551615s", DurationUnit::MilliSecond).unwrap_err(),
+            CliOptionsError::Error("Duration value too large".to_string())
         );
     }
 

--- a/packages/hurl/src/runner/options.rs
+++ b/packages/hurl/src/runner/options.rs
@@ -19,7 +19,7 @@ use hurl_core::ast::{
     BooleanOption, CountOption, DurationOption, Entry, NaturalOption, Number as AstNumber,
     OptionKind, Placeholder, Template, VariableDefinition, VariableValue, VerbosityOption,
 };
-use hurl_core::types::{BytesPerSec, Count, DurationUnit};
+use hurl_core::types::{BytesPerSec, Count, DurationUnit, duration_from_str};
 
 use crate::http::{CredentialForwarding, FollowLocation, Header, IpResolve, RequestedHttpVersion};
 use crate::pretty::PrettyMode;
@@ -472,6 +472,8 @@ fn eval_duration_option(
     variables: &VariableSet,
     default_unit: DurationUnit,
 ) -> Result<std::time::Duration, RunnerError> {
+    const EXPECTING_DURATION: &str = "non-negative integer or duration string";
+
     let millis = match duration_value {
         DurationOption::Literal(literal) => {
             let unit = literal.unit.unwrap_or(default_unit);
@@ -489,7 +491,7 @@ fn eval_duration_option(
                 if value < 0 {
                     let kind = RunnerErrorKind::ExpressionInvalidType {
                         value: format!("integer <{value}>"),
-                        expecting: "positive integer".to_string(),
+                        expecting: EXPECTING_DURATION.to_string(),
                     };
                     return Err(RunnerError::new(expr.source_info, kind, false));
                 } else {
@@ -501,10 +503,19 @@ fn eval_duration_option(
                     }
                 }
             }
+            Value::String(value) => {
+                return duration_from_str(&value, default_unit).map_err(|_| {
+                    let kind = RunnerErrorKind::ExpressionInvalidType {
+                        value: format!("string <{value}>"),
+                        expecting: EXPECTING_DURATION.to_string(),
+                    };
+                    RunnerError::new(expr.source_info, kind, false)
+                });
+            }
             v => {
                 let kind = RunnerErrorKind::ExpressionInvalidType {
                     value: v.repr(),
-                    expecting: "positive integer".to_string(),
+                    expecting: EXPECTING_DURATION.to_string(),
                 };
                 return Err(RunnerError::new(expr.source_info, kind, false));
             }
@@ -652,6 +663,95 @@ mod tests {
             )
             .unwrap(),
             std::time::Duration::from_millis(10)
+        );
+
+        variables.insert("retry".to_string(), Value::String("3s".to_string()));
+        assert_eq!(
+            eval_duration_option(
+                &retry_option_template(),
+                &variables,
+                DurationUnit::MilliSecond
+            )
+            .unwrap(),
+            std::time::Duration::from_secs(3)
+        );
+
+        variables.insert("retry".to_string(), Value::String("10".to_string()));
+        assert_eq!(
+            eval_duration_option(
+                &retry_option_template(),
+                &variables,
+                DurationUnit::MilliSecond
+            )
+            .unwrap(),
+            std::time::Duration::from_millis(10)
+        );
+
+        variables.insert("retry".to_string(), Value::String("".to_string()));
+        let error = eval_duration_option(
+            &retry_option_template(),
+            &variables,
+            DurationUnit::MilliSecond,
+        )
+        .err()
+        .unwrap();
+        assert_eq!(
+            error.kind,
+            RunnerErrorKind::ExpressionInvalidType {
+                value: "string <>".to_string(),
+                expecting: "non-negative integer or duration string".to_string()
+            }
+        );
+
+        variables.insert("retry".to_string(), Value::String("10x".to_string()));
+        let error = eval_duration_option(
+            &retry_option_template(),
+            &variables,
+            DurationUnit::MilliSecond,
+        )
+        .err()
+        .unwrap();
+        assert_eq!(
+            error.kind,
+            RunnerErrorKind::ExpressionInvalidType {
+                value: "string <10x>".to_string(),
+                expecting: "non-negative integer or duration string".to_string()
+            }
+        );
+
+        variables.insert(
+            "retry".to_string(),
+            Value::String("18446744073709551616".to_string()),
+        );
+        let error = eval_duration_option(
+            &retry_option_template(),
+            &variables,
+            DurationUnit::MilliSecond,
+        )
+        .err()
+        .unwrap();
+        assert_eq!(
+            error.kind,
+            RunnerErrorKind::ExpressionInvalidType {
+                value: "string <18446744073709551616>".to_string(),
+                expecting: "non-negative integer or duration string".to_string()
+            }
+        );
+
+        variables.insert("retry".to_string(), Value::Number(Number::Integer(-1)));
+        let error = eval_duration_option(
+            &retry_option_template(),
+            &variables,
+            DurationUnit::MilliSecond,
+        )
+        .err()
+        .unwrap();
+        assert_eq!(
+            error.kind,
+            RunnerErrorKind::ExpressionInvalidType {
+                value: "integer <-1>".to_string(),
+                expecting: "non-negative integer or duration string".to_string()
+            }
         );
     }
 }

--- a/packages/hurl_core/src/types.rs
+++ b/packages/hurl_core/src/types.rs
@@ -24,6 +24,9 @@ use std::fmt::Formatter;
 use std::num::NonZero;
 use std::ops::AddAssign;
 use std::str::FromStr;
+use std::time::Duration;
+
+use regex::Regex;
 
 /// Represents a count operation, either finite or infinite.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -88,6 +91,36 @@ impl FromStr for DurationUnit {
             "h" => Ok(DurationUnit::Hour),
             x => Err(format!("Invalid duration unit {x}")),
         }
+    }
+}
+
+/// Parses a string with or without time unit into a [`Duration`].
+///
+/// When there is no time unit in the user string, the duration is parsed with a default time unit.
+pub fn duration_from_str(value: &str, default_unit: DurationUnit) -> Result<Duration, String> {
+    let re = Regex::new(r"^(\d+)([a-zA-Z]*)$").unwrap();
+    let Some(caps) = re.captures(value) else {
+        return Err("Invalid duration".to_string());
+    };
+    let source = caps.get(1).unwrap().as_str().to_string();
+    let duration = source
+        .parse::<u64>()
+        .map_err(|_| "Duration value too large".to_string())?;
+    let unit = caps.get(2).unwrap().as_str();
+    let unit = if unit.is_empty() {
+        default_unit
+    } else {
+        DurationUnit::from_str(unit)?
+    };
+    let millis = match unit {
+        DurationUnit::MilliSecond => Some(duration),
+        DurationUnit::Second => duration.checked_mul(1000),
+        DurationUnit::Minute => duration.checked_mul(1000 * 60),
+        DurationUnit::Hour => duration.checked_mul(1000 * 60 * 60),
+    };
+    match millis {
+        Some(millis) => Ok(Duration::from_millis(millis)),
+        None => Err("Duration value too large".to_string()),
     }
 }
 


### PR DESCRIPTION
## Summary

- Share duration string parsing through `hurl_core` so CLI/config parsing and runner duration placeholders use the same rules.
- Accept unit-suffixed string placeholders for duration options such as `retry-interval: {{retryInterval}}` with `retryInterval=3s`.
- Preserve existing numeric placeholder behavior and reject invalid or overflowing string values as expression type errors.

## Why

Fixes #4693.

`retry-interval: 3s` already works as a literal option value, but `retry-interval: {{retryInterval}}` rejected `--variable retryInterval=3s` as a string instead of parsing it as a duration. A collaborator confirmed that templating `retry-interval: {{retryInterval}}` with `retryInterval=3s` should be supported.

## Tests

- `cargo test -p hurl runner::options::tests::test_eval_natural_option`
- `cargo test -p hurl cli::options::duration::tests`
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test --lib`
- `cargo clippy`
- Localhost smoke: `target/debug/hurl --variable retryInterval=3s hurl-4693-smoke.hurl`
- `bin/test/test_integ.sh`

## Scope / non-goals

- Keeps the change limited to shared duration parsing and duration option placeholder evaluation.
- Keeps existing numeric placeholder behavior intact.
- Does not add support for `retry-interval: {{retryInterval}}s` with `retryInterval=3`; the maintainer comment described that form as less certain.
- Does not change retry behavior, literal duration parsing, or non-duration option type rules.

## Caveats

- Prior closed PR #4963 attempted the same feature but closed unmerged. This implementation addresses its review concerns by sharing the parser and covering invalid/overflow cases.

## Checklist status

- CONTRIBUTING/PR template followed: yes; no PR template was found in `.github`.
- Duplicate PR check: yes; no open duplicate PR returned for `retry-interval template` close to submission prep.
- Issue/comment check: yes; #4693 remains open and no new maintainer comment changed scope.
- Agent-trap / AI policy check: clear; no AI-specific policy or prompt-injection bait found in scanned repo surfaces.
- Minimal diff: yes; three Rust files only.
- Reviews complete: self-review, separate read-only independent review, CE simplification pass, and AutoReview closeout are complete.
