### PR TITLE
Add Sublime Text syntax highlighting

### DIFF
--- a/contrib/sublime-text/Hurl.sublime-syntax
+++ b/contrib/sublime-text/Hurl.sublime-syntax
@@ -1,0 +1,310 @@
+%YAML 1.2
+---
+# Sublime Text syntax file
+# Language: Hurl (https://hurl.dev)
+# Also used by bat (https://github.com/sharkdp/bat) and other syntect-based tools.
+name: Hurl
+file_extensions:
+  - hurl
+scope: source.hurl
+
+variables:
+  # An unquoted uppercase HTTP method token (grammar: method = [A-Z]+).
+  method: '[A-Z]+'
+  # Characters allowed in a header / parameter / capture key (key-string-text).
+  key_char: '[A-Za-z0-9_.\-\[\]@$]'
+
+contexts:
+  main:
+    - include: comments
+    - include: response-line
+    - include: request-line
+    - include: sections
+    - include: templates
+    - include: multiline-strings
+    - include: oneline-strings
+    - include: quoted-strings
+    - include: encoded-values
+    - include: json-body
+    - include: xml-body
+    - include: keys
+    - include: operators
+    - include: keywords
+    - include: literals
+
+  # ----------------------------------------------------------------------------
+  # Comments
+  # ----------------------------------------------------------------------------
+  comments:
+    - match: '#'
+      scope: punctuation.definition.comment.hurl
+      push:
+        - meta_scope: comment.line.number-sign.hurl
+        - match: '$'
+          pop: true
+
+  # ----------------------------------------------------------------------------
+  # Request line:  METHOD url
+  # ----------------------------------------------------------------------------
+  request-line:
+    - match: '^\s*({{method}})(?=\s)(?![A-Za-z0-9])'
+      captures:
+        1: keyword.control.method.hurl
+      push: url
+
+  url:
+    - meta_content_scope: markup.underline.link.hurl
+    - include: templates
+    - match: '\\#'
+      scope: constant.character.escape.hurl
+    - match: '(?=\s*#)'
+      pop: true
+    - match: '$'
+      pop: true
+
+  # ----------------------------------------------------------------------------
+  # Response line:  HTTP <status>
+  # ----------------------------------------------------------------------------
+  response-line:
+    - match: '^\s*(HTTP(?:/(?:1\.0|1\.1|2|3|\*))?)\b'
+      captures:
+        1: keyword.control.version.hurl
+      push:
+        - match: '\b([0-9]+|\*)\b'
+          scope: constant.numeric.status.hurl
+          pop: true
+        - match: '$'
+          pop: true
+
+  # ----------------------------------------------------------------------------
+  # Section headers
+  # ----------------------------------------------------------------------------
+  sections:
+    - match: '^\s*(\[)(QueryStringParams|Query|FormParams|Form|MultipartFormData|Multipart|Cookies|Captures|Asserts|Options|BasicAuth)(\])'
+      captures:
+        1: punctuation.definition.section.begin.hurl
+        2: keyword.control.section.hurl
+        3: punctuation.definition.section.end.hurl
+
+  # ----------------------------------------------------------------------------
+  # Header / parameter / capture / option keys:  name:
+  # ----------------------------------------------------------------------------
+  keys:
+    - match: '^\s*({{key_char}}+)(\s*)(:)'
+      captures:
+        1: entity.name.tag.hurl
+        3: punctuation.separator.key-value.hurl
+
+  # ----------------------------------------------------------------------------
+  # Templates / placeholders:  {{ expr }}
+  # ----------------------------------------------------------------------------
+  templates:
+    - match: '{{'
+      scope: punctuation.definition.template.begin.hurl
+      push:
+        - meta_scope: meta.template.hurl
+        - meta_content_scope: variable.other.template.hurl
+        - match: '}}'
+          scope: punctuation.definition.template.end.hurl
+          pop: true
+        - match: '\b(getEnv|newDate|newUuid)\b'
+          scope: support.function.builtin.hurl
+        - include: filter-keywords
+        - include: quoted-strings
+
+  # ----------------------------------------------------------------------------
+  # Strings
+  # ----------------------------------------------------------------------------
+  quoted-strings:
+    - match: '"'
+      scope: punctuation.definition.string.begin.hurl
+      push:
+        - meta_scope: string.quoted.double.hurl
+        - match: '\\(["\\/bfnrt]|u\{[0-9A-Fa-f]+\})'
+          scope: constant.character.escape.hurl
+        - include: templates
+        - match: '"'
+          scope: punctuation.definition.string.end.hurl
+          pop: true
+
+  oneline-strings:
+    - match: '`'
+      scope: punctuation.definition.string.begin.hurl
+      push:
+        - meta_scope: string.quoted.other.backtick.hurl
+        - match: '\\(`|#|\\|[bfnrt]|u\{[0-9A-Fa-f]+\})'
+          scope: constant.character.escape.hurl
+        - include: templates
+        - match: '`'
+          scope: punctuation.definition.string.end.hurl
+          pop: true
+
+  multiline-strings:
+    - match: '(```)([a-zA-Z0-9]+)?'
+      captures:
+        1: punctuation.definition.string.begin.hurl
+        2: storage.type.multiline.hurl
+      push:
+        - meta_scope: string.quoted.multiline.hurl
+        - match: '\\(`|\\|[bfnrt]|u\{[0-9A-Fa-f]+\})'
+          scope: constant.character.escape.hurl
+        - include: templates
+        - match: '```'
+          scope: punctuation.definition.string.end.hurl
+          pop: true
+
+  # ----------------------------------------------------------------------------
+  # Inline encoded bodies / values:  base64,...;  hex,...;  file,...;
+  # ----------------------------------------------------------------------------
+  encoded-values:
+    - match: '\b(base64|hex|file)(,)'
+      captures:
+        1: support.function.encoding.hurl
+        2: punctuation.separator.hurl
+      push:
+        - meta_content_scope: string.unquoted.encoded.hurl
+        - include: templates
+        - match: ';'
+          scope: punctuation.terminator.hurl
+          pop: true
+        - match: '$'
+          pop: true
+
+  # ----------------------------------------------------------------------------
+  # JSON body
+  # ----------------------------------------------------------------------------
+  json-body:
+    - match: '(?=^\s*[{\[])'
+      push: json-value
+
+  json-value:
+    - include: templates
+    - match: '\{'
+      scope: punctuation.section.mapping.begin.json.hurl
+      push: json-object
+    - match: '\['
+      scope: punctuation.section.sequence.begin.json.hurl
+      push: json-array
+    - match: '"'
+      scope: punctuation.definition.string.begin.json.hurl
+      push: json-string
+    - match: '\b(true|false)\b'
+      scope: constant.language.json.hurl
+    - match: '\bnull\b'
+      scope: constant.language.null.json.hurl
+    - match: '-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][-+]?\d+)?'
+      scope: constant.numeric.json.hurl
+    - match: '(?=\S)'
+      pop: true
+
+  json-object:
+    - meta_scope: meta.mapping.json.hurl
+    - match: '\}'
+      scope: punctuation.section.mapping.end.json.hurl
+      pop: true
+    - include: templates
+    - match: '"'
+      scope: punctuation.definition.string.begin.json.hurl
+      push:
+        - meta_scope: string.quoted.double.json.hurl support.type.property-name.json.hurl
+        - match: '\\(["\\/bfnrt]|u[0-9A-Fa-f]{4})'
+          scope: constant.character.escape.json.hurl
+        - include: templates
+        - match: '"'
+          scope: punctuation.definition.string.end.json.hurl
+          pop: true
+    - match: ':'
+      scope: punctuation.separator.key-value.json.hurl
+      push:
+        - match: '(?=,|\})'
+          pop: true
+        - include: json-value
+    - match: ','
+      scope: punctuation.separator.json.hurl
+
+  json-array:
+    - meta_scope: meta.sequence.json.hurl
+    - match: '\]'
+      scope: punctuation.section.sequence.end.json.hurl
+      pop: true
+    - match: ','
+      scope: punctuation.separator.json.hurl
+    - include: json-value
+
+  json-string:
+    - meta_scope: string.quoted.double.json.hurl
+    - match: '\\(["\\/bfnrt]|u[0-9A-Fa-f]{4})'
+      scope: constant.character.escape.json.hurl
+    - include: templates
+    - match: '"'
+      scope: punctuation.definition.string.end.json.hurl
+      pop: true
+
+  # ----------------------------------------------------------------------------
+  # XML body (light touch)
+  # ----------------------------------------------------------------------------
+  xml-body:
+    - match: '(?=^\s*<\??[a-zA-Z!/])'
+      push:
+        - meta_scope: meta.body.xml.hurl
+        - match: '<!--'
+          scope: punctuation.definition.comment.xml.hurl
+          push:
+            - meta_scope: comment.block.xml.hurl
+            - match: '-->'
+              pop: true
+        - match: '(</?)([\w:.\-]+)'
+          captures:
+            1: punctuation.definition.tag.begin.xml.hurl
+            2: entity.name.tag.xml.hurl
+        - match: '/?>'
+          scope: punctuation.definition.tag.end.xml.hurl
+        - include: quoted-strings
+        - include: templates
+        - match: '^(?=\s*$)'
+          pop: true
+
+  # ----------------------------------------------------------------------------
+  # Operators (predicate comparisons)
+  # ----------------------------------------------------------------------------
+  operators:
+    - match: '(==|!=|>=|<=|>|<)'
+      scope: keyword.operator.comparison.hurl
+
+  # ----------------------------------------------------------------------------
+  # Keyword groups
+  # ----------------------------------------------------------------------------
+  keywords:
+    - include: query-keywords
+    - include: predicate-keywords
+    - include: filter-keywords
+    - include: certificate-fields
+
+  query-keywords:
+    - match: '\b(status|version|url|ip|header|certificate|cookie|body|xpath|jsonpath|regex|variable|duration|bytes|sha256|md5|redirects)\b'
+      scope: support.function.query.hurl
+
+  predicate-keywords:
+    - match: '\bnot\b'
+      scope: keyword.operator.logical.hurl
+    - match: '\b(startsWith|endsWith|matches|contains|includes|exists|isBoolean|isCollection|isDate|isEmpty|isFloat|isInteger|isNumber|isIpv4|isIpv6|isIsoDate|isList|isObject|isString|isUuid)\b'
+      scope: support.function.predicate.hurl
+
+  filter-keywords:
+    - match: '\b(base64Decode|base64Encode|base64UrlSafeDecode|base64UrlSafeEncode|charsetDecode|count|daysAfterNow|daysBeforeNow|first|dateFormat|htmlEscape|htmlUnescape|jsonpath|last|location|nth|regex|replaceRegex|replace|split|toDate|toFloat|toHex|toInt|toString|urlDecode|urlEncode|urlQueryParam|utf8Decode|utf8Encode|xpath)\b'
+      scope: support.function.filter.hurl
+
+  certificate-fields:
+    - match: '\b(Subject|Issuer|Start-Date|Expire-Date|Serial-Number)\b'
+      scope: constant.other.certificate-field.hurl
+
+  # ----------------------------------------------------------------------------
+  # Literals (booleans, null, numbers)
+  # ----------------------------------------------------------------------------
+  literals:
+    - match: '\b(true|false)\b'
+      scope: constant.language.boolean.hurl
+    - match: '\bnull\b'
+      scope: constant.language.null.hurl
+    - match: '\b-?\d+(\.\d+)?\b'
+      scope: constant.numeric.hurl

