### PR TITLE
Add openssl to the macOS build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1754,9 +1754,13 @@ $ apk add curl-dev gcc libxml2-dev musl-dev openssl-dev clang-dev
 
 ### Build on macOS
 
+Hurl depends on libssl, libcurl and libxml2 native libraries. On a fresh macOS,
+OpenSSL is not where `openssl-sys` looks for it, and `cargo build` stops with
+"Could not find directory of OpenSSL installation".
+
 ```shell
 $ xcode-select --install
-$ brew install pkg-config
+$ brew install pkg-config openssl
 ```
 
 Hurl is written in [Rust]. You should [install] the latest stable release.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -171,9 +171,13 @@ $ apk add curl-dev gcc libxml2-dev musl-dev openssl-dev clang-dev
 
 ### Build on macOS
 
+Hurl depends on libssl, libcurl and libxml2 native libraries. On a fresh macOS,
+OpenSSL is not where `openssl-sys` looks for it, and `cargo build` stops with
+"Could not find directory of OpenSSL installation".
+
 ```shell
 $ xcode-select --install
-$ brew install pkg-config
+$ brew install pkg-config openssl
 ```
 
 Hurl is written in [Rust]. You should [install] the latest stable release.

--- a/packages/hurl/README.md
+++ b/packages/hurl/README.md
@@ -1754,9 +1754,13 @@ $ apk add curl-dev gcc libxml2-dev musl-dev openssl-dev clang-dev
 
 ### Build on macOS
 
+Hurl depends on libssl, libcurl and libxml2 native libraries. On a fresh macOS,
+OpenSSL is not where `openssl-sys` looks for it, and `cargo build` stops with
+"Could not find directory of OpenSSL installation".
+
 ```shell
 $ xcode-select --install
-$ brew install pkg-config
+$ brew install pkg-config openssl
 ```
 
 Hurl is written in [Rust]. You should [install] the latest stable release.


### PR DESCRIPTION
Closes #5096

The macOS section installs `pkg-config` but not OpenSSL, so on a clean machine `cargo build` stops in `openssl-sys` before anything is compiled. The Linux section right above already names the native libraries and lists them per distribution, so this says the same thing for macOS and adds `openssl` to the brew line

Wording of the first sentence is taken from the Linux section so the two read the same way

Three files, because README.md and packages/hurl/README.md are generated: I edited `docs/installation.md` and regenerated both with `bin/docs/build_readme.py github` and `... crates`, the way `bin/docs/update_all.sh` calls them 
