### PR TITLE
Update README with Guix install instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1634,6 +1634,12 @@ $ pacman -Sy hurl
 
 [NixOS / Nix package] is available on stable channel.
 
+#### Guix
+
+```shell
+$ guix install hurl
+```
+
 ### macOS
 
 Precompiled binaries for Intel and ARM CPUs are available at [Hurl latest GitHub release].


### PR DESCRIPTION
This PR mentions how to install hurl with [guix](https://packages.guix.gnu.org/search/?query=hurl).