--- a/contrib/sublime-text/README.md
+++ b/contrib/sublime-text/README.md
@@ -1,0 +1,50 @@
+# Support for Hurl Syntax Highlighting
+
+This enables syntax coloring for Hurl files in [Sublime Text], and in any tool
+that reuses Sublime Text syntax definitions, such as [bat].
+
+The `Hurl.sublime-syntax` definition covers methods, URLs, versions and status,
+sections, headers and parameters, queries, predicates, filters, functions,
+templates/placeholders (`{{ ... }}`), comments, and bodies (JSON, XML,
+multiline strings, oneline strings, and `base64,`/`hex,`/`file,` values).
+
+## Sublime Text
+
+File-extension detection is built into the syntax (`.hurl`), so a single file
+is all that is needed.
+
+1. In Sublime Text, open `Preferences > Browse Packages…` to open the
+   `Packages` directory.
+2. Copy `Hurl.sublime-syntax` into the `User` sub-directory:
+
+   ```bash
+   # Linux
+   cp Hurl.sublime-syntax ~/.config/sublime-text/Packages/User/
+
+   # macOS
+   cp Hurl.sublime-syntax "~/Library/Application Support/Sublime Text/Packages/User/"
+
+   # Windows
+   copy Hurl.sublime-syntax "%APPDATA%\Sublime Text\Packages\User\"
+   ```
+
+3. Open any `.hurl` file; the `Hurl` syntax is applied automatically.
+
+## bat
+
+[bat] reuses Sublime Text syntaxes.
+
+```bash
+mkdir -p "$(bat --config-dir)/syntaxes"
+cp Hurl.sublime-syntax "$(bat --config-dir)/syntaxes/"
+bat cache --build
+```
+
+Then:
+
+```bash
+bat test.hurl
+```
+
+[Sublime Text]: https://www.sublimetext.com
+[bat]: https://github.com/sharkdp/bat

