### PR TITLE
Fix grammar line terminator to allow CRLF.

### DIFF
--- a/docs/spec/grammar/hurl.grammar
+++ b/docs/spec/grammar/hurl.grammar
@@ -691,7 +691,7 @@ exponent: ("e" | "E") ("+"|"-")? digit+
 
 sp: [ \t]
 
-lt: sp* comment? [\n]?
+lt: sp* comment? ("\n" | "\r\n")?
 
 comment: "#" ~[\n]*
 


### PR DESCRIPTION
This fixes https://github.com/Orange-OpenSource/hurl/issues/3647 and documents that CRLF is also accepted as a line terminator.