--- a/contrib/sublime-text/test.hurl
+++ b/contrib/sublime-text/test.hurl
@@ -1,0 +1,73 @@
+# This is a comment
+GET https://example.org/api/items?q={{search}}
+User-Agent: hurl/1.0
+Accept: application/json
+
+HTTP 200
+[Captures]
+item_id: jsonpath "$.items[0].id"
+csrf: header "X-CSRF" split "," nth 0
+
+# Create a new item, with options
+POST https://example.org/api/items
+Content-Type: application/json
+[Options]
+retry: 3
+insecure: true
+delay: 500ms
+{
+  "name": "widget",
+  "price": 9.99,
+  "active": true,
+  "tags": ["a", "b"],
+  "owner": {{user_id}},
+  "meta": null
+}
+
+HTTP 201
+[Asserts]
+status == 201
+jsonpath "$.name" startsWith "wid"
+jsonpath "$.price" > 5
+jsonpath "$.count" isNumber
+header "Location" matches "/items/[0-9]+"
+jsonpath "$.tags" count == 2
+variable "token" exists
+body contains "widget"
+redirects count == 0
+duration < 1000
+
+# Form parameters
+POST https://example.org/login
+[FormParams]
+username: alice
+password: {{secret}}
+
+# Multipart upload
+POST https://example.org/upload
+[MultipartFormData]
+file: file,data.bin; application/octet-stream
+
+# Basic auth
+GET https://example.org/private
+[BasicAuth]
+alice: {{password}}
+
+# Oneline and multiline bodies
+PUT https://example.org/raw
+`inline oneline body {{x}}`
+
+POST https://example.org/graphql
+```graphql
+query { user(id: {{id}}) { name } }
+```
+
+# XML body
+POST https://example.org/soap
+```xml
+<request><id>{{id}}</id></request>
+```
+
+# Inline encoded body
+POST https://example.org/bin
+hex,deadbeef;


### PR DESCRIPTION
Add a Sublime Text syntax definition for Hurl files, following the conventions of the other contrib editor integrations (README, syntax file, and test.hurl).

The .sublime-syntax definition is also consumed by bat and other syntect-based tools. It covers methods, URLs, versions/status, sections, headers and parameters, queries, predicates, filters, functions, templates, comments, and bodies (JSON, XML, multiline/oneline strings, and base64/hex/file encoded